### PR TITLE
feat: Add suite setup function support to SuiteSpec

### DIFF
--- a/examples/programmatic-agent-creation/create_agent.py
+++ b/examples/programmatic-agent-creation/create_agent.py
@@ -43,12 +43,9 @@ async def create_inventory_agent(client: AsyncLetta, sample: Sample) -> str:
     The agent is customized with item details from sample.agent_args.
     """
     tools = await client.tools.list(name="manage_inventory")
-    if tools:
-        tool = tools[0]
-    else:
-        tool = await client.tools.add(
-            tool=ManageInventoryTool(),
-        )
+    if not tools:
+        raise RuntimeError("Tool 'manage_inventory' not found. Please ensure setup has been run.")
+    tool = tools[0]
 
     item = sample.agent_args["item"]
     item_context = f"""Target Item Details:

--- a/examples/programmatic-agent-creation/setup.py
+++ b/examples/programmatic-agent-creation/setup.py
@@ -1,0 +1,46 @@
+from typing import List, Type
+
+from letta_client import AsyncLetta
+from letta_client.client import BaseTool
+from pydantic import BaseModel
+
+from letta_evals.decorators import suite_setup
+
+
+class InventoryItem(BaseModel):
+    sku: str
+    name: str
+    price: float
+    category: str
+
+
+class InventoryEntry(BaseModel):
+    timestamp: int
+    item: InventoryItem
+    transaction_id: str
+
+
+class InventoryEntryData(BaseModel):
+    data: InventoryEntry
+    quantity_change: int
+
+
+class ManageInventoryTool(BaseTool):
+    name: str = "manage_inventory"
+    args_schema: Type[BaseModel] = InventoryEntryData
+    description: str = "Update inventory catalogue with a new data entry"
+    tags: List[str] = ["inventory", "shop"]
+
+    def run(self, data: InventoryEntry, quantity_change: int) -> str:
+        return f"Updated inventory for {data.item.name} with a quantity change of {quantity_change}"
+
+
+@suite_setup
+async def prepare_evaluation(client: AsyncLetta) -> None:
+    """Set up the evaluation environment by creating required tools."""
+    tools = await client.tools.list(name="manage_inventory")
+    if not tools:
+        await client.tools.add(tool=ManageInventoryTool())
+        print("Created manage_inventory tool")
+    else:
+        print("manage_inventory tool already exists")

--- a/examples/programmatic-agent-creation/suite.yaml
+++ b/examples/programmatic-agent-creation/suite.yaml
@@ -1,6 +1,7 @@
 name: programmatic-inventory-agent-test
 description: Test inventory agent created programmatically via Python script
 dataset: dataset.jsonl
+setup_script: setup.py:prepare_evaluation
 target:
   kind: agent
   agent_script: create_agent.py:create_inventory_agent

--- a/letta_evals/models.py
+++ b/letta_evals/models.py
@@ -128,6 +128,13 @@ class SuiteSpec(BaseModel):
     max_samples: Optional[int] = Field(default=None, description="Maximum number of samples to evaluate")
     sample_tags: Optional[List[str]] = Field(default=None, description="Only evaluate samples with these tags")
 
+    setup_script: Optional[str] = Field(
+        default=None, description="Path to Python script with setup function (e.g., setup.py:prepare_evaluation)"
+    )
+
+    # internal field for path resolution
+    base_dir: Optional[Path] = Field(default=None, exclude=True)
+
     @classmethod
     def from_yaml(cls, yaml_data: Dict[str, Any], base_dir: Optional[Path] = None) -> "SuiteSpec":
         """Create from parsed YAML data."""
@@ -157,6 +164,9 @@ class SuiteSpec(BaseModel):
 
                 # store base_dir in grader for custom function resolution
                 yaml_data["grader"]["base_dir"] = base_dir
+
+            # store base_dir in SuiteSpec for setup_script resolution
+            yaml_data["base_dir"] = base_dir
 
         if "gate" in yaml_data and isinstance(yaml_data["gate"], dict):
             yaml_data["gate"] = GateSpec(**yaml_data["gate"])

--- a/letta_evals/targets/agent.py
+++ b/letta_evals/targets/agent.py
@@ -14,23 +14,19 @@ class AgentTarget(Target):
 
     def __init__(
         self,
-        base_url: str,
+        client: AsyncLetta,
         agent_id: str = None,
         agent_file: Path = None,
         agent_script: str = None,
-        api_key: str = None,
-        timeout: float = 300.0,
         base_dir: Path = None,
         llm_config: Optional[LlmConfig] = None,
     ):
-        self.base_url = base_url
+        self.client = client
         self.agent_id = agent_id
         self.agent_file = agent_file
         self.agent_script = agent_script
         self.base_dir = base_dir or Path.cwd()
         self.llm_config = llm_config
-
-        self.client = AsyncLetta(base_url=self.base_url, token=api_key, timeout=timeout)
 
     async def run(self, sample: Sample, progress_callback: Optional[ProgressCallback] = None) -> TargetResult:
         """Run the agent on a sample."""


### PR DESCRIPTION
- Add @suite_setup decorator for functions that initialize evaluation environment
- Add optional setup_script field to SuiteSpec YAML configuration
- Setup function runs once before evaluation with shared Letta client
- Updated example to demonstrate tool creation via setup script