### PR TITLE
fix: Cannot access local variable 'stream' error 

### DIFF
--- a/letta_evals/targets/agent.py
+++ b/letta_evals/targets/agent.py
@@ -98,7 +98,6 @@ class AgentTarget(Target):
             stream = self.client.agents.messages.create_stream(
                 agent_id=agent_id,
                 messages=[MessageCreate(role="user", content=input_msg)],
-                stream_tokens=True,
             )
 
             messages = []


### PR DESCRIPTION
Updates for contradicting facts in #21 accidentally [removed stream creation](https://github.com/letta-ai/letta-evals/pull/21/files#diff-1e45b6ca302948561362e84774300e6d4e7ba139149803d67336d8ac20b3ecf0L71), leading to the following error:
```cannot access local variable 'stream' where it is not associated with a value```

This PR fixes the error by re-introducing stream creation.