### PR TITLE
feat: Remove hardcoding metric to accuracy

### DIFF
--- a/letta_evals/cli.py
+++ b/letta_evals/cli.py
@@ -333,7 +333,7 @@ def display_results(result: RunnerResult, verbose: bool = False, cached_mode: bo
     op_symbol = op_symbols.get(gate_op, gate_op)
 
     status = "[green]PASSED[/green]" if result.gates_passed else "[red]FAILED[/red]"
-    
+
     if gate_metric == "avg_score":
         actual = metrics.avg_score
         suffix = ""
@@ -345,7 +345,7 @@ def display_results(result: RunnerResult, verbose: bool = False, cached_mode: bo
         else:
             actual = 0.0
         suffix = "%"
-    
+
     # Prefer display name for gate metric key
     display_label = None
     if gate_metric_key and "graders" in result.config and isinstance(result.config["graders"], dict):

--- a/letta_evals/models.py
+++ b/letta_evals/models.py
@@ -259,7 +259,9 @@ class ModelMetrics(BaseModel):
     avg_score: float = Field(description="Average score across all results (0.0 to 1.0)")
     passed_samples: int = Field(description="Number of attempted samples that passed the gate")
     failed_samples: int = Field(description="Number of attempted samples that failed the gate")
-    metrics: Dict[str, float] = Field(default_factory=dict, description="Per-metric pass rates (metric_key -> percentage)")
+    metrics: Dict[str, float] = Field(
+        default_factory=dict, description="Per-metric pass rates (metric_key -> percentage)"
+    )
 
 
 class MetricAggregate(BaseModel):
@@ -283,7 +285,9 @@ class Metrics(BaseModel):
         default=None, description="Metrics broken down by model configuration"
     )
     by_metric: Optional[Dict[str, MetricAggregate]] = Field(default=None, description="Aggregates for each metric key")
-    metrics: Dict[str, float] = Field(default_factory=dict, description="Per-metric pass rates (metric_key -> percentage)")
+    metrics: Dict[str, float] = Field(
+        default_factory=dict, description="Per-metric pass rates (metric_key -> percentage)"
+    )
 
 
 class SampleResult(BaseModel):

--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -405,9 +405,7 @@ class Runner:
         """
         total = len(self.results)
         if total == 0:
-            return Metrics(
-                total=0, total_attempted=0, avg_score=0.0, passed_attempts=0, failed_attempts=0, metrics={}
-            )
+            return Metrics(total=0, total_attempted=0, avg_score=0.0, passed_attempts=0, failed_attempts=0, metrics={})
 
         # success = completed without error; error results have empty trajectory or missing agent_id
         def is_success(r: SampleResult) -> bool:
@@ -442,7 +440,7 @@ class Runner:
             gate_key = self._gate_metric_key()
             for key, agg in by_metric.items():
                 metrics_dict[key] = agg.pass_rate
-            
+
             agg = (
                 by_metric.get(gate_key)
                 if gate_key in by_metric
@@ -468,7 +466,7 @@ class Runner:
             for model_name, results in model_results.items():
                 model_attempted = sum(1 for r in results if is_success(r))
                 model_metrics_dict: Dict[str, float] = {}
-                
+
                 if self.graders is not None:
                     gate_key = self._gate_metric_key()
                     # Calculate pass rate for each metric
@@ -481,8 +479,10 @@ class Runner:
                             and metric_key in r.grades
                             and self._check_sample_pass(r.grades[metric_key].score)
                         )
-                        model_metrics_dict[metric_key] = (metric_passed / model_attempted) * 100.0 if model_attempted > 0 else 0.0
-                    
+                        model_metrics_dict[metric_key] = (
+                            (metric_passed / model_attempted) * 100.0 if model_attempted > 0 else 0.0
+                        )
+
                     model_scores = [r.grades[gate_key].score for r in results if r.grades and gate_key in r.grades]
                     model_passed = sum(
                         1
@@ -496,8 +496,10 @@ class Runner:
                     model_scores = [r.grade.score for r in results]
                     model_passed = sum(1 for r in results if is_success(r) and self._check_sample_pass(r.grade.score))
                     default_key = "default"
-                    model_metrics_dict[default_key] = (model_passed / model_attempted) * 100.0 if model_attempted > 0 else 0.0
-                
+                    model_metrics_dict[default_key] = (
+                        (model_passed / model_attempted) * 100.0 if model_attempted > 0 else 0.0
+                    )
+
                 model_avg = sum(model_scores) / len(model_scores) if model_scores else 0.0
 
                 per_model.append(


### PR DESCRIPTION
This PR removes the accuracy being hard coded as the metric in the results file. Instead, it uses the name of the metric that is defined eg. `contains`