### PR TITLE
fix: Google loads `google.svg`

### DIFF
--- a/leaderboard_site/src/icons/google.svg
+++ b/leaderboard_site/src/icons/google.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg fill="#000000" height="800px" width="800px" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+	 viewBox="0 0 210 210" xml:space="preserve">
+<path d="M0,105C0,47.103,47.103,0,105,0c23.383,0,45.515,7.523,64.004,21.756l-24.4,31.696C133.172,44.652,119.477,40,105,40
+	c-35.841,0-65,29.159-65,65s29.159,65,65,65c28.867,0,53.398-18.913,61.852-45H105V85h105v20c0,57.897-47.103,105-105,105
+	S0,162.897,0,105z"/>
+</svg>
+

--- a/leaderboard_site/src/icons/google_ai.svg
+++ b/leaderboard_site/src/icons/google_ai.svg
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="iso-8859-1"?>
-<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg fill="#000000" height="800px" width="800px" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
-	 viewBox="0 0 210 210" xml:space="preserve">
-<path d="M0,105C0,47.103,47.103,0,105,0c23.383,0,45.515,7.523,64.004,21.756l-24.4,31.696C133.172,44.652,119.477,40,105,40
-	c-35.841,0-65,29.159-65,65s29.159,65,65,65c28.867,0,53.398-18.913,61.852-45H105V85h105v20c0,57.897-47.103,105-105,105
-	S0,162.897,0,105z"/>
-</svg>


### PR DESCRIPTION
Before

<img width="967" height="392" alt="Screenshot 2025-11-26 at 7 42 30 PM" src="https://github.com/user-attachments/assets/0d2c9678-57a0-4ace-bb03-20fca0a3c514" />

After:
<img width="758" height="313" alt="Screenshot 2025-11-26 at 7 43 35 PM" src="https://github.com/user-attachments/assets/2c4ce293-4efd-498f-959d-5c74466e412a" />
