### PR TITLE
fix: Update examples to use cloud by default

### DIFF
--- a/examples/custom-tool-grader-and-extractor/suite.yaml
+++ b/examples/custom-tool-grader-and-extractor/suite.yaml
@@ -4,7 +4,7 @@ dataset: dataset.jsonl
 target:
   kind: letta_agent
   agent_file: fruit-preferences-agent.af
-  base_url: http://localhost:8283
+  base_url: https://api.letta.com/
 graders:
   preference_check:
     kind: tool

--- a/examples/letta-agent-rubric-grader/custom_judge_suite.yaml
+++ b/examples/letta-agent-rubric-grader/custom_judge_suite.yaml
@@ -4,7 +4,7 @@ dataset: dataset.csv
 target:
   kind: letta_agent
   agent_file: test-fetch-webpage-simple-agent.af
-  base_url: http://localhost:8283
+  base_url: https://api.letta.com/
 graders:
   agent_judge:
     kind: letta_judge

--- a/examples/letta-agent-rubric-grader/default_judge_suite.yaml
+++ b/examples/letta-agent-rubric-grader/default_judge_suite.yaml
@@ -4,7 +4,7 @@ dataset: dataset.csv
 target:
   kind: letta_agent
   agent_file: test-fetch-webpage-simple-agent.af
-  base_url: http://localhost:8283
+  base_url: https://api.letta.com/
 graders:
   agent_judge:
     kind: letta_judge

--- a/examples/multi-grader-gate/suite.logical-and.yaml
+++ b/examples/multi-grader-gate/suite.logical-and.yaml
@@ -4,7 +4,7 @@ dataset: dataset.csv
 target:
   kind: letta_agent
   agent_file: ascii-art-agent.af
-  base_url: http://localhost:8283
+  base_url: https://api.letta.com/
 graders:
   quality:
     kind: model_judge

--- a/examples/multi-grader-gate/suite.weighted-average.yaml
+++ b/examples/multi-grader-gate/suite.weighted-average.yaml
@@ -4,7 +4,7 @@ dataset: dataset.csv
 target:
   kind: letta_agent
   agent_file: ascii-art-agent.af
-  base_url: http://localhost:8283
+  base_url: https://api.letta.com/
 graders:
   quality:
     kind: model_judge

--- a/examples/multi-model-simple-rubric-grader/suite.yaml
+++ b/examples/multi-model-simple-rubric-grader/suite.yaml
@@ -4,7 +4,7 @@ dataset: dataset.jsonl
 target:
   kind: letta_agent
   agent_file: ascii-art-agent.af
-  base_url: http://localhost:8283
+  base_url: https://api.letta.com/
   model_handles:
     - openai/gpt-4.1
     - openai/gpt-5-mini

--- a/examples/multiturn-memory-block-extractor/suite.yaml
+++ b/examples/multiturn-memory-block-extractor/suite.yaml
@@ -4,7 +4,7 @@ dataset: dataset.jsonl
 target:
   kind: letta_agent
   agent_file: test-fruit-pref-agent.af
-  base_url: http://localhost:8283
+  base_url: https://api.letta.com/
 graders:
   memory_check:
     kind: tool

--- a/examples/programmatic-agent-creation/suite.yaml
+++ b/examples/programmatic-agent-creation/suite.yaml
@@ -5,7 +5,7 @@ setup_script: setup.py:prepare_evaluation
 target:
   kind: letta_agent
   agent_script: create_agent.py:create_inventory_agent
-  base_url: http://localhost:8283
+  base_url: https://api.letta.com/
 graders:
   inventory_check:
     kind: tool

--- a/examples/simple-memory-block-extractor/suite.yaml
+++ b/examples/simple-memory-block-extractor/suite.yaml
@@ -4,7 +4,7 @@ dataset: dataset.jsonl
 target:
   kind: letta_agent
   agent_file: test-fruit-pref-agent.af
-  base_url: http://localhost:8283
+  base_url: https://api.letta.com/
 graders:
   memory_check:
     kind: tool

--- a/examples/simple-rubric-grader/suite.ascii-only-accuracy.yaml
+++ b/examples/simple-rubric-grader/suite.ascii-only-accuracy.yaml
@@ -4,7 +4,7 @@ dataset: dataset.csv
 target:
   kind: letta_agent
   agent_file: ascii-art-agent.af
-  base_url: http://localhost:8283
+  base_url: https://api.letta.com/
 graders:
   quality:
     kind: model_judge

--- a/examples/simple-rubric-grader/suite.yaml
+++ b/examples/simple-rubric-grader/suite.yaml
@@ -5,7 +5,7 @@ max_samples: 3
 target:
   kind: letta_agent
   agent_file: ascii-art-agent.af
-  base_url: http://localhost:8283
+  base_url: https://api.letta.com/
 graders:
   quality:
     kind: model_judge

--- a/examples/simple-tool-grader/last_assistant_suite.yaml
+++ b/examples/simple-tool-grader/last_assistant_suite.yaml
@@ -4,7 +4,7 @@ dataset: assistant_dataset.csv
 target:
   kind: letta_agent
   agent_file: test-fetch-webpage-simple-agent.af
-  base_url: http://localhost:8283
+  base_url: https://api.letta.com/
 graders:
   contains_check:
     kind: tool

--- a/examples/simple-tool-grader/multi_run_tool_output_suite.yaml
+++ b/examples/simple-tool-grader/multi_run_tool_output_suite.yaml
@@ -5,7 +5,7 @@ num_runs: 2 # Run this twice
 target:
   kind: letta_agent
   agent_file: test-fetch-webpage-simple-agent.af
-  base_url: http://localhost:8283
+  base_url: https://api.letta.com/
 graders:
   tool_output_check:
     kind: tool


### PR DESCRIPTION
Update examples to use `base_url: https://api.letta.com/` instead of `base_url: http://localhost:8283`  