### PR TITLE
chore: Add sandbox attribute for letta code

### DIFF
--- a/letta_evals/models.py
+++ b/letta_evals/models.py
@@ -135,6 +135,9 @@ class LettaCodeTargetSpec(BaseTargetSpec):
     kind: Literal[TargetKind.LETTA_CODE] = TargetKind.LETTA_CODE
 
     working_dir: Optional[Path] = Field(default=None, description="Working directory for letta code execution")
+    sandbox: bool = Field(
+        default=True, description="Create a per-model subdirectory under working_dir for isolated sandbox execution."
+    )
     skills_dir: Optional[Path] = Field(default=None, description="Directory containing skills to load")
     allowed_tools: Optional[List[str]] = Field(
         default=None, description="List of allowed tools for letta code (e.g., ['Bash', 'Read'])"

--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -171,16 +171,11 @@ class Runner:
             if not model_handle:
                 raise ValueError("LettaCodeTarget requires a model_handle (string), but got None")
 
-            # create sandbox working directory for the model
-            model_name = model_handle.split("/")[-1]
-            working_dir = self.suite.target.working_dir / model_name
-            if not working_dir.exists():
-                working_dir.mkdir(parents=True, exist_ok=True)
-
             return LettaCodeTarget(
                 client=self.client,
                 model_handle=model_handle,
-                working_dir=working_dir,
+                working_dir=self.suite.target.working_dir,
+                sandbox=self.suite.target.sandbox,
                 skills_dir=self.suite.target.skills_dir,
                 allowed_tools=self.suite.target.allowed_tools,
                 disallowed_tools=self.suite.target.disallowed_tools,


### PR DESCRIPTION
## Summary
- Add sandbox boolean attribute to `LettaCodeTargetSpec` (defaults to true for backwards compatibility)
- When `sandbox: true`, each model gets an isolated subdirectory under `working_dir` (existing behavior)
- When `sandbox: false`, all models share `working_dir` directly — useful for read-only evals where the agent doesn't create artifacts