### PR TITLE
fix: Use --new-agent for letta code

### DIFF
--- a/letta_evals/targets/letta_code_target.py
+++ b/letta_evals/targets/letta_code_target.py
@@ -90,7 +90,7 @@ class LettaCodeTarget(AbstractAgentTarget):
                 # NOTE: letta-code CLI flags have changed over time; keep to stable, documented flags.
                 cmd = [
                     "letta",
-                    "--new",
+                    "--new-agent",
                     "--yolo",
                     "--output-format",
                     "json",


### PR DESCRIPTION
Use `--new-agent` instead of `--new` for letta code