### PR TITLE
feat: Add token-level data (IDs + logprobs) to TargetResult for training

### DIFF
--- a/letta_evals/__init__.py
+++ b/letta_evals/__init__.py
@@ -23,6 +23,7 @@ from letta_evals.models import (
     SuiteSpec,
     TargetResult,
     TargetSpec,
+    TurnTokenData,
 )
 from letta_evals.runner import Runner, run_suite
 from letta_evals.targets import AbstractAgentTarget, LettaAgentTarget
@@ -66,6 +67,7 @@ __all__ = [
     "GradeResult",
     "SampleResult",
     "TargetResult",
+    "TurnTokenData",
     "Metrics",
     "ModelMetrics",
     "MetricAggregate",

--- a/letta_evals/models.py
+++ b/letta_evals/models.py
@@ -444,6 +444,24 @@ class SuiteSpec(BaseModel):
 # Target/Grader result models
 
 
+class TurnTokenData(BaseModel):
+    """Token-level data for a single message in a turn.
+
+    Used by training pipelines (e.g. GRPO) that need per-token IDs and
+    log-probabilities from the generation model.
+    """
+
+    role: str = Field(description="Message role: assistant, tool, tool_call, tool_return, etc.")
+    content: Optional[str] = Field(default=None, description="Text content of this message")
+    output_ids: Optional[List[int]] = Field(
+        default=None, description="Token IDs produced by the model for this message"
+    )
+    output_token_logprobs: Optional[List[Any]] = Field(
+        default=None,
+        description="Per-token log-probabilities. Each entry is either a float or a list whose first element is the logprob.",
+    )
+
+
 class TargetResult(BaseModel):
     """Result from running a target."""
 
@@ -457,6 +475,16 @@ class TargetResult(BaseModel):
     )
     agent_state: Optional[AgentState] = Field(
         default=None, description="Agent state after running the target (includes memory blocks)"
+    )
+    run_ids: Optional[List[str]] = Field(
+        default=None, description="Run IDs for each input turn (needed for token-level data fetching in training)"
+    )
+    token_data: Optional[List[TurnTokenData]] = Field(
+        default=None,
+        description=(
+            "Token-level data (IDs + logprobs) for each message across all turns. "
+            "Only populated when return_token_data=True is passed to the target."
+        ),
     )
 
 

--- a/letta_evals/targets/letta_agent.py
+++ b/letta_evals/targets/letta_agent.py
@@ -6,7 +6,7 @@ import anyio
 from letta_client import AsyncLetta
 from letta_client.types import LlmConfig, MessageCreateParam
 
-from letta_evals.models import Sample, TargetResult
+from letta_evals.models import Sample, TargetResult, TurnTokenData
 from letta_evals.targets.base import AbstractAgentTarget, TargetError
 from letta_evals.utils import consume_stream_with_resumes, list_all_run_messages, load_object
 from letta_evals.visualization.base import ProgressCallback
@@ -45,6 +45,7 @@ class LettaAgentTarget(AbstractAgentTarget):
         progress_callback: Optional[ProgressCallback] = None,
         project_id: Optional[str] = None,
         retrieve_agent_state: bool = False,
+        return_token_data: bool = False,
     ) -> TargetResult:
         """Run the agent on a sample."""
         attempt = 0
@@ -167,6 +168,11 @@ class LettaAgentTarget(AbstractAgentTarget):
                         messages = await list_all_run_messages(self.client, run_id)
                         trajectory.append(messages)
 
+                    # Fetch token-level data if requested (for RL training)
+                    token_data: Optional[list[TurnTokenData]] = None
+                    if return_token_data and run_id:
+                        token_data = await self._fetch_token_data([run_id])
+
                     final_agent_state = None
                     if retrieve_agent_state:
                         final_agent_state = await self.client.agents.retrieve(
@@ -179,6 +185,7 @@ class LettaAgentTarget(AbstractAgentTarget):
                         model_name=model_name,
                         agent_usage=usage_stats,
                         agent_state=final_agent_state,
+                        token_data=token_data,
                     )
 
             except Exception as e:
@@ -211,3 +218,32 @@ class LettaAgentTarget(AbstractAgentTarget):
                 await anyio.sleep(backoff_time)
 
         raise last_error or RuntimeError("Unexpected failure in agent run retry loop")
+
+    async def _fetch_token_data(self, run_ids: list[str]) -> list[TurnTokenData]:
+        """Fetch token-level data (IDs + logprobs) from the runs API.
+
+        For each run, re-fetches messages with ``return_token_ids=True`` to
+        obtain ``output_ids`` and ``output_token_logprobs`` per message.
+        """
+        token_data: list[TurnTokenData] = []
+        for run_id in run_ids:
+            try:
+                messages = await list_all_run_messages(
+                    self.client,
+                    run_id,
+                    params={"return_token_ids": "true"},
+                )
+                for msg in messages:
+                    output_ids = getattr(msg, "output_ids", None)
+                    output_token_logprobs = getattr(msg, "output_token_logprobs", None)
+                    if output_ids:
+                        token_data.append(
+                            TurnTokenData(
+                                role=getattr(msg, "role", "assistant"),
+                                output_ids=output_ids,
+                                output_token_logprobs=output_token_logprobs,
+                            )
+                        )
+            except Exception as e:
+                logger.warning(f"Could not fetch token data for run {run_id}: {e}")
+        return token_data

--- a/letta_evals/targets/letta_code_target.py
+++ b/letta_evals/targets/letta_code_target.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from letta_client import AsyncLetta
 
-from letta_evals.models import Sample, TargetResult
+from letta_evals.models import Sample, TargetResult, TurnTokenData
 from letta_evals.targets.base import AbstractAgentTarget, TargetError
 from letta_evals.utils import list_all_agent_messages, load_object
 from letta_evals.visualization.base import ProgressCallback
@@ -78,6 +78,7 @@ class LettaCodeTarget(AbstractAgentTarget):
         progress_callback: Optional[ProgressCallback] = None,
         project_id: Optional[str] = None,
         retrieve_agent_state: bool = False,
+        return_token_data: bool = False,
     ) -> TargetResult:
         """Run the letta CLI command on a sample."""
         attempt = 0
@@ -222,6 +223,11 @@ class LettaCodeTarget(AbstractAgentTarget):
                         }
                     )
 
+                # Fetch token-level data if requested (for RL training)
+                token_data: Optional[list[TurnTokenData]] = None
+                if return_token_data and agent_id:
+                    token_data = await self._fetch_token_data(agent_id)
+
                 # Retrieve agent state if needed (e.g., for memory block extractors)
                 agent_state = None
                 if retrieve_agent_state:
@@ -233,6 +239,7 @@ class LettaCodeTarget(AbstractAgentTarget):
                     model_name=self.model_handle,
                     agent_usage=usage_stats if usage_stats else None,
                     agent_state=agent_state,
+                    token_data=token_data,
                 )
 
             except Exception as e:
@@ -256,3 +263,43 @@ class LettaCodeTarget(AbstractAgentTarget):
                 await asyncio.sleep(backoff_time)
 
         raise last_error or RuntimeError("Unexpected failure in letta command retry loop")
+
+    async def _fetch_token_data(self, agent_id: str) -> list[TurnTokenData]:
+        """Fetch token-level data (IDs + logprobs) for a letta code agent.
+
+        Retrieves messages with ``return_token_ids=True`` to get
+        ``output_ids`` and ``output_token_logprobs`` per message.
+        """
+        token_data: list[TurnTokenData] = []
+        try:
+            # Try to get run IDs for this agent
+            run_ids: list[str] = []
+            try:
+                runs_page = await self.client.agents.runs.list(agent_id=agent_id)
+                if runs_page.items:
+                    run_ids = [runs_page.items[0].id]
+            except Exception as e:
+                logger.warning(f"Could not fetch run IDs for agent {agent_id}: {e}")
+
+            if run_ids:
+                from letta_evals.utils import list_all_run_messages
+
+                messages = await list_all_run_messages(
+                    self.client,
+                    run_ids[0],
+                    params={"return_token_ids": "true"},
+                )
+                for msg in messages:
+                    output_ids = getattr(msg, "output_ids", None)
+                    output_token_logprobs = getattr(msg, "output_token_logprobs", None)
+                    if output_ids:
+                        token_data.append(
+                            TurnTokenData(
+                                role=getattr(msg, "role", "assistant"),
+                                output_ids=output_ids,
+                                output_token_logprobs=output_token_logprobs,
+                            )
+                        )
+        except Exception as e:
+            logger.warning(f"Could not fetch token data for agent {agent_id}: {e}")
+        return token_data


### PR DESCRIPTION
Add `TurnTokenData` model and `return_token_data` parameter to targets so training pipelines (e.g. GRPO via letta-train) can get per-token IDs and log-probabilities without reimplementing agent execution logic.

- New `TurnTokenData` model with role, content, output_ids, output_token_logprobs
- New `TargetResult.token_data` and `TargetResult.run_ids` fields
- `LettaAgentTarget.run(return_token_data=True)` fetches from runs API
- `LettaCodeTarget.run(return_token_data=True)` fetches from runs API
- Backward compatible: token_data defaults to None when not requested

🐾 Generated with [Letta Code](https://letta.com)