### PR TITLE
fix: Report grading errors to progress callback

### DIFF
--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -507,6 +507,10 @@ class Runner:
                             exception_type="GradingError",
                             message=f"Grading failed for: {details}",
                         )
+                        if self.progress_callback:
+                            await self.progress_callback.sample_error(
+                                sample_id, error_info.message, agent_id=agent_id, model_name=model_name
+                            )
 
                 if error_info is None and self.progress_callback:
                     metric_scores = None


### PR DESCRIPTION
## Summary

Grading errors (e.g. LLM judge timeouts, API failures) were setting `error_info` but never calling `sample_error` on the progress callback. This left samples stuck in the "🔍 grading" state in the live UI with no error count increment, even though the result was recorded as an error.

The extraction error path and the exception path both called `sample_error` correctly — this was the only missing case.