### PR TITLE
fix: Include .af agent files in pip package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,5 +87,6 @@ ignore = [
 include = [
     "letta_evals/**/*.py",
     "letta_evals/**/*.json",
+    "letta_evals/**/*.af",
     "letta_evals/py.typed",
 ]


### PR DESCRIPTION
## Summary
- Adds `letta_evals/**/*.af` to the hatch build include list in `pyproject.toml`
- Fixes `FileNotFoundError` when using `letta_judge` grader from a pip-installed package, since the bundled `letta-evals-judge-agent.af` file was missing

Closes #155

🐾 Generated with [Letta Code](https://letta.com)