### PR TITLE
fix: Reduce Rich progress table repaint churn

### DIFF
--- a/letta_evals/visualization/reducer.py
+++ b/letta_evals/visualization/reducer.py
@@ -8,6 +8,7 @@ from letta_evals.visualization.state import (
     ProgressEvent,
     SampleProgress,
     SampleState,
+    is_active_state,
     is_terminal_state,
 )
 
@@ -23,6 +24,8 @@ class ProgressRuntimeState:
     metric_counts: Dict[str, int] = field(default_factory=dict)
     completed_count: int = 0
     error_count: int = 0
+    next_active_sort_sequence: int = 1
+    next_completion_sequence: int = 1
 
 
 @dataclass(frozen=True)
@@ -44,6 +47,8 @@ class ProgressStateReducer:
         self.state.metric_counts.clear()
         self.state.completed_count = 0
         self.state.error_count = 0
+        self.state.next_active_sort_sequence = 1
+        self.state.next_completion_sequence = 1
 
     def ensure_sample(
         self,
@@ -135,7 +140,15 @@ class ProgressStateReducer:
                 setattr(sample, key, value)
         sample.last_update_ts = now
 
+        if previous_state != state and is_active_state(state):
+            sample.active_sort_sequence = self.state.next_active_sort_sequence
+            self.state.next_active_sort_sequence += 1
+
         is_new_completion = not is_terminal_state(previous_state) and is_terminal_state(state)
+
+        if is_new_completion:
+            sample.completion_sequence = self.state.next_completion_sequence
+            self.state.next_completion_sequence += 1
 
         if state == SampleState.COMPLETED and is_new_completion:
             self.state.completed_count += 1

--- a/letta_evals/visualization/rich_progress.py
+++ b/letta_evals/visualization/rich_progress.py
@@ -88,6 +88,9 @@ class EvalProgress(ProgressCallback):
         self._event_task: Optional[asyncio.Task[None]] = None
         self._render_task: Optional[asyncio.Task[None]] = None
         self._background_error: Optional[BaseException] = None
+        self._last_visible_snapshot: Optional[tuple] = None
+        self._message_progress_buckets: Dict[tuple[int, Optional[str]], tuple[int, int]] = {}
+        self._turn_progress_buckets: Dict[tuple[int, Optional[str]], tuple[int, int]] = {}
         self._reset_visualization_stats()
 
     def _render(self):
@@ -98,6 +101,7 @@ class EvalProgress(ProgressCallback):
         """Reset counters and state for a new run"""
         self.start_time = time.time()
         self._background_error = None
+        self._reset_refresh_tracking()
         self._reset_visualization_stats()
         self._reducer.reset()
         if self.main_task_id is not None:
@@ -108,6 +112,7 @@ class EvalProgress(ProgressCallback):
         """Start the progress display"""
         self.start_time = time.time()
         self._background_error = None
+        self._reset_refresh_tracking()
         task_description = "Re-grading cached trajectories" if self.cached_mode else "Evaluating samples"
         self.main_task_id = self.main_progress.add_task(
             task_description,
@@ -150,9 +155,14 @@ class EvalProgress(ProgressCallback):
     def _refresh_live(self, reason: str = "tick") -> None:
         if not self.live or not self._dirty:
             return
+        visible_snapshot = self._renderer.build_visible_snapshot(self._runtime_state)
+        if visible_snapshot == self._last_visible_snapshot:
+            self._dirty = False
+            return
         self.live.refresh()
         self._refresh_count += 1
         self._refresh_reasons[reason] = self._refresh_reasons.get(reason, 0) + 1
+        self._last_visible_snapshot = visible_snapshot
         self._dirty = False
 
     def _record_background_error(self, task: asyncio.Task[None]) -> None:
@@ -280,6 +290,8 @@ class EvalProgress(ProgressCallback):
         model_name: Optional[str] = None,
     ):
         """Update message sending progress"""
+        if not self._should_emit_progress_bucket(self._message_progress_buckets, sample_id, model_name, message_num, total_messages):
+            return
         await self.update_sample_state(
             sample_id,
             SampleState.SENDING_MESSAGES,
@@ -318,6 +330,11 @@ class EvalProgress(ProgressCallback):
             model_name=model_name,
         )
 
+        if not self._should_emit_progress_bucket(
+            self._turn_progress_buckets, sample_id, model_name, turn_num + 1, total_turns
+        ):
+            return
+
         await self.update_sample_state(
             sample_id,
             SampleState.GRADING_TURNS,
@@ -352,6 +369,7 @@ class EvalProgress(ProgressCallback):
             metric_scores=metric_scores,
             metric_rationales=metric_rationales,
         )
+        self._clear_progress_buckets(sample_id, model_name)
 
     async def sample_error(
         self, sample_id: int, error: str, agent_id: Optional[str] = None, model_name: Optional[str] = None
@@ -364,6 +382,7 @@ class EvalProgress(ProgressCallback):
             model_name=model_name,
             error=error,
         )
+        self._clear_progress_buckets(sample_id, model_name)
 
     def get_stats_snapshot(self) -> VisualizationStats:
         """Return instrumentation counters for tuning the live renderer."""
@@ -390,6 +409,41 @@ class EvalProgress(ProgressCallback):
         self._render_wakeup_count = 0
         self._dirty_mark_count = 0
         self._max_queue_depth = 0
+
+    def _reset_refresh_tracking(self) -> None:
+        self._last_visible_snapshot = None
+        self._message_progress_buckets.clear()
+        self._turn_progress_buckets.clear()
+
+    def _should_emit_progress_bucket(
+        self,
+        bucket_store: Dict[tuple[int, Optional[str]], tuple[int, int]],
+        sample_id: int,
+        model_name: Optional[str],
+        current: int,
+        total: int,
+    ) -> bool:
+        if total <= 0:
+            return True
+
+        key = (sample_id, model_name)
+        bucket = self._progress_bucket(current, total)
+        previous_bucket, previous_total = bucket_store.get(key, (-1, -1))
+
+        if current == 1 or current >= total or total != previous_total or bucket != previous_bucket:
+            bucket_store[key] = (bucket, total)
+            return True
+        return False
+
+    def _progress_bucket(self, current: int, total: int, bucket_count: int = 10) -> int:
+        if total <= 1:
+            return total
+        return min(bucket_count, int((current * bucket_count) / total))
+
+    def _clear_progress_buckets(self, sample_id: int, model_name: Optional[str]) -> None:
+        key = (sample_id, model_name)
+        self._message_progress_buckets.pop(key, None)
+        self._turn_progress_buckets.pop(key, None)
 
     async def suite_completed(self, result):
         """Display summary and detailed results after evaluation completes"""

--- a/letta_evals/visualization/rich_progress.py
+++ b/letta_evals/visualization/rich_progress.py
@@ -290,7 +290,9 @@ class EvalProgress(ProgressCallback):
         model_name: Optional[str] = None,
     ):
         """Update message sending progress"""
-        if not self._should_emit_progress_bucket(self._message_progress_buckets, sample_id, model_name, message_num, total_messages):
+        if not self._should_emit_progress_bucket(
+            self._message_progress_buckets, sample_id, model_name, message_num, total_messages
+        ):
             return
         await self.update_sample_state(
             sample_id,

--- a/letta_evals/visualization/rich_renderer.py
+++ b/letta_evals/visualization/rich_renderer.py
@@ -387,9 +387,7 @@ class RichProgressRenderer:
                 if sample.metric_rationales and metric_key in sample.metric_rationales:
                     rationale = sample.metric_rationales.get(metric_key) or ""
                 score_cell = (
-                    f"{score_value:.2f}"
-                    if isinstance(score_value, (int, float)) and score_value is not None
-                    else "-"
+                    f"{score_value:.2f}" if isinstance(score_value, (int, float)) and score_value is not None else "-"
                 )
                 cells.extend([self._text_cell(score_cell), self._text_cell(rationale)])
             return cells

--- a/letta_evals/visualization/rich_renderer.py
+++ b/letta_evals/visualization/rich_renderer.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional
 
 from rich.align import Align
 from rich.box import MINIMAL_DOUBLE_HEAD, ROUNDED
-from rich.console import Console, Group
+from rich.console import Console, Group, RenderableType
 from rich.layout import Layout
 from rich.panel import Panel
 from rich.progress import Progress
@@ -27,6 +27,13 @@ from letta_evals.visualization.state import (
 class RichProgressRenderer:
     """Render the live Rich layout for evaluation progress."""
 
+    ACTIVE_STATE_ORDER = {
+        SampleState.LOADING_AGENT: 0,
+        SampleState.SENDING_MESSAGES: 1,
+        SampleState.GRADING: 2,
+        SampleState.GRADING_TURNS: 3,
+    }
+
     def __init__(
         self,
         *,
@@ -45,11 +52,12 @@ class RichProgressRenderer:
         self.rubric_model = rubric_model
         self.max_concurrent = max_concurrent
         self.metric_labels = metric_labels or {}
+        self._detail_sizes: Optional[tuple[int, int]] = None
 
     def render(self, runtime_state: ProgressRuntimeState, main_progress: Progress) -> Layout:
         """Render the complete live progress display."""
         layout = Layout()
-        active_panel_size, completed_panel_size = self._detail_layout_budget(runtime_state)
+        active_panel_size, completed_panel_size = self._detail_layout_budget()
         active_row_limit = self._panel_row_limit(active_panel_size)
         completed_row_limit = self._panel_row_limit(completed_panel_size)
 
@@ -67,12 +75,47 @@ class RichProgressRenderer:
 
         return layout
 
+    def build_visible_snapshot(self, runtime_state: ProgressRuntimeState) -> tuple:
+        """Return a stable snapshot of visible content for refresh diffing."""
+        active_panel_size, completed_panel_size = self._detail_layout_budget()
+        active_row_limit = self._panel_row_limit(active_panel_size)
+        completed_row_limit = self._panel_row_limit(completed_panel_size)
+        metric_keys = self._metric_keys(runtime_state)
+
+        visible_metric_totals = []
+        for key in metric_keys:
+            if key not in runtime_state.metric_totals:
+                continue
+            visible_metric_totals.append(
+                (
+                    key,
+                    round(runtime_state.metric_totals[key], 6),
+                    runtime_state.metric_counts.get(key, 0),
+                )
+            )
+
+        return (
+            active_panel_size,
+            completed_panel_size,
+            runtime_state.completed_count,
+            runtime_state.error_count,
+            tuple(visible_metric_totals),
+            tuple(
+                self._row_snapshot(sample, metric_keys)
+                for sample in self.select_active_rows(runtime_state, limit=active_row_limit)
+            ),
+            tuple(
+                self._row_snapshot(sample, metric_keys)
+                for sample in self.select_completed_rows(runtime_state, limit=completed_row_limit)
+            ),
+        )
+
     def select_active_rows(
         self, runtime_state: ProgressRuntimeState, limit: Optional[int] = None
     ) -> List[SampleProgress]:
-        """Select only currently active rows for the live top panel."""
+        """Select active rows with stable ordering inside each phase bucket."""
         rows = [sample for sample in runtime_state.samples.values() if is_active_state(sample.state)]
-        rows.sort(key=lambda sample: (sample.model_name or "", sample.sample_id))
+        rows.sort(key=self._active_sort_key)
         if limit is None:
             return rows
         return rows[:limit]
@@ -80,12 +123,22 @@ class RichProgressRenderer:
     def select_completed_rows(
         self, runtime_state: ProgressRuntimeState, limit: Optional[int] = None
     ) -> List[SampleProgress]:
-        """Select the most recent completed or errored rows for the bottom panel."""
+        """Select completed rows in completion order instead of hot update order."""
         rows = [sample for sample in runtime_state.samples.values() if is_completed_state(sample.state)]
-        rows.sort(key=lambda sample: (-get_last_update_key(sample), sample.model_name or "", sample.sample_id))
+        rows.sort(key=self._completed_sort_key)
         if limit is None:
             return rows
         return rows[:limit]
+
+    def _active_sort_key(self, sample: SampleProgress) -> tuple:
+        state_rank = self.ACTIVE_STATE_ORDER.get(sample.state, len(self.ACTIVE_STATE_ORDER))
+        sequence = sample.active_sort_sequence or 10**9
+        return (state_rank, sequence, sample.model_name or "", sample.sample_id)
+
+    def _completed_sort_key(self, sample: SampleProgress) -> tuple:
+        completion_rank = sample.completion_sequence if sample.completion_sequence is not None else 0
+        fallback = get_last_update_key(sample) if sample.completion_sequence is None else 0.0
+        return (-completion_rank, -fallback, sample.model_name or "", sample.sample_id)
 
     def _get_state_icon(self, state: SampleState) -> Text:
         icons = {
@@ -98,49 +151,49 @@ class RichProgressRenderer:
             SampleState.ERROR: ("⚠", "red"),
         }
         icon, style = icons.get(state, ("?", "white"))
-        return Text(icon, style=style)
+        return Text(icon, style=style, end="")
 
     def _get_state_text(self, sample: SampleProgress) -> Text:
         icon = self._get_state_icon(sample.state)
 
         if sample.state == SampleState.SENDING_MESSAGES and sample.total_messages > 0:
-            text = Text()
+            text = Text(overflow="ellipsis", no_wrap=True, end="")
             text.append(icon)
             text.append(f" sending [{sample.messages_sent}/{sample.total_messages}]")
             return text
 
         if sample.state == SampleState.GRADING_TURNS and sample.total_turns > 0:
-            text = Text()
+            text = Text(overflow="ellipsis", no_wrap=True, end="")
             text.append(icon)
             text.append(f" grading [{sample.turns_graded}/{sample.total_turns}]")
             return text
 
         if sample.state == SampleState.COMPLETED:
-            text = Text()
-            text.append(Text("✓", style="green"))
+            text = Text(overflow="ellipsis", no_wrap=True, end="")
+            text.append(Text("✓", style="green", end=""))
             text.append(" completed")
             return text
 
-        text = Text()
+        text = Text(overflow="ellipsis", no_wrap=True, end="")
         text.append(icon)
         text.append(f" {sample.state.value}")
         return text
 
     def _create_header_panel(self) -> Panel:
-        header_title = Text(f"🧪 Evaluation: {self.suite_name}", style="bold white")
+        header_title = Text(f"🧪 Evaluation: {self.suite_name}", style="bold white", end="")
         try:
             header_title.apply_gradient("#00D1FF", "#7C3AED")
         except Exception:
             pass
 
-        subtitle = Text()
+        subtitle = Text(end="")
         subtitle.append(f"Target: {self.target_kind}  •  ", style="dim")
         subtitle.append(f"Grader: {self.grader_kind}  •  ", style="dim")
         subtitle.append(f"Concurrent: {self.max_concurrent}", style="dim")
 
-        rows: List[Text] = [Align.center(header_title), Align.center(subtitle)]
+        rows: List[RenderableType] = [Align.center(header_title), Align.center(subtitle)]
         if self.metric_labels:
-            metrics_line = Text("Metrics: ", style="dim")
+            metrics_line = Text("Metrics: ", style="dim", end="")
             metrics_line.append(", ".join(self.metric_labels.values()), style="white")
             rows.append(Align.center(metrics_line))
 
@@ -160,14 +213,13 @@ class RichProgressRenderer:
             errors_pct = (runtime_state.error_count / completed * 100.0) if completed > 0 else 0.0
             errors_text = f"Errored: {errors_pct:.1f}%"
 
-        chips = Text()
+        chips = Text(end="")
         chips.append(f"  {errors_text}", style="bold white")
 
         if runtime_state.metric_totals:
             chips.append("   ")
             first = True
-            keys = list(self.metric_labels.keys()) if self.metric_labels else list(runtime_state.metric_totals.keys())
-            for key in keys:
+            for key in self._metric_keys(runtime_state):
                 if key not in runtime_state.metric_totals:
                     continue
                 total = runtime_state.metric_totals[key]
@@ -187,35 +239,25 @@ class RichProgressRenderer:
             chips.append("   ")
             chips.append(f"⚠ {runtime_state.error_count}", style="yellow")
 
-        return Panel(Group(main_progress, Text(""), chips), box=ROUNDED, border_style="blue", padding=(0, 1))
+        return Panel(Group(main_progress, Text("", end=""), chips), box=ROUNDED, border_style="blue", padding=(0, 1))
 
-    def _detail_layout_budget(self, runtime_state: ProgressRuntimeState) -> tuple[int, int]:
-        available_lines = max(12, self.console.height - 10)
-        has_completed = any(is_completed_state(sample.state) for sample in runtime_state.samples.values())
-
-        if has_completed:
+    def _detail_layout_budget(self) -> tuple[int, int]:
+        if self._detail_sizes is None:
+            available_lines = max(12, self.console.height - 10)
             completed_panel_size = min(11, max(6, available_lines // 3))
-        else:
-            completed_panel_size = 5
-
-        active_panel_size = max(7, available_lines - completed_panel_size)
-        return active_panel_size, completed_panel_size
+            active_panel_size = max(7, available_lines - completed_panel_size)
+            self._detail_sizes = (active_panel_size, completed_panel_size)
+        return self._detail_sizes
 
     def _panel_row_limit(self, panel_size: int) -> int:
         return max(1, panel_size - 5)
 
-    def _create_samples_table(self, rows: List[SampleProgress], title: str, empty_message: str):
-        if not rows:
-            return Panel(
-                Text(empty_message, style="dim"),
-                title=title,
-                border_style="blue",
-                box=ROUNDED,
-                padding=(0, 1),
-            )
-
+    def _create_samples_table(
+        self, rows: List[SampleProgress], title: str, row_limit: int, empty_message: Optional[str] = None
+    ) -> Table:
+        metric_keys = self._metric_keys_from_rows(rows)
         table = Table(
-            title=f"{title}  (♻ means cached)",
+            title=title,
             show_header=True,
             header_style="bold cyan",
             border_style="blue",
@@ -223,126 +265,214 @@ class RichProgressRenderer:
             expand=True,
         )
 
-        table.add_column("#", style="cyan", width=5)
-        table.add_column("Agent ID", style="dim cyan", no_wrap=False)
-        table.add_column("Model", style="yellow", width=27)
+        table.add_column("#", style="cyan", width=5, no_wrap=True)
+        table.add_column("Agent ID", style="dim cyan", max_width=24, no_wrap=True, overflow="ellipsis")
+        table.add_column("Model", style="yellow", max_width=27, no_wrap=True, overflow="ellipsis")
         if self.grader_kind == GraderKind.MODEL_JUDGE.value and self.rubric_model:
-            table.add_column("Rubric Model", style="magenta", width=27)
-        table.add_column("Status", width=20)
+            table.add_column("Rubric Model", style="magenta", max_width=27, no_wrap=True, overflow="ellipsis")
+        table.add_column("Status", max_width=20, no_wrap=True, overflow="ellipsis")
 
-        metric_keys = list(self.metric_labels.keys())
         if metric_keys:
             for metric_key in metric_keys:
                 label = self.metric_labels.get(metric_key, metric_key)
-                table.add_column(f"{label} Score", width=10, justify="right")
-                table.add_column(f"{label} Rationale", width=45, justify="left")
+                table.add_column(f"{label} Score", width=10, justify="right", no_wrap=True)
+                table.add_column(
+                    f"{label} Rationale",
+                    max_width=45,
+                    no_wrap=True,
+                    overflow="ellipsis",
+                )
         else:
-            table.add_column("Score", width=10, justify="right")
-            table.add_column("Rationale", width=45, justify="left")
-        table.add_column("Time", width=8, justify="right")
-        table.add_column("Details", justify="left")
+            table.add_column("Score", width=10, justify="right", no_wrap=True)
+            table.add_column("Rationale", max_width=45, no_wrap=True, overflow="ellipsis")
+        table.add_column("Time", width=8, justify="right", no_wrap=True)
+        table.add_column("Details", ratio=1, min_width=16, no_wrap=True, overflow="ellipsis")
 
-        for sample in rows:
-            if sample.start_time and sample.end_time:
-                duration = sample.end_time - sample.start_time
-                time_text = f"{duration:.1f}s"
-            elif sample.start_time:
-                duration = time.time() - sample.start_time
-                time_text = f"{duration:.1f}s"
-            else:
-                time_text = "-"
+        displayed_rows = rows[:row_limit]
+        for sample in displayed_rows:
+            table.add_row(*self._build_row_cells(sample, metric_keys))
 
-            cells: List[str] = []
-            if sample.state == SampleState.GRADING_TURNS and sample.turn_scores:
-                if self.metric_labels:
-                    for metric_key in metric_keys:
-                        grader_scores = sample.turn_scores.get(metric_key)
-                        if grader_scores:
-                            score_cell = f"{calculate_turn_average(grader_scores):.2f}"
-                            rationale = build_turn_symbols(grader_scores)
-                        else:
-                            score_cell = "-"
-                            rationale = ""
-                        cells.extend([score_cell, rationale])
-                else:
-                    first_grader = next(iter(sample.turn_scores.values()), None)
-                    if first_grader:
-                        score_cell = f"{calculate_turn_average(first_grader):.2f}"
-                        rationale = build_turn_symbols(first_grader)
-                    else:
-                        score_cell = "-"
-                        rationale = ""
-                    cells.extend([score_cell, rationale])
-            elif self.metric_labels:
-                for metric_key in metric_keys:
-                    score_value = None
-                    rationale = ""
-                    if sample.metric_scores and metric_key in sample.metric_scores:
-                        score_value = sample.metric_scores.get(metric_key)
-                    if sample.metric_rationales and metric_key in sample.metric_rationales:
-                        rationale = sample.metric_rationales.get(metric_key) or ""
-                    score_cell = (
-                        f"{score_value:.2f}"
-                        if isinstance(score_value, (int, float)) and score_value is not None
-                        else "-"
-                    )
-                    if rationale and len(rationale) > 50:
-                        rationale = rationale[:47] + "..."
-                    cells.extend([score_cell, rationale])
-            else:
-                score_cell = f"{sample.score:.2f}" if sample.score is not None else "-"
-                rationale = sample.rationale or ""
-                if rationale and len(rationale) > 50:
-                    rationale = rationale[:47] + "..."
-                cells.extend([score_cell, rationale])
-
-            if sample.state == SampleState.SENDING_MESSAGES and sample.total_messages > 0:
-                progress = sample.messages_sent / sample.total_messages
-                bar_width = max(10, min(30, max(10, self.console.width // 6)))
-                filled = int(progress * bar_width)
-                bar = "▰" * filled + "▱" * (bar_width - filled)
-                details = f"{bar}  msg {sample.messages_sent}/{sample.total_messages}"
-            elif sample.state == SampleState.GRADING_TURNS and sample.total_turns > 0:
-                progress = sample.turns_graded / sample.total_turns
-                bar_width = max(10, min(30, max(10, self.console.width // 6)))
-                filled = int(progress * bar_width)
-                bar = "▰" * filled + "▱" * (bar_width - filled)
-                details = f"{bar}  turn {sample.turns_graded}/{sample.total_turns}"
-            elif sample.state == SampleState.LOADING_AGENT:
-                details = "Loading from cache…" if sample.from_cache else "Loading agent…"
-            elif sample.state == SampleState.GRADING:
-                details = "Grading response…"
-            elif sample.state == SampleState.COMPLETED:
-                details = "[green]✓ Completed[/green]"
-            elif sample.state == SampleState.ERROR:
-                details = f"[red]Error: {sample.error[:25]}…[/red]" if sample.error else "[red]Error[/red]"
-            elif sample.state == SampleState.QUEUED:
-                details = "[dim]Waiting…[/dim]"
-            else:
-                details = ""
-
-            sample_num = str(sample.sample_id + 1)
-            if sample.from_cache:
-                sample_num = f"{sample_num} ♻"
-
-            row_data = [
-                sample_num,
-                sample.agent_id or "-",
-                sample.model_name or "-",
-            ]
-            if self.grader_kind == GraderKind.MODEL_JUDGE.value and self.rubric_model:
-                row_data.append(self.rubric_model)
-            row_data.extend([self._get_state_text(sample), *cells, time_text, details])
-            table.add_row(*row_data)
+        placeholder_message = empty_message if not displayed_rows else None
+        for _ in range(row_limit - len(displayed_rows)):
+            table.add_row(*self._blank_row_cells(metric_keys, placeholder_message))
+            placeholder_message = None
 
         return table
 
-    def _create_active_view(self, runtime_state: ProgressRuntimeState, limit: int):
-        rows = self.select_active_rows(runtime_state, limit=limit)
-        title = f"Active Samples · showing {len(rows)}"
-        return self._create_samples_table(rows, title, "No active samples")
+    def _metric_keys(self, runtime_state: ProgressRuntimeState) -> List[str]:
+        if self.metric_labels:
+            return list(self.metric_labels.keys())
+        return list(runtime_state.metric_totals.keys())
 
-    def _create_completed_view(self, runtime_state: ProgressRuntimeState, limit: int):
+    def _metric_keys_from_rows(self, rows: List[SampleProgress]) -> List[str]:
+        del rows
+        if self.metric_labels:
+            return list(self.metric_labels.keys())
+        return []
+
+    def _build_row_cells(self, sample: SampleProgress, metric_keys: List[str]) -> List[RenderableType]:
+        score_cells = self._get_score_cells(sample, metric_keys)
+        sample_num = str(sample.sample_id + 1)
+        if sample.from_cache:
+            sample_num = f"{sample_num} ♻"
+
+        row_data: List[RenderableType] = [
+            self._text_cell(sample_num),
+            self._text_cell(sample.agent_id or "-"),
+            self._text_cell(sample.model_name or "-"),
+        ]
+        if self.grader_kind == GraderKind.MODEL_JUDGE.value and self.rubric_model:
+            row_data.append(self._text_cell(self.rubric_model))
+        row_data.extend(
+            [
+                self._get_state_text(sample),
+                *score_cells,
+                self._text_cell(self._get_time_text(sample)),
+                self._get_details_text(sample),
+            ]
+        )
+        return row_data
+
+    def _blank_row_cells(self, metric_keys: List[str], message: Optional[str] = None) -> List[RenderableType]:
+        row_data: List[RenderableType] = [
+            self._text_cell(""),
+            self._text_cell(""),
+            self._text_cell(""),
+        ]
+        if self.grader_kind == GraderKind.MODEL_JUDGE.value and self.rubric_model:
+            row_data.append(self._text_cell(""))
+
+        row_data.append(self._text_cell(""))
+        if metric_keys:
+            for _ in metric_keys:
+                row_data.extend([self._text_cell(""), self._text_cell("")])
+        else:
+            row_data.extend([self._text_cell(""), self._text_cell("")])
+
+        row_data.append(self._text_cell(""))
+        row_data.append(self._text_cell(message or "", style="dim"))
+        return row_data
+
+    def _get_score_cells(self, sample: SampleProgress, metric_keys: List[str]) -> List[RenderableType]:
+        cells: List[RenderableType] = []
+
+        if sample.state == SampleState.GRADING_TURNS and sample.turn_scores:
+            if metric_keys:
+                for metric_key in metric_keys:
+                    grader_scores = sample.turn_scores.get(metric_key)
+                    if grader_scores:
+                        score_cell = f"{calculate_turn_average(grader_scores):.2f}"
+                        rationale = build_turn_symbols(grader_scores)
+                    else:
+                        score_cell = "-"
+                        rationale = ""
+                    cells.extend([self._text_cell(score_cell), self._text_cell(rationale)])
+            else:
+                first_grader = next(iter(sample.turn_scores.values()), None)
+                if first_grader:
+                    score_cell = f"{calculate_turn_average(first_grader):.2f}"
+                    rationale = build_turn_symbols(first_grader)
+                else:
+                    score_cell = "-"
+                    rationale = ""
+                cells.extend([self._text_cell(score_cell), self._text_cell(rationale)])
+            return cells
+
+        if metric_keys:
+            for metric_key in metric_keys:
+                score_value = None
+                rationale = ""
+                if sample.metric_scores and metric_key in sample.metric_scores:
+                    score_value = sample.metric_scores.get(metric_key)
+                if sample.metric_rationales and metric_key in sample.metric_rationales:
+                    rationale = sample.metric_rationales.get(metric_key) or ""
+                score_cell = (
+                    f"{score_value:.2f}"
+                    if isinstance(score_value, (int, float)) and score_value is not None
+                    else "-"
+                )
+                cells.extend([self._text_cell(score_cell), self._text_cell(rationale)])
+            return cells
+
+        score_cell = f"{sample.score:.2f}" if sample.score is not None else "-"
+        rationale = sample.rationale or ""
+        return [self._text_cell(score_cell), self._text_cell(rationale)]
+
+    def _get_time_text(self, sample: SampleProgress) -> str:
+        if sample.start_time and sample.end_time:
+            duration = sample.end_time - sample.start_time
+            return f"{duration:.1f}s"
+        if sample.start_time:
+            duration = time.time() - sample.start_time
+            return f"{duration:.1f}s"
+        return "-"
+
+    def _get_details_text(self, sample: SampleProgress) -> Text:
+        if sample.state == SampleState.SENDING_MESSAGES and sample.total_messages > 0:
+            progress = sample.messages_sent / sample.total_messages
+            bar_width = max(10, min(30, max(10, self.console.width // 6)))
+            filled = int(progress * bar_width)
+            bar = "▰" * filled + "▱" * (bar_width - filled)
+            details = f"{bar}  msg {sample.messages_sent}/{sample.total_messages}"
+            return self._text_cell(details)
+
+        if sample.state == SampleState.GRADING_TURNS and sample.total_turns > 0:
+            progress = sample.turns_graded / sample.total_turns
+            bar_width = max(10, min(30, max(10, self.console.width // 6)))
+            filled = int(progress * bar_width)
+            bar = "▰" * filled + "▱" * (bar_width - filled)
+            details = f"{bar}  turn {sample.turns_graded}/{sample.total_turns}"
+            return self._text_cell(details)
+
+        if sample.state == SampleState.LOADING_AGENT:
+            return self._text_cell("Loading from cache…" if sample.from_cache else "Loading agent…")
+        if sample.state == SampleState.GRADING:
+            return self._text_cell("Grading response…")
+        if sample.state == SampleState.COMPLETED:
+            return self._text_cell("✓ Completed", style="green")
+        if sample.state == SampleState.ERROR:
+            detail = f"Error: {sample.error}" if sample.error else "Error"
+            return self._text_cell(detail, style="red")
+        if sample.state == SampleState.QUEUED:
+            return self._text_cell("Waiting…", style="dim")
+        return self._text_cell("")
+
+    def _text_cell(self, value: str, style: str = "") -> Text:
+        return Text(value, style=style, overflow="ellipsis", no_wrap=True, end="")
+
+    def _row_snapshot(self, sample: SampleProgress, metric_keys: List[str]) -> tuple:
+        score_snapshot = []
+        for cell in self._get_score_cells(sample, metric_keys):
+            if isinstance(cell, Text):
+                score_snapshot.append(cell.plain)
+            else:
+                score_snapshot.append(str(cell))
+
+        return (
+            sample.sample_id,
+            sample.from_cache,
+            sample.agent_id or "-",
+            sample.model_name or "-",
+            self.rubric_model if self.grader_kind == GraderKind.MODEL_JUDGE.value and self.rubric_model else None,
+            sample.state.value,
+            sample.messages_sent,
+            sample.total_messages,
+            sample.turns_graded,
+            sample.total_turns,
+            tuple(score_snapshot),
+            self._get_time_snapshot(sample),
+            self._get_details_text(sample).plain,
+        )
+
+    def _get_time_snapshot(self, sample: SampleProgress) -> Optional[float]:
+        if sample.start_time and sample.end_time:
+            return round(sample.end_time - sample.start_time, 3)
+        return round(sample.start_time, 3) if sample.start_time else None
+
+    def _create_active_view(self, runtime_state: ProgressRuntimeState, limit: int) -> Table:
+        rows = self.select_active_rows(runtime_state, limit=limit)
+        return self._create_samples_table(rows, "Active Samples", limit, empty_message="No active samples")
+
+    def _create_completed_view(self, runtime_state: ProgressRuntimeState, limit: int) -> Table:
         rows = self.select_completed_rows(runtime_state, limit=limit)
-        title = f"Recent Completed · showing {len(rows)}"
-        return self._create_samples_table(rows, title, "No completed samples yet")
+        return self._create_samples_table(rows, "Recent Completed", limit, empty_message="No completed samples yet")

--- a/letta_evals/visualization/state.py
+++ b/letta_evals/visualization/state.py
@@ -56,6 +56,8 @@ class SampleProgress:
     turns_graded: int = 0
     total_turns: int = 0
     turn_scores: Optional[Dict[str, List[Optional[float]]]] = None
+    active_sort_sequence: int = 0
+    completion_sequence: Optional[int] = None
 
 
 @dataclass

--- a/tests/test_rich_progress.py
+++ b/tests/test_rich_progress.py
@@ -101,3 +101,56 @@ async def test_stats_capture_queue_pressure_under_concurrency() -> None:
     assert stats.refreshes < stats.events_processed
 
     progress.stop()
+
+
+@pytest.mark.asyncio
+async def test_offscreen_updates_do_not_force_refresh() -> None:
+    progress = EvalProgress(
+        suite_name="demo",
+        total_samples=3,
+        console=Console(width=120, height=12, force_terminal=False),
+        update_freq=20.0,
+    )
+    progress.main_task_id = progress.main_progress.add_task("Evaluating samples", total=3, completed=0)
+    live = DummyLive()
+    progress.live = live  # type: ignore[assignment]
+    progress._start_background_tasks()
+
+    await progress.update_sample_state(0, SampleState.LOADING_AGENT)
+    await progress.update_sample_state(1, SampleState.LOADING_AGENT)
+    await progress.update_sample_state(2, SampleState.LOADING_AGENT)
+    await asyncio.sleep(0.1)
+
+    assert live.refresh_count == 1
+
+    await progress.update_sample_state(2, SampleState.LOADING_AGENT, agent_id="agent-offscreen")
+    await asyncio.sleep(0.1)
+
+    assert live.refresh_count == 1
+
+    progress.stop()
+
+
+@pytest.mark.asyncio
+async def test_message_progress_is_bucketed_before_emitting_events() -> None:
+    progress = EvalProgress(
+        suite_name="demo",
+        total_samples=1,
+        console=Console(width=120, height=20, force_terminal=False),
+        update_freq=20.0,
+    )
+    progress.main_task_id = progress.main_progress.add_task("Evaluating samples", total=1, completed=0)
+    progress.live = DummyLive()  # type: ignore[assignment]
+    progress._start_background_tasks()
+
+    for message_num in range(1, 21):
+        await progress.message_sending(0, message_num, 20, model_name="gpt-5")
+
+    await asyncio.sleep(0.1)
+    stats = progress.get_stats_snapshot()
+
+    assert stats.events_emitted < 20
+    assert stats.events_processed < 20
+    assert progress._runtime_state.samples[(0, "gpt-5")].messages_sent == 20  # noqa: SLF001
+
+    progress.stop()

--- a/tests/test_rich_renderer.py
+++ b/tests/test_rich_renderer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import time
+
 from rich.console import Console
 
 from letta_evals.visualization.reducer import ProgressRuntimeState
@@ -21,11 +23,36 @@ def build_renderer() -> RichProgressRenderer:
 def build_runtime_state() -> ProgressRuntimeState:
     return ProgressRuntimeState(
         samples={
-            (0, None): SampleProgress(sample_id=0, state=SampleState.GRADING, last_update_ts=30.0),
-            (3, None): SampleProgress(sample_id=3, state=SampleState.SENDING_MESSAGES, last_update_ts=10.0),
-            (5, None): SampleProgress(sample_id=5, state=SampleState.COMPLETED, last_update_ts=80.0),
-            (2, None): SampleProgress(sample_id=2, state=SampleState.ERROR, last_update_ts=70.0),
-            (7, None): SampleProgress(sample_id=7, state=SampleState.COMPLETED, last_update_ts=60.0),
+            (0, None): SampleProgress(
+                sample_id=0,
+                state=SampleState.GRADING,
+                last_update_ts=30.0,
+                active_sort_sequence=2,
+            ),
+            (3, None): SampleProgress(
+                sample_id=3,
+                state=SampleState.SENDING_MESSAGES,
+                last_update_ts=10.0,
+                active_sort_sequence=1,
+            ),
+            (5, None): SampleProgress(
+                sample_id=5,
+                state=SampleState.COMPLETED,
+                last_update_ts=80.0,
+                completion_sequence=3,
+            ),
+            (2, None): SampleProgress(
+                sample_id=2,
+                state=SampleState.ERROR,
+                last_update_ts=70.0,
+                completion_sequence=2,
+            ),
+            (7, None): SampleProgress(
+                sample_id=7,
+                state=SampleState.COMPLETED,
+                last_update_ts=999.0,
+                completion_sequence=1,
+            ),
             (6, None): SampleProgress(sample_id=6, state=SampleState.QUEUED, last_update_ts=5.0),
         }
     )
@@ -36,7 +63,7 @@ def test_select_active_rows_excludes_completed_and_queued() -> None:
 
     rows = renderer.select_active_rows(build_runtime_state(), limit=5)
 
-    assert [row.sample_id for row in rows] == [0, 3]
+    assert [row.sample_id for row in rows] == [3, 0]
 
 
 def test_select_completed_rows_is_recent_first() -> None:
@@ -45,3 +72,64 @@ def test_select_completed_rows_is_recent_first() -> None:
     rows = renderer.select_completed_rows(build_runtime_state(), limit=5)
 
     assert [row.sample_id for row in rows] == [5, 2, 7]
+
+
+def test_create_samples_table_pads_rows_to_fixed_limit() -> None:
+    renderer = build_renderer()
+    table = renderer._create_samples_table(  # noqa: SLF001
+        [SampleProgress(sample_id=0, state=SampleState.LOADING_AGENT)],
+        "Active Samples",
+        row_limit=3,
+    )
+
+    assert table.title == "Active Samples"
+    assert len(table.rows) == 3
+    assert table.columns[1].no_wrap is True
+    assert table.columns[-1].no_wrap is True
+
+
+def test_visible_snapshot_ignores_offscreen_row_updates() -> None:
+    renderer = RichProgressRenderer(
+        console=Console(width=120, height=12, force_terminal=False),
+        suite_name="demo",
+        target_kind="agent",
+        grader_kind="tool",
+        rubric_model=None,
+        max_concurrent=8,
+    )
+    state = ProgressRuntimeState(
+        samples={
+            (0, None): SampleProgress(sample_id=0, state=SampleState.LOADING_AGENT, active_sort_sequence=1),
+            (1, None): SampleProgress(sample_id=1, state=SampleState.LOADING_AGENT, active_sort_sequence=2),
+            (2, None): SampleProgress(sample_id=2, state=SampleState.LOADING_AGENT, active_sort_sequence=3),
+        }
+    )
+
+    snapshot_before = renderer.build_visible_snapshot(state)
+    state.samples[(2, None)].agent_id = "agent-offscreen"
+    state.samples[(2, None)].messages_sent = 5
+    state.samples[(2, None)].total_messages = 10
+    snapshot_after = renderer.build_visible_snapshot(state)
+
+    assert snapshot_before == snapshot_after
+
+
+def test_visible_snapshot_does_not_drift_with_elapsed_time_only() -> None:
+    renderer = build_renderer()
+    started = time.time() - 5
+    state = ProgressRuntimeState(
+        samples={
+            (0, None): SampleProgress(
+                sample_id=0,
+                state=SampleState.GRADING,
+                start_time=started,
+                active_sort_sequence=1,
+            )
+        }
+    )
+
+    snapshot_before = renderer.build_visible_snapshot(state)
+    time.sleep(0.02)
+    snapshot_after = renderer.build_visible_snapshot(state)
+
+    assert snapshot_before == snapshot_after

--- a/tests/test_visualization_reducer.py
+++ b/tests/test_visualization_reducer.py
@@ -77,3 +77,62 @@ def test_record_turn_grade_initializes_and_updates_turn_scores() -> None:
     assert sample.agent_id == "agent-4"
     assert sample.model_name == "gpt-5"
     assert sample.turn_scores == {"safety": [None, 0.8, None]}
+
+
+def test_active_sort_sequence_changes_only_on_state_transition() -> None:
+    reducer = ProgressStateReducer(ProgressRuntimeState())
+
+    reducer.apply_event(
+        ProgressEvent(
+            kind="update_sample_state",
+            payload={"sample_id": 5, "state": SampleState.LOADING_AGENT},
+        )
+    )
+    first_sequence = reducer.state.samples[(5, None)].active_sort_sequence
+
+    reducer.apply_event(
+        ProgressEvent(
+            kind="update_sample_state",
+            payload={"sample_id": 5, "state": SampleState.LOADING_AGENT, "agent_id": "agent-5"},
+        )
+    )
+
+    assert reducer.state.samples[(5, None)].active_sort_sequence == first_sequence
+
+    reducer.apply_event(
+        ProgressEvent(
+            kind="update_sample_state",
+            payload={"sample_id": 5, "state": SampleState.GRADING},
+        )
+    )
+
+    assert reducer.state.samples[(5, None)].active_sort_sequence > first_sequence
+
+
+def test_completion_sequence_tracks_first_terminal_transition() -> None:
+    reducer = ProgressStateReducer(ProgressRuntimeState())
+
+    reducer.apply_event(
+        ProgressEvent(
+            kind="update_sample_state",
+            payload={"sample_id": 6, "state": SampleState.LOADING_AGENT},
+        )
+    )
+    reducer.apply_event(
+        ProgressEvent(
+            kind="update_sample_state",
+            payload={"sample_id": 6, "state": SampleState.COMPLETED},
+        )
+    )
+
+    sample = reducer.state.samples[(6, None)]
+    first_completion_sequence = sample.completion_sequence
+
+    reducer.apply_event(
+        ProgressEvent(
+            kind="update_sample_state",
+            payload={"sample_id": 6, "state": SampleState.COMPLETED, "score": 1.0},
+        )
+    )
+
+    assert sample.completion_sequence == first_completion_sequence


### PR DESCRIPTION
## Summary
- stabilize the Rich progress tables with fixed geometry, padded rows, and single-line truncation
- keep sorting but make it sticky with stable active/completion ordering instead of hot update reshuffles
- skip refreshes when the visible frame is unchanged and bucket noisy message/turn progress updates

## Testing
- uv run pytest tests/test_rich_progress.py tests/test_rich_renderer.py tests/test_visualization_reducer.py tests/test_visualization_summary.py