### PR TITLE
feat(visualization): Add live target cost to rich progress

### DIFF
--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -539,6 +539,7 @@ class Runner:
 
         async with self.semaphore:
             agent_id = None
+            agent_usage = None
             phase = ErrorCategory.UNKNOWN
             t_sample_start = time.perf_counter()
             try:  # noqa: SIM105 — outer try/finally for agent cleanup
@@ -552,6 +553,10 @@ class Runner:
                     sample, llm_config, retrieve_agent_state=retrieve_agent_state
                 )
 
+                cost = calculate_cost_from_agent_usage(model_name, agent_usage) if model_name else None
+                prompt_tokens, completion_tokens, cached_input_tokens, cache_write_tokens, reasoning_tokens = (
+                    extract_token_counts(agent_usage)
+                )
                 target_time = time.perf_counter() - t_sample_start
 
                 if self.progress_callback:
@@ -570,7 +575,11 @@ class Runner:
                 error_info = self._detect_errors(grade_result, trajectory, submission, grades_dict)
                 if error_info and self.progress_callback:
                     await self.progress_callback.sample_error(
-                        sample_id, error_info.message, agent_id=agent_id, model_name=model_name
+                        sample_id,
+                        error_info.message,
+                        agent_id=agent_id,
+                        model_name=model_name,
+                        target_cost=cost if cost and cost > 0 else None,
                     )
 
                 if error_info is None and self.progress_callback:
@@ -583,17 +592,12 @@ class Runner:
                         sample_id,
                         agent_id=agent_id,
                         score=grade_result.score,
+                        target_cost=cost if cost and cost > 0 else None,
                         model_name=model_name,
                         metric_scores=metric_scores,
                         rationale=grade_result.rationale,
                         metric_rationales=metric_rationales,
                     )
-
-                # Calculate cost and extract token counts from agent usage
-                cost = calculate_cost_from_agent_usage(model_name, agent_usage) if model_name else None
-                prompt_tokens, completion_tokens, cached_input_tokens, cache_write_tokens, reasoning_tokens = (
-                    extract_token_counts(agent_usage)
-                )
 
                 # Calculate timing
                 total_time = time.perf_counter() - t_sample_start
@@ -636,9 +640,17 @@ class Runner:
                     exception_type=type(cause).__name__,
                     message=error_message,
                 )
+                cost = calculate_cost_from_agent_usage(model_name, agent_usage) if model_name and agent_usage else None
+                prompt_tokens, completion_tokens, cached_input_tokens, cache_write_tokens, reasoning_tokens = (
+                    extract_token_counts(agent_usage)
+                )
                 if self.progress_callback:
                     await self.progress_callback.sample_error(
-                        sample_id, error_message, agent_id=agent_id, model_name=model_name
+                        sample_id,
+                        error_message,
+                        agent_id=agent_id,
+                        model_name=model_name,
+                        target_cost=cost if cost and cost > 0 else None,
                     )
                 return SampleResult(
                     sample=sample,
@@ -649,10 +661,13 @@ class Runner:
                     grade=GradeResult(score=0.0, rationale=f"Error: {error_message}"),
                     grades=None,
                     model_name=model_name,
-                    agent_usage=None,
-                    cost=None,
-                    prompt_tokens=None,
-                    completion_tokens=None,
+                    agent_usage=agent_usage,
+                    cost=cost if cost and cost > 0 else None,
+                    prompt_tokens=prompt_tokens if prompt_tokens > 0 else None,
+                    completion_tokens=completion_tokens if completion_tokens > 0 else None,
+                    cached_input_tokens=cached_input_tokens if cached_input_tokens > 0 else None,
+                    cache_write_tokens=cache_write_tokens if cache_write_tokens > 0 else None,
+                    reasoning_tokens=reasoning_tokens if reasoning_tokens > 0 else None,
                     total_time=time.perf_counter() - t_sample_start,
                     error=error_info,
                 )

--- a/letta_evals/visualization/base.py
+++ b/letta_evals/visualization/base.py
@@ -83,6 +83,7 @@ class ProgressCallback(ABC):
         sample_id: int,
         agent_id: Optional[str] = None,
         score: Optional[float] = None,
+        target_cost: Optional[float] = None,
         model_name: Optional[str] = None,
         metric_scores: Optional[Dict[str, float]] = None,
         rationale: Optional[str] = None,
@@ -93,7 +94,12 @@ class ProgressCallback(ABC):
 
     @abstractmethod
     async def sample_error(
-        self, sample_id: int, error: str, agent_id: Optional[str] = None, model_name: Optional[str] = None
+        self,
+        sample_id: int,
+        error: str,
+        agent_id: Optional[str] = None,
+        model_name: Optional[str] = None,
+        target_cost: Optional[float] = None,
     ) -> None:
         """Called when a sample evaluation encounters an error."""
         ...

--- a/letta_evals/visualization/noop_progress.py
+++ b/letta_evals/visualization/noop_progress.py
@@ -18,6 +18,7 @@ class NoOpProgress(ProgressCallback):
         sample_id: int,
         agent_id: Optional[str] = None,
         score: Optional[float] = None,
+        target_cost: Optional[float] = None,
         model_name: Optional[str] = None,
         metric_scores: Optional[Dict[str, float]] = None,
         rationale: Optional[str] = None,
@@ -26,6 +27,11 @@ class NoOpProgress(ProgressCallback):
         pass
 
     async def sample_error(
-        self, sample_id: int, error: str, agent_id: Optional[str] = None, model_name: Optional[str] = None
+        self,
+        sample_id: int,
+        error: str,
+        agent_id: Optional[str] = None,
+        model_name: Optional[str] = None,
+        target_cost: Optional[float] = None,
     ) -> None:
         pass

--- a/letta_evals/visualization/reducer.py
+++ b/letta_evals/visualization/reducer.py
@@ -21,6 +21,7 @@ class ProgressRuntimeState:
     samples: Dict[SampleKey, SampleProgress] = field(default_factory=dict)
     metric_totals: Dict[str, float] = field(default_factory=dict)
     metric_counts: Dict[str, int] = field(default_factory=dict)
+    total_target_cost: float = 0.0
     completed_count: int = 0
     error_count: int = 0
 
@@ -42,6 +43,7 @@ class ProgressStateReducer:
         self.state.samples.clear()
         self.state.metric_totals.clear()
         self.state.metric_counts.clear()
+        self.state.total_target_cost = 0.0
         self.state.completed_count = 0
         self.state.error_count = 0
 
@@ -139,6 +141,7 @@ class ProgressStateReducer:
 
         if state == SampleState.COMPLETED and is_new_completion:
             self.state.completed_count += 1
+            self.state.total_target_cost += sample.target_cost or 0.0
 
             if sample.metric_scores:
                 for metric_key, metric_score in sample.metric_scores.items():
@@ -151,6 +154,7 @@ class ProgressStateReducer:
 
         if state == SampleState.ERROR and is_new_completion:
             self.state.error_count += 1
+            self.state.total_target_cost += sample.target_cost or 0.0
             return ReducerResult(progress_completed=self.state.completed_count + self.state.error_count)
 
         return ReducerResult()

--- a/letta_evals/visualization/rich_progress.py
+++ b/letta_evals/visualization/rich_progress.py
@@ -340,6 +340,7 @@ class EvalProgress(ProgressCallback):
         sample_id: int,
         agent_id: Optional[str] = None,
         score: Optional[float] = None,
+        target_cost: Optional[float] = None,
         model_name: Optional[str] = None,
         metric_scores: Optional[Dict[str, float]] = None,
         rationale: Optional[str] = None,
@@ -354,6 +355,7 @@ class EvalProgress(ProgressCallback):
             agent_id=agent_id,
             model_name=model_name,
             score=score,
+            target_cost=target_cost,
             rationale=rationale,
             from_cache=existing_from_cache,
             metric_scores=metric_scores,
@@ -361,7 +363,12 @@ class EvalProgress(ProgressCallback):
         )
 
     async def sample_error(
-        self, sample_id: int, error: str, agent_id: Optional[str] = None, model_name: Optional[str] = None
+        self,
+        sample_id: int,
+        error: str,
+        agent_id: Optional[str] = None,
+        model_name: Optional[str] = None,
+        target_cost: Optional[float] = None,
     ):
         """Mark sample as having an error"""
         await self.update_sample_state(
@@ -370,6 +377,7 @@ class EvalProgress(ProgressCallback):
             agent_id=agent_id,
             model_name=model_name,
             error=error,
+            target_cost=target_cost,
         )
 
     def get_stats_snapshot(self) -> VisualizationStats:

--- a/letta_evals/visualization/rich_renderer.py
+++ b/letta_evals/visualization/rich_renderer.py
@@ -175,17 +175,16 @@ class RichProgressRenderer:
         completed = runtime_state.completed_count + runtime_state.error_count
 
         if completed == 0:
-            errors_text = "Errored: N/A"
+            errors_text = "Errors: N/A"
         else:
             errors_pct = (runtime_state.error_count / completed * 100.0) if completed > 0 else 0.0
-            errors_text = f"Errored: {errors_pct:.1f}%"
+            errors_text = f"Errors: {errors_pct:.1f}%"
 
         chips = Text()
         chips.append(f"  {errors_text}", style="bold white")
 
-        if runtime_state.total_target_cost > 0:
-            chips.append("   ")
-            chips.append(f"Target cost: ${runtime_state.total_target_cost:.4f}", style="bold white")
+        chips.append("   ")
+        chips.append(f"Target cost: ${runtime_state.total_target_cost:.4f}", style="bold white")
 
         if runtime_state.metric_totals:
             chips.append("   ")

--- a/letta_evals/visualization/rich_renderer.py
+++ b/letta_evals/visualization/rich_renderer.py
@@ -183,6 +183,10 @@ class RichProgressRenderer:
         chips = Text()
         chips.append(f"  {errors_text}", style="bold white")
 
+        if runtime_state.total_target_cost > 0:
+            chips.append("   ")
+            chips.append(f"Target cost: ${runtime_state.total_target_cost:.4f}", style="bold white")
+
         if runtime_state.metric_totals:
             chips.append("   ")
             first = True

--- a/letta_evals/visualization/simple_progress.py
+++ b/letta_evals/visualization/simple_progress.py
@@ -79,6 +79,7 @@ class SimpleProgress(ProgressCallback):
         sample_id: int,
         agent_id: Optional[str] = None,
         score: Optional[float] = None,
+        target_cost: Optional[float] = None,
         model_name: Optional[str] = None,
         metric_scores: Optional[Dict[str, float]] = None,
         rationale: Optional[str] = None,
@@ -98,7 +99,12 @@ class SimpleProgress(ProgressCallback):
         self.console.print("  ".join(parts))
 
     async def sample_error(
-        self, sample_id: int, error: str, agent_id: Optional[str] = None, model_name: Optional[str] = None
+        self,
+        sample_id: int,
+        error: str,
+        agent_id: Optional[str] = None,
+        model_name: Optional[str] = None,
+        target_cost: Optional[float] = None,
     ) -> None:
         prefix = self._format_prefix(sample_id, agent_id, model_name)
         self.console.print(f"{prefix} [bold yellow]⚠ ERROR[/]: {error}")

--- a/letta_evals/visualization/state.py
+++ b/letta_evals/visualization/state.py
@@ -43,6 +43,7 @@ class SampleProgress:
     agent_id: Optional[str] = None
     model_name: Optional[str] = None
     score: Optional[float] = None
+    target_cost: Optional[float] = None
     rationale: Optional[str] = None
     error: Optional[str] = None
     messages_sent: int = 0

--- a/tests/test_rich_renderer.py
+++ b/tests/test_rich_renderer.py
@@ -105,3 +105,21 @@ def test_model_judge_renderer_moves_rubric_model_into_header_and_uses_fixed_colu
     assert isinstance(header_panel.renderable, Group)
     console.print(header_panel)
     assert "Rubric: judge-model-v1" in console.export_text()
+
+
+def test_progress_panel_renders_live_target_cost() -> None:
+    console = Console(width=120, height=20, force_terminal=False, record=True)
+    renderer = RichProgressRenderer(
+        console=console,
+        suite_name="demo",
+        target_kind="agent",
+        grader_kind="tool",
+        rubric_model=None,
+        max_concurrent=8,
+    )
+    runtime_state = ProgressRuntimeState(total_target_cost=0.0342, completed_count=2, error_count=1)
+    progress = Progress()
+
+    console.print(renderer._create_progress_with_metrics(runtime_state, progress))
+
+    assert "Target cost: $0.0342" in console.export_text()

--- a/tests/test_visualization_reducer.py
+++ b/tests/test_visualization_reducer.py
@@ -14,6 +14,7 @@ def test_apply_completed_update_tracks_counts_and_metric_totals() -> None:
                 "sample_id": 0,
                 "state": SampleState.COMPLETED,
                 "score": 0.75,
+                "target_cost": 0.0123,
                 "metric_scores": {"accuracy": 1.0, "fluency": 0.5},
             },
         )
@@ -21,6 +22,7 @@ def test_apply_completed_update_tracks_counts_and_metric_totals() -> None:
 
     assert reducer.state.completed_count == 1
     assert reducer.state.error_count == 0
+    assert reducer.state.total_target_cost == 0.0123
     assert reducer.state.metric_totals == {"accuracy": 1.0, "fluency": 0.5}
     assert reducer.state.metric_counts == {"accuracy": 1, "fluency": 1}
     assert result.progress_completed == 1
@@ -32,13 +34,34 @@ def test_apply_error_update_tracks_progress_without_incrementing_completed() -> 
     result = reducer.apply_event(
         ProgressEvent(
             kind="update_sample_state",
-            payload={"sample_id": 1, "state": SampleState.ERROR, "error": "boom"},
+            payload={"sample_id": 1, "state": SampleState.ERROR, "error": "boom", "target_cost": 0.0456},
         )
     )
 
     assert reducer.state.completed_count == 0
     assert reducer.state.error_count == 1
+    assert reducer.state.total_target_cost == 0.0456
     assert result.progress_completed == 1
+
+
+def test_duplicate_terminal_updates_do_not_double_count_target_cost() -> None:
+    reducer = ProgressStateReducer(ProgressRuntimeState())
+
+    reducer.apply_event(
+        ProgressEvent(
+            kind="update_sample_state",
+            payload={"sample_id": 9, "state": SampleState.COMPLETED, "target_cost": 0.02},
+        )
+    )
+    reducer.apply_event(
+        ProgressEvent(
+            kind="update_sample_state",
+            payload={"sample_id": 9, "state": SampleState.COMPLETED, "target_cost": 0.03},
+        )
+    )
+
+    assert reducer.state.completed_count == 1
+    assert reducer.state.total_target_cost == 0.02
 
 
 def test_ensure_sample_migrates_placeholder_when_model_name_arrives() -> None:


### PR DESCRIPTION
## Summary
- Add a live cumulative `Target cost` chip to the rich progress status row, visible from the start at $0.0000
- Plumb target cost through the progress callback and reducer so the total updates as samples finish
- Preserve target-cost accounting for errored samples when target usage is available
- Rename "Errored" label to "Errors" in the status bar
- Add reducer and renderer coverage for the new live total

## Testing
- `uv run pytest tests/test_visualization_reducer.py tests/test_rich_renderer.py tests/test_rich_progress.py tests/test_metrics.py`
- `uv run python -m compileall letta_evals`

## Screenshots
- Not included; this is a small terminal UI change to the existing rich progress status row