### PR TITLE
fix: Remove duplicate error logs and use consistent 0-indexed sample IDs

### DIFF
--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -628,7 +628,7 @@ class Runner:
                     agent_id = e.agent_id
                 agent_str = f" ({agent_id})" if agent_id else ""
                 log_message = str(e) or type(e).__name__
-                logger.error(f"Error running sample {sample_id + 1}{agent_str} with model {model_name}: {log_message}")
+                logger.error(f"Error running sample {sample_id}{agent_str} with model {model_name}: {log_message}")
                 category = ErrorCategory.TARGET if isinstance(e, TargetError) else phase
                 cause = e.__cause__ if e.__cause__ else e
                 error_message = str(e) or type(cause).__name__

--- a/letta_evals/targets/letta_agent.py
+++ b/letta_evals/targets/letta_agent.py
@@ -193,10 +193,6 @@ class LettaAgentTarget(AbstractAgentTarget):
                 attempt += 1
 
                 if attempt > self.max_retries:
-                    logger.error(
-                        f"Failed to run agent for sample {sample.id} after {self.max_retries} retries. "
-                        f"Final error: {type(e).__name__}: {str(e)}"
-                    )
                     timeout_hint = f"Timed out after {self.timeout}s" if isinstance(e, TimeoutError) else ""
                     msg = str(e) or timeout_hint or type(e).__name__
                     raise TargetError(msg, agent_id=agent_id) from e

--- a/letta_evals/targets/letta_code_target.py
+++ b/letta_evals/targets/letta_code_target.py
@@ -234,9 +234,6 @@ class LettaCodeTarget(AbstractAgentTarget):
                 stderr_text = "".join(stderr_chunks)
 
                 if process.returncode != 0:
-                    logger.error(f"Letta command failed with return code {process.returncode}")
-                    logger.error(f"Stderr: {stderr_text}")
-
                     # Surface the last stdout event so the real error isn't lost
                     last_stdout_event = ""
                     for ev in reversed(events):
@@ -305,11 +302,6 @@ class LettaCodeTarget(AbstractAgentTarget):
                 attempt += 1
 
                 if attempt > self.max_retries:
-                    logger.error(
-                        f"Failed to run letta command for sample {sample.id} after {self.max_retries} retries. "
-                        f"Agent: {agent_id or factory_agent_id or 'unknown'}. "
-                        f"Final error: {type(e).__name__}: {str(e)}"
-                    )
                     timeout_hint = f"Timed out after {self.timeout}s" if isinstance(e, TimeoutError) else ""
                     msg = str(e) or timeout_hint or type(e).__name__
                     raise TargetError(msg, agent_id=agent_id or factory_agent_id) from e

--- a/letta_evals/visualization/rich_renderer.py
+++ b/letta_evals/visualization/rich_renderer.py
@@ -392,7 +392,7 @@ class RichProgressRenderer:
             else:
                 details = ""
 
-            sample_num = str(sample.sample_id + 1)
+            sample_num = str(sample.sample_id)
             if sample.from_cache:
                 sample_num = f"{sample_num} ♻"
 

--- a/letta_evals/visualization/summary.py
+++ b/letta_evals/visualization/summary.py
@@ -139,7 +139,7 @@ def build_simple_sample_results_table(config: Dict[str, Any], displayed_results:
                 cells.append(f"{score:.2f}" if score is not None else "-")
 
         table.add_row(
-            f"Sample {sample_result.sample.id + 1}",
+            f"Sample {sample_result.sample.id}",
             sample_result.agent_id or "-",
             sample_result.model_name or "-",
             *cells,
@@ -174,7 +174,7 @@ def build_rich_sample_results_table(config: Dict[str, Any], displayed_results: l
                 cells.extend([f"{score:.2f}" if score is not None else "-", rationale])
 
         table.add_row(
-            f"Sample {sample_result.sample.id + 1}",
+            f"Sample {sample_result.sample.id}",
             sample_result.agent_id or "-",
             sample_result.model_name or "-",
             *cells,


### PR DESCRIPTION
## Summary
- **Remove duplicate error logging**: Errors from target failures were logged up to 3 times (target internal log, target retry handler, runner catch). Removed the target-level logs since the runner already logs with the most context (sample ID, agent ID, model name).
- **Use raw 0-indexed sample IDs everywhere**: Some places added `+1` for display while others didn't, causing mismatches in logs (e.g., target saying "sample 18" vs runner saying "sample 19"). Now all logs and UI consistently use the raw dataset ID, which directly corresponds to the line index in the JSONL/CSV file.

## Test plan
- [ ] Run an eval suite and verify errors are logged exactly once per failure
- [ ] Verify sample IDs in logs match line numbers in the dataset file
- [ ] Check rich progress UI and summary tables show consistent sample IDs

🤖 Generated with [Letta Code](https://letta.com)