### PR TITLE
feat(letta-code-target): Add per-sample env override hook via sample.extra_vars["env"]

### DIFF
--- a/letta_evals/targets/letta_code_target.py
+++ b/letta_evals/targets/letta_code_target.py
@@ -57,6 +57,10 @@ class LettaCodeTarget(AbstractAgentTarget):
                 rules (e.g., "--memfs --context-window 8000").
             permission_mode: Permission mode for letta code (e.g., "memory" to scope
                 writes to memory roots). When "memory", sets MEMORY_DIR env var.
+
+        Agent factories may set ``sample.extra_vars["env"]`` (dict) to inject
+        per-sample env vars into the subprocess; user keys win over target-managed
+        ones. See ``_build_subprocess_env``.
         """
         self.client = client
         self.model_handle = model_handle
@@ -78,6 +82,42 @@ class LettaCodeTarget(AbstractAgentTarget):
         else:
             self.working_dir = wd_base
         self.working_dir.mkdir(parents=True, exist_ok=True)
+
+    def _build_subprocess_env(self, sample: Sample, agent_id: Optional[str]) -> dict[str, str]:
+        """Build subprocess env: os.environ -> target-managed -> sample.extra_vars["env"]."""
+        env = os.environ.copy()
+
+        if self.base_url:
+            env["LETTA_BASE_URL"] = self.base_url
+            logger.info(f"Setting LETTA_BASE_URL={self.base_url} for letta CLI")
+
+        if self.permission_mode == "memory" and agent_id:
+            memory_dir = Path.home() / ".letta" / "agents" / agent_id / "memory"
+            memory_dir.mkdir(parents=True, exist_ok=True)
+            env["MEMORY_DIR"] = str(memory_dir)
+
+        sample_env = (sample.extra_vars or {}).get("env")
+        if sample_env is not None:
+            if not isinstance(sample_env, dict):
+                raise TargetError(
+                    f"sample.extra_vars['env'] must be a dict, got {type(sample_env).__name__} for sample {sample.id}",
+                    agent_id=agent_id,
+                )
+            applied = []
+            for k, v in sample_env.items():
+                if not isinstance(k, str):
+                    raise TargetError(
+                        f"sample.extra_vars['env'] keys must be strings, got "
+                        f"{type(k).__name__} ({k!r}) for sample {sample.id}",
+                        agent_id=agent_id,
+                    )
+                # Coerce to str — env values must be strings; None becomes empty.
+                env[k] = "" if v is None else str(v)
+                applied.append(k)
+            if applied:
+                logger.info(f"Applied per-sample env overrides for sample {sample.id}: keys={sorted(applied)}")
+
+        return env
 
     async def run(
         self,
@@ -154,24 +194,19 @@ class LettaCodeTarget(AbstractAgentTarget):
                     f"Running letta command for sample {sample.id} (prompt via stdin, {len(prompt_bytes)} bytes)"
                 )
 
-                # Prepare environment variables for the subprocess
-                # Pass base_url to letta CLI if specified
-                env = os.environ.copy()
-                if self.base_url:
-                    env["LETTA_BASE_URL"] = self.base_url
-                    logger.info(f"Setting LETTA_BASE_URL={self.base_url} for letta CLI")
+                # Prepare environment variables for the subprocess.
+                # Layers target-managed env (LETTA_BASE_URL, MEMORY_DIR) and per-sample
+                # overrides from sample.extra_vars["env"] (see class docstring).
+                env = self._build_subprocess_env(sample, factory_agent_id)
 
                 agent_id = factory_agent_id
                 events = []
                 stderr_chunks = []
 
-                # When using memory permission mode, set MEMORY_DIR and cwd to the
-                # agent's memory root so relative file paths resolve correctly.
+                # When using memory permission mode, also cd into the agent's
+                # memory root so relative file paths resolve correctly.
                 if self.permission_mode == "memory" and factory_agent_id:
-                    memory_dir = Path.home() / ".letta" / "agents" / factory_agent_id / "memory"
-                    memory_dir.mkdir(parents=True, exist_ok=True)
-                    env["MEMORY_DIR"] = str(memory_dir)
-                    run_cwd = str(memory_dir)
+                    run_cwd = str(Path.home() / ".letta" / "agents" / factory_agent_id / "memory")
                 else:
                     run_cwd = str(self.working_dir)
 

--- a/tests/test_letta_code_target_env_overrides.py
+++ b/tests/test_letta_code_target_env_overrides.py
@@ -1,0 +1,189 @@
+"""Unit tests for LettaCodeTarget._build_subprocess_env per-sample env overrides."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from letta_evals.models import Sample
+from letta_evals.targets.base import TargetError
+from letta_evals.targets.letta_code_target import LettaCodeTarget
+
+
+def _make_target(tmp_path, **overrides) -> LettaCodeTarget:
+    """Build a LettaCodeTarget with a sandboxed working_dir and a stub client."""
+    kwargs = dict(
+        client=None,  # _build_subprocess_env never touches the client
+        model_handle="anthropic/claude-sonnet-4-5-20250929",
+        working_dir=tmp_path,
+        sandbox=False,
+    )
+    kwargs.update(overrides)
+    return LettaCodeTarget(**kwargs)
+
+
+def _make_sample(extra_vars=None, sample_id: int = 0) -> Sample:
+    return Sample(id=sample_id, input="hello", extra_vars=extra_vars)
+
+
+def test_build_env_inherits_os_environ_when_no_overrides(tmp_path, monkeypatch):
+    monkeypatch.setenv("EXISTING_VAR", "from-os")
+    # Make sure target-managed vars are not present in os.environ for this test
+    monkeypatch.delenv("LETTA_BASE_URL", raising=False)
+    monkeypatch.delenv("MEMORY_DIR", raising=False)
+
+    target = _make_target(tmp_path)
+    sample = _make_sample()
+
+    env = target._build_subprocess_env(sample, agent_id=None)
+
+    assert env["EXISTING_VAR"] == "from-os"
+    assert "LETTA_BASE_URL" not in env  # no base_url configured
+    assert "MEMORY_DIR" not in env  # no memory permission mode
+
+
+def test_build_env_sets_base_url_when_configured(tmp_path):
+    target = _make_target(tmp_path, base_url="https://api.example.com")
+    sample = _make_sample()
+
+    env = target._build_subprocess_env(sample, agent_id=None)
+
+    assert env["LETTA_BASE_URL"] == "https://api.example.com"
+
+
+def test_build_env_sets_memory_dir_in_memory_permission_mode(tmp_path, monkeypatch):
+    # Redirect HOME so the test doesn't pollute the real ~/.letta
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    target = _make_target(tmp_path, permission_mode="memory")
+    sample = _make_sample()
+
+    env = target._build_subprocess_env(sample, agent_id="agent-abc")
+
+    expected = str(Path(tmp_path) / ".letta" / "agents" / "agent-abc" / "memory")
+    assert env["MEMORY_DIR"] == expected
+    # mkdir(parents=True, exist_ok=True) should have created it
+    assert Path(expected).is_dir()
+
+
+def test_build_env_skips_memory_dir_without_agent_id(tmp_path, monkeypatch):
+    monkeypatch.delenv("MEMORY_DIR", raising=False)
+
+    target = _make_target(tmp_path, permission_mode="memory")
+    sample = _make_sample()
+
+    env = target._build_subprocess_env(sample, agent_id=None)
+
+    assert "MEMORY_DIR" not in env
+
+
+def test_build_env_applies_per_sample_overrides(tmp_path):
+    target = _make_target(tmp_path)
+    sample = _make_sample(extra_vars={"env": {"LETTA_PARENT_AGENT_ID": "agent-parent-123", "FOO": "bar"}})
+
+    env = target._build_subprocess_env(sample, agent_id="agent-child")
+
+    assert env["LETTA_PARENT_AGENT_ID"] == "agent-parent-123"
+    assert env["FOO"] == "bar"
+
+
+def test_build_env_per_sample_overrides_win_over_target_managed(tmp_path):
+    target = _make_target(tmp_path, base_url="https://api.example.com")
+    sample = _make_sample(extra_vars={"env": {"LETTA_BASE_URL": "https://override.example.com"}})
+
+    env = target._build_subprocess_env(sample, agent_id=None)
+
+    assert env["LETTA_BASE_URL"] == "https://override.example.com"
+
+
+def test_build_env_per_sample_overrides_win_over_os_environ(tmp_path, monkeypatch):
+    monkeypatch.setenv("MY_VAR", "from-os")
+
+    target = _make_target(tmp_path)
+    sample = _make_sample(extra_vars={"env": {"MY_VAR": "from-sample"}})
+
+    env = target._build_subprocess_env(sample, agent_id=None)
+
+    assert env["MY_VAR"] == "from-sample"
+
+
+def test_build_env_coerces_non_string_values_to_str(tmp_path):
+    target = _make_target(tmp_path)
+    sample = _make_sample(extra_vars={"env": {"INT_VAR": 42, "FLOAT_VAR": 3.14, "BOOL_VAR": True}})
+
+    env = target._build_subprocess_env(sample, agent_id=None)
+
+    assert env["INT_VAR"] == "42"
+    assert env["FLOAT_VAR"] == "3.14"
+    assert env["BOOL_VAR"] == "True"
+
+
+def test_build_env_none_value_becomes_empty_string(tmp_path):
+    target = _make_target(tmp_path)
+    sample = _make_sample(extra_vars={"env": {"NULL_VAR": None}})
+
+    env = target._build_subprocess_env(sample, agent_id=None)
+
+    assert env["NULL_VAR"] == ""
+
+
+def test_build_env_empty_extra_vars_is_noop(tmp_path):
+    target = _make_target(tmp_path)
+    sample = _make_sample(extra_vars={})
+
+    env = target._build_subprocess_env(sample, agent_id=None)
+
+    # No crash; env still inherits os.environ
+    assert isinstance(env, dict)
+
+
+def test_build_env_empty_env_dict_is_noop(tmp_path):
+    target = _make_target(tmp_path)
+    sample = _make_sample(extra_vars={"env": {}})
+
+    env = target._build_subprocess_env(sample, agent_id=None)
+
+    # No crash; nothing added
+    assert isinstance(env, dict)
+
+
+def test_build_env_other_extra_vars_keys_ignored(tmp_path):
+    """Keys other than 'env' in extra_vars must not affect the subprocess env."""
+    target = _make_target(tmp_path)
+    sample = _make_sample(extra_vars={"rubric_var_x": "irrelevant", "env": {"REAL_VAR": "real"}})
+
+    env = target._build_subprocess_env(sample, agent_id=None)
+
+    assert env["REAL_VAR"] == "real"
+    assert "rubric_var_x" not in env
+
+
+def test_build_env_rejects_non_dict_env(tmp_path):
+    target = _make_target(tmp_path)
+    sample = _make_sample(extra_vars={"env": "FOO=bar"})  # str, not dict
+
+    with pytest.raises(TargetError) as exc_info:
+        target._build_subprocess_env(sample, agent_id="agent-x")
+
+    assert "must be a dict" in str(exc_info.value)
+    assert exc_info.value.agent_id == "agent-x"
+
+
+def test_build_env_rejects_non_string_keys(tmp_path):
+    target = _make_target(tmp_path)
+    sample = _make_sample(extra_vars={"env": {42: "value"}})  # type: ignore[dict-item]
+
+    with pytest.raises(TargetError) as exc_info:
+        target._build_subprocess_env(sample, agent_id=None)
+
+    assert "keys must be strings" in str(exc_info.value)
+
+
+def test_build_env_does_not_mutate_os_environ(tmp_path):
+    target = _make_target(tmp_path)
+    sample = _make_sample(extra_vars={"env": {"NEW_TEST_VAR": "x"}})
+
+    target._build_subprocess_env(sample, agent_id=None)
+
+    # The injected key must NOT have leaked into the process's actual environment.
+    assert "NEW_TEST_VAR" not in os.environ


### PR DESCRIPTION
## Summary

Adds a generic per-sample environment-variable override hook to `LettaCodeTarget`. Agent factories can populate `sample.extra_vars["env"]` with a `dict[str, Any]` and those vars get injected into the letta subprocess for that sample only — race-free under `--max-concurrent > 1`.

Mutating `os.environ` from an `@agent_factory` is unsafe because the target snapshots `os.environ` after the factory yields, so two concurrent samples can clobber each other's values. Per-sample data flow via `sample.extra_vars` avoids that race entirely.

## Design

`LettaCodeTarget._build_subprocess_env(sample, agent_id)` composes the env in three explicit layers (later wins on collision):

1. `os.environ.copy()` — inherited base
2. Target-managed: `LETTA_BASE_URL` (when configured), `MEMORY_DIR` (when `permission_mode == "memory"` and `agent_id` is available)
3. Per-sample overrides from `sample.extra_vars["env"]`

Validation rejects non-dict `env` and non-string keys (raises `TargetError` carrying `agent_id` for diagnosability). Values are coerced to `str()` (`None` → `""`). Applied keys are logged at INFO; values are not (they may be sensitive).

## Test plan

- [x] 15 new unit tests in `tests/test_letta_code_target_env_overrides.py`:
  - inheritance from `os.environ`
  - target-managed `LETTA_BASE_URL` / `MEMORY_DIR` layering (and the no-`agent_id` skip)
  - per-sample overrides applied and winning over both target-managed and `os.environ`
  - coercion of `int` / `float` / `bool` / `None`
  - empty `extra_vars` and empty `env` dict are no-ops
  - other `extra_vars` keys are ignored
  - rejects non-dict `env` and non-string keys with `TargetError`
  - does not mutate `os.environ` (key isolation)
- [x] `uv run pytest tests/ --ignore=tests/test_examples_e2e_live.py` — 183 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format` applied

## Backward compatibility

Pure addition. Existing evals are unaffected because the new code path is gated on `sample.extra_vars["env"]` being present. The `LettaCodeTarget` constructor signature is unchanged.

👾 Generated with [Letta Code](https://letta.com)