### PR TITLE
fix(letta-code-target): Remove model-specific system prompt branch and require model_handle

### DIFF
--- a/letta_evals/targets/letta_code_target.py
+++ b/letta_evals/targets/letta_code_target.py
@@ -23,7 +23,7 @@ class LettaCodeTarget(AbstractAgentTarget):
     def __init__(
         self,
         client: AsyncLetta,
-        model_handle: str = "anthropic/claude-sonnet-4-5-20250929",
+        model_handle: str,
         working_dir: Optional[Path] = None,
         sandbox: bool = True,
         allowed_tools: Optional[list[str]] = None,
@@ -172,10 +172,6 @@ class LettaCodeTarget(AbstractAgentTarget):
                     cmd.extend(["--agent", factory_agent_id])
                 else:
                     cmd.append("--new-agent")
-
-                # Use codex system prompt for GPT-style models (matches `letta --help` examples)
-                if "gpt" in self.model_handle:
-                    cmd.extend(["--system", "codex"])
 
                 # append any extra flags from suite config
                 if self.flags:


### PR DESCRIPTION
## Summary
- Remove the implicit `if "gpt" in model_handle: --system codex` branch in `LettaCodeTarget` so letta-code uses its default system prompt regardless of the model under evaluation.
- Make `model_handle` a required parameter on `LettaCodeTarget.__init__` (drops the hardcoded `"anthropic/claude-sonnet-4-5-20250929"` default). Both call sites — `runner.py` (which already raises `ValueError` if the handle is missing) and `tests/test_letta_code_target_env_overrides.py` — pass it explicitly, so this is a no-op at the call sites and removes a misleading fallback.

## Test plan
- [ ] `uv run pytest tests/test_letta_code_target_env_overrides.py`
- [ ] Run a letta-code suite end-to-end against a GPT model and confirm the default system prompt is used (no `--system codex` in the constructed CLI command).
- [ ] Run a letta-code suite against a non-GPT model and confirm behavior is unchanged.

👾 Generated with [Letta Code](https://letta.com)