### PR TITLE
feat(runner): Surface token_data + agent_state on SampleResult

### DIFF
--- a/letta_evals/models.py
+++ b/letta_evals/models.py
@@ -715,6 +715,22 @@ class SampleResult(BaseModel):
     )
     per_grader_time: Optional[Dict[str, float]] = Field(default=None, description="Wall time in seconds per grader key")
     error: Optional[ErrorInfo] = Field(default=None, description="Structured error info if this sample failed")
+    agent_state: Optional[AgentState] = Field(
+        default=None,
+        description=(
+            "Agent state after running the target (includes memory blocks). "
+            "Only populated when at least one grader requires agent_state. "
+            "Lets callers avoid re-fetching state via a separate "
+            "client.agents.retrieve(...) call."
+        ),
+    )
+    token_data: Optional[List[TurnTokenData]] = Field(
+        default=None,
+        description=(
+            "Per-token IDs and logprobs across all turns in the trajectory. "
+            "Only populated when run_sample(return_token_data=True) is called."
+        ),
+    )
 
 
 class RunnerResult(BaseModel):

--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -330,11 +330,28 @@ class Runner:
         return cache
 
     async def _get_or_run_trajectory(
-        self, sample: Sample, llm_config: Optional[LlmConfig | str], retrieve_agent_state: bool = False
-    ) -> tuple[List[List[LettaMessageUnion]], str, str, Optional[list[dict]], Optional[AgentState]]:
-        """Return (trajectory, agent_id, model_name, agent_usage, agent_state) using cache or by running the target.
+        self,
+        sample: Sample,
+        llm_config: Optional[LlmConfig | str],
+        retrieve_agent_state: bool = False,
+        return_token_data: bool = False,
+    ) -> tuple[
+        List[List[LettaMessageUnion]],
+        str,
+        str,
+        Optional[list[dict]],
+        Optional[AgentState],
+        Optional[list],
+    ]:
+        """Return (trajectory, agent_id, model_name, agent_usage, agent_state, token_data) using cache or by running the target.
 
         If cache is enabled and contains an exact match, use it; otherwise run the target.
+
+        Args:
+            return_token_data: If True, also requests per-token IDs and logprobs from
+                the target. Used by callers that need generation, grading, and
+                token extraction in a single pass. Cached results never include
+                token_data (they don't carry it).
         """
         sample_id = sample.id
         model_name = _extract_model_name(llm_config)
@@ -362,6 +379,7 @@ class Runner:
                     model_name,
                     getattr(cached_result, "agent_usage", None),
                     getattr(cached_result, "agent_state", None),
+                    getattr(cached_result, "token_data", None),
                 )
 
         target = self._create_target(llm_config)
@@ -370,6 +388,7 @@ class Runner:
             progress_callback=self.progress_callback,
             project_id=self.project_id,
             retrieve_agent_state=retrieve_agent_state,
+            return_token_data=return_token_data,
         )
         return (
             target_result.trajectory,
@@ -377,6 +396,7 @@ class Runner:
             target_result.model_name,
             target_result.agent_usage,
             target_result.agent_state,
+            target_result.token_data,
         )
 
     async def _grade_per_turn(
@@ -533,8 +553,20 @@ class Runner:
 
         return None
 
-    async def run_sample(self, sample: Sample, llm_config: Optional[LlmConfig | str] = None) -> SampleResult:
-        """Run a single sample through target and grader."""
+    async def run_sample(
+        self,
+        sample: Sample,
+        llm_config: Optional[LlmConfig | str] = None,
+        return_token_data: bool = False,
+    ) -> SampleResult:
+        """Run a single sample through target and grader.
+
+        Args:
+            return_token_data: If True, requests per-token IDs and logprobs from
+                the target and includes them on the returned ``SampleResult.token_data``.
+                Default False; existing callers that don't pass it see no
+                behavior change.
+        """
         sample_id = sample.id
         model_name = _extract_model_name(llm_config)
 
@@ -550,8 +582,18 @@ class Runner:
                 # check if any grader needs agent_state
                 phase = ErrorCategory.TARGET
                 retrieve_agent_state = self._requires_agent_state()
-                trajectory, agent_id, model_name, agent_usage, agent_state = await self._get_or_run_trajectory(
-                    sample, llm_config, retrieve_agent_state=retrieve_agent_state
+                (
+                    trajectory,
+                    agent_id,
+                    model_name,
+                    agent_usage,
+                    agent_state,
+                    token_data,
+                ) = await self._get_or_run_trajectory(
+                    sample,
+                    llm_config,
+                    retrieve_agent_state=retrieve_agent_state,
+                    return_token_data=return_token_data,
                 )
 
                 cost = calculate_cost_from_agent_usage(model_name, agent_usage) if model_name else None
@@ -625,6 +667,8 @@ class Runner:
                     extraction_time=extraction_time if extraction_time > 0 else None,
                     per_grader_time=per_grader_time if per_grader_time else None,
                     error=error_info,
+                    agent_state=agent_state,
+                    token_data=token_data,
                 )
             except Exception as e:
                 # Recover agent_id from TargetError if the target created an agent before failing

--- a/tests/test_runner_token_data.py
+++ b/tests/test_runner_token_data.py
@@ -1,0 +1,346 @@
+"""Tests for ``Runner.run_sample(return_token_data=True)`` and the
+``SampleResult.{token_data, agent_state}`` plumbing.
+
+Three contracts:
+
+  T0.1: ``Runner.run_sample(return_token_data=True)`` propagates the flag to
+        the target and surfaces the resulting token data on
+        ``SampleResult.token_data``.
+  T0.2: When at least one grader's extractor needs ``agent_state``,
+        ``Runner.run_sample`` retrieves it from the target and surfaces it on
+        ``SampleResult.agent_state`` so callers do not have to re-fetch it.
+  T0.3: ``SampleResult`` validates with the new optional ``token_data`` and
+        ``agent_state`` fields — both as ``None`` (default) and as fully
+        populated objects.
+
+These tests bypass ``Runner.__init__`` (which builds an AsyncLetta client and
+loads model configs from disk) and inject only the attributes
+``run_sample`` actually reads. The goal is to lock down the wire-up between
+``Runner`` and the new fields, not to re-test target/grader internals.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+from unittest.mock import AsyncMock, MagicMock
+
+import anyio
+import pytest
+
+from letta_evals.graders.base import Grader
+from letta_evals.models import (
+    AgentState,
+    GradeResult,
+    LettaMessageUnion,
+    Sample,
+    SampleResult,
+    TargetResult,
+    TurnTokenData,
+)
+from letta_evals.runner import Runner
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class _FakeGrader(Grader):
+    """Minimal Grader that records calls and returns a fixed score.
+
+    ``requires_agent_state`` is a property on ``Grader``; we override it via
+    instance dict so the parent's property short-circuits in our favour.
+    """
+
+    def __init__(self, *, requires_agent_state: bool = False, score: float = 1.0):
+        self._requires_agent_state = requires_agent_state
+        self._score = score
+        self.last_agent_state: Optional[AgentState] = None
+        self.call_count = 0
+
+    @property
+    def requires_agent_state(self) -> bool:  # type: ignore[override]
+        return self._requires_agent_state
+
+    async def grade(
+        self,
+        sample: Sample,
+        trajectory: List[List[LettaMessageUnion]],
+        agent_state: Optional[AgentState] = None,
+    ) -> Tuple[GradeResult, str]:
+        self.call_count += 1
+        self.last_agent_state = agent_state
+        return GradeResult(score=self._score, rationale="fake"), "submission"
+
+
+def _make_agent_state() -> AgentState:
+    """Build a minimal AgentState — only the id is exercised by these tests."""
+    # AgentState is re-exported from letta_evals.models. Use the constructor
+    # path that requires the fewest mandatory fields by mocking it: the test
+    # only checks identity, never field values.
+    return MagicMock(spec=AgentState, id="agent-fake-1")
+
+
+def _make_target_result(
+    *,
+    agent_state: Optional[AgentState] = None,
+    token_data: Optional[List[TurnTokenData]] = None,
+) -> TargetResult:
+    """Build a TargetResult with an empty trajectory.
+
+    SampleResult/TargetResult only accept ``LettaMessageUnion`` instances
+    in trajectory — building a real one drags in the Letta SDK. The fake
+    grader in this file does not inspect trajectory contents, and
+    ``_detect_errors`` only flags empty trajectories when score is 0.0,
+    so we use an empty turn list and ensure the fake grader returns a
+    non-zero score.
+    """
+    return TargetResult(
+        trajectory=[[]],
+        agent_id="agent-fake-1",
+        model_name="fake/model",
+        agent_usage=None,
+        agent_state=agent_state,
+        run_ids=None,
+        token_data=token_data,
+    )
+
+
+def _make_runner(grader: _FakeGrader, target: MagicMock) -> Runner:
+    """Construct a Runner with only the attributes ``run_sample`` reads.
+
+    Skips __init__ (which would build an AsyncLetta client + load model
+    configs from disk) by going through ``Runner.__new__``.
+    """
+    runner = Runner.__new__(Runner)
+    runner.suite = MagicMock()
+    runner.suite.cleanup = False  # _should_cleanup_agent → False, no client.delete
+    runner.suite.target = MagicMock()
+    runner.suite.target.kind = MagicMock()
+    runner.client = MagicMock()
+    runner.graders = {"acc": grader}
+    runner.results = []
+    runner.max_concurrent = 1
+    runner.semaphore = anyio.Semaphore(1)
+    runner.progress_callback = None
+    runner.model_configs = [None]
+    runner.cached_results = None
+    runner._cached_trajectories = {}
+    runner.stream_writer = None
+    runner.output_path = None
+    runner.project_id = None
+
+    # Patch _create_target so _get_or_run_trajectory returns our canned target.
+    runner._create_target = lambda llm_config=None: target  # type: ignore[method-assign]
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# T0.3 — SampleResult schema accepts both new fields
+# ---------------------------------------------------------------------------
+
+
+def test_t0_3_sample_result_validates_with_new_fields_none():
+    """T0.3a: callers that don't pass these fields → both are None."""
+    sample = Sample(id=0, input="hi")
+    result = SampleResult(
+        sample=sample,
+        submission="x",
+        trajectory=[[]],
+        grade=GradeResult(score=1.0),
+        model_name="m",
+    )
+    assert result.token_data is None
+    assert result.agent_state is None
+
+
+def test_t0_3_sample_result_validates_with_token_data_populated():
+    """T0.3b: callers passing populated token_data → schema accepts it."""
+    sample = Sample(id=0, input="hi")
+    token_data = [
+        TurnTokenData(
+            role="assistant_message",
+            content="hello",
+            output_ids=[1, 2, 3],
+            output_token_logprobs=[(-0.1,), (-0.2,), (-0.3,)],
+        )
+    ]
+    result = SampleResult(
+        sample=sample,
+        submission="x",
+        trajectory=[[]],
+        grade=GradeResult(score=1.0),
+        model_name="m",
+        token_data=token_data,
+    )
+    assert result.token_data == token_data
+    assert result.token_data[0].output_ids == [1, 2, 3]
+
+
+def test_t0_3_sample_result_round_trips_through_pydantic():
+    """T0.3c: the new fields survive model_dump → model_validate.
+
+    Anyone caching SampleResults (e.g. for re-grading) needs both fields
+    to round-trip cleanly. agent_state is intentionally omitted here because
+    it's a complex Letta SDK type whose serialization is its own concern;
+    token_data is the new addition this PR introduces.
+    """
+    sample = Sample(id=0, input="hi")
+    original = SampleResult(
+        sample=sample,
+        submission="x",
+        trajectory=[[]],
+        grade=GradeResult(score=1.0),
+        model_name="m",
+        token_data=[TurnTokenData(role="tool_call_message", content="t", output_ids=[9, 10])],
+    )
+    dumped = original.model_dump()
+    revived = SampleResult.model_validate(dumped)
+    assert revived.token_data is not None
+    assert revived.token_data[0].output_ids == [9, 10]
+
+
+# ---------------------------------------------------------------------------
+# T0.1 — return_token_data plumbing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t0_1_return_token_data_flag_propagates_to_target():
+    """run_sample(return_token_data=True) calls target.run with the flag."""
+    grader = _FakeGrader(requires_agent_state=False)
+    target = MagicMock()
+    target.run = AsyncMock(return_value=_make_target_result(token_data=None))
+
+    runner = _make_runner(grader, target)
+    sample = Sample(id=0, input="hi", ground_truth="ok")
+
+    await runner.run_sample(sample, llm_config=None, return_token_data=True)
+
+    target.run.assert_awaited_once()
+    kwargs = target.run.await_args.kwargs
+    assert kwargs.get("return_token_data") is True, (
+        "T0.1: Runner.run_sample must propagate return_token_data to the target."
+    )
+
+
+@pytest.mark.asyncio
+async def test_t0_1_token_data_surfaces_on_sample_result():
+    """When the target returns token_data, it appears on SampleResult.token_data."""
+    grader = _FakeGrader(requires_agent_state=False)
+    token_data = [
+        TurnTokenData(
+            role="assistant_message",
+            content="hello",
+            output_ids=[100, 101, 102],
+            output_token_logprobs=[(-0.1,)] * 3,
+        ),
+    ]
+    target = MagicMock()
+    target.run = AsyncMock(return_value=_make_target_result(token_data=token_data))
+
+    runner = _make_runner(grader, target)
+    sample = Sample(id=0, input="hi", ground_truth="ok")
+
+    result = await runner.run_sample(sample, llm_config=None, return_token_data=True)
+
+    assert result.token_data == token_data, (
+        "T0.1: SampleResult.token_data must equal the list returned by the target. "
+        "Pydantic re-validates the list during model construction so identity is "
+        "not preserved, but value-equality must hold exactly."
+    )
+    assert result.token_data[0].output_ids == [100, 101, 102]
+
+
+@pytest.mark.asyncio
+async def test_t0_1_default_keeps_token_data_none():
+    """Default eval-mode call (return_token_data not passed) → field stays None.
+
+    This is the back-compat guarantee: existing eval callers don't get a
+    surprise field populated, and they don't pay the token-fetch cost.
+    """
+    grader = _FakeGrader(requires_agent_state=False)
+    target = MagicMock()
+    target.run = AsyncMock(return_value=_make_target_result(token_data=None))
+
+    runner = _make_runner(grader, target)
+    sample = Sample(id=0, input="hi", ground_truth="ok")
+
+    result = await runner.run_sample(sample, llm_config=None)
+
+    assert target.run.await_args.kwargs.get("return_token_data") is False
+    assert result.token_data is None
+
+
+# ---------------------------------------------------------------------------
+# T0.2 — agent_state plumbing (gated by graders)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_t0_2_agent_state_requested_when_grader_needs_it():
+    """Grader with requires_agent_state=True → target.run gets retrieve_agent_state=True."""
+    grader = _FakeGrader(requires_agent_state=True)
+    agent_state = _make_agent_state()
+    target = MagicMock()
+    target.run = AsyncMock(return_value=_make_target_result(agent_state=agent_state))
+
+    runner = _make_runner(grader, target)
+    sample = Sample(id=0, input="hi", ground_truth="ok")
+
+    result = await runner.run_sample(sample, llm_config=None)
+
+    target.run.assert_awaited_once()
+    kwargs = target.run.await_args.kwargs
+    assert kwargs.get("retrieve_agent_state") is True, "T0.2: Runner must request agent_state when any grader needs it."
+    # And it surfaces on SampleResult so callers don't re-fetch it.
+    assert result.agent_state is agent_state
+    # Also: the grader actually received the agent_state in its grade() call.
+    assert grader.last_agent_state is agent_state
+
+
+@pytest.mark.asyncio
+async def test_t0_2_agent_state_skipped_when_no_grader_needs_it():
+    """Grader with requires_agent_state=False → target.run gets retrieve_agent_state=False.
+
+    This is the perf-sensitive default: no grader needs agent_state →
+    skip the extra Letta server round-trip the eval would otherwise pay.
+    """
+    grader = _FakeGrader(requires_agent_state=False)
+    target = MagicMock()
+    target.run = AsyncMock(return_value=_make_target_result(agent_state=None))
+
+    runner = _make_runner(grader, target)
+    sample = Sample(id=0, input="hi", ground_truth="ok")
+
+    result = await runner.run_sample(sample, llm_config=None)
+
+    kwargs = target.run.await_args.kwargs
+    assert kwargs.get("retrieve_agent_state") is False
+    assert result.agent_state is None
+
+
+@pytest.mark.asyncio
+async def test_t0_2_agent_state_and_token_data_combine_in_one_call():
+    """Both flags True → one target.run call carrying both.
+
+    The whole point of the plumbing: a single ``run_sample`` call returns
+    trajectory, agent_state, and token_data together, instead of forcing
+    callers to re-fetch state via separate client.agents.* calls.
+    """
+    grader = _FakeGrader(requires_agent_state=True)
+    agent_state = _make_agent_state()
+    token_data = [TurnTokenData(role="assistant_message", output_ids=[1, 2])]
+    target = MagicMock()
+    target.run = AsyncMock(return_value=_make_target_result(agent_state=agent_state, token_data=token_data))
+
+    runner = _make_runner(grader, target)
+    sample = Sample(id=0, input="hi", ground_truth="ok")
+
+    result = await runner.run_sample(sample, llm_config=None, return_token_data=True)
+
+    assert target.run.await_count == 1, "T0.2 + T0.1: combined RL fetch must be a single target.run call."
+    kwargs = target.run.await_args.kwargs
+    assert kwargs.get("retrieve_agent_state") is True
+    assert kwargs.get("return_token_data") is True
+    assert result.agent_state is agent_state  # AgentState is not re-validated
+    assert result.token_data == token_data


### PR DESCRIPTION
## What

Two backwards-compatible additions so callers can get token-level IDs/logprobs and agent state out of `Runner.run_sample` in a single call, instead of doing it via `target.run` directly and then re-fetching trajectory + agent state via separate client calls.

### `Runner.run_sample(return_token_data=True)`

When set, the flag is propagated through `_get_or_run_trajectory` to the underlying target. The resulting per-token IDs and logprobs land on `SampleResult.token_data`. Default is `False`, so existing callers that don't pass the flag see no behavior change.

### `SampleResult.token_data` and `SampleResult.agent_state`

Both are `Optional` with default `None`.
- `agent_state` is populated whenever any grader's extractor needs it (via the existing `_requires_agent_state()` gate).
- `token_data` is populated whenever `return_token_data=True` is passed to `run_sample`.

## Why

Without these, downstream tools that want both grading inputs and token-level data have to either:

1. Call `target.run(return_token_data=True, retrieve_agent_state=True)` directly and skip `Runner` entirely (losing all of Runner's grading orchestration, error handling, and progress reporting).
2. Run `Runner.run_sample` once for grading, then issue separate `client.agents.messages.list()` and `client.agents.retrieve(include=["agent.blocks"])` calls to re-fetch the same data the target already had in memory.

Both options waste server round-trips. Plumbing the existing target-side fields (`TargetResult.token_data`, `TargetResult.agent_state` — already shipped in 0.15.0) through `Runner` and onto `SampleResult` lets a single `run_sample` call return everything.

Use cases on the eval side:
- Parity smokes that compare extractor output across two runs of the same trajectory.
- Offline re-grading scripts that want both submissions and the token data needed to reconstruct what the model produced.

## Tests

Tier 0 tests in `tests/test_runner_token_data.py`:

- **T0.1**: `run_sample(return_token_data=True)` propagates the flag to the target, surfaces `token_data` on `SampleResult.token_data`, and the default keeps it `None`.
- **T0.2**: when at least one grader's extractor needs `agent_state`, Runner requests it from the target, surfaces it on `SampleResult.agent_state`, AND the grader receives the same `agent_state` in its `grade()` call.
- **T0.3**: `SampleResult` validates with both new fields `None`, with `token_data` populated, and round-trips cleanly through `model_dump()` / `model_validate()`.

The tests bypass `Runner.__init__` (which would build an `AsyncLetta` client and load model configs from disk) by going through `Runner.__new__` and injecting only the attributes `run_sample` reads. A `FakeGrader` records `grade()` calls; a stub target with `AsyncMock` on `run()` produces canned `TargetResult`s. This isolates the Runner-level plumbing from target/grader internals.

All 9 tests pass.

## Backward compatibility

- `run_sample` signature: new param has a default → no breaking change.
- `SampleResult` schema: new fields are `Optional` with `None` defaults → existing serialized `SampleResult`s parse fine; new code reading older results sees `None`.
- No changes to target interfaces. The target-side support (`LettaCodeTarget.run` / `LettaAgentTarget.run` accepting `return_token_data` and populating `TargetResult.token_data` + `agent_state`) already shipped in 0.15.0; this PR just lifts those values up to the `Runner` boundary.