### PR TITLE
fix(letta-code-target): Raise asyncio StreamReader limit to 16 MiB

### DIFF
--- a/letta_evals/targets/letta_code_target.py
+++ b/letta_evals/targets/letta_code_target.py
@@ -207,6 +207,14 @@ class LettaCodeTarget(AbstractAgentTarget):
                     run_cwd = str(self.working_dir)
 
                 # run the letta command with prompt piped via stdin
+                #
+                # NOTE: We bump the StreamReader limit well above asyncio's
+                # 64 KiB default. letta-code emits one JSON event per line in
+                # stream-json mode, and a single event (e.g. a Read of a large
+                # file, verbose Bash output, or a base64-encoded image) can
+                # easily exceed 64 KiB. Without this, `async for raw_line in
+                # process.stdout` below raises LimitOverrunError on long-tool-
+                # result turns and crashes the rollout.
                 process = await asyncio.create_subprocess_exec(
                     *cmd,
                     stdin=asyncio.subprocess.PIPE,
@@ -214,6 +222,7 @@ class LettaCodeTarget(AbstractAgentTarget):
                     stderr=asyncio.subprocess.PIPE,
                     cwd=run_cwd,
                     env=env,
+                    limit=16 * 1024 * 1024,
                 )
                 # Write prompt to stdin and close it
                 process.stdin.write(prompt_bytes)


### PR DESCRIPTION
## Summary
- `async for raw_line in process.stdout` in `LettaCodeTarget._read_stdout` uses the default asyncio `StreamReader` limit of **64 KiB**. letta-code emits one JSON event per line in stream-json mode, and a single event (large `Read` result, verbose `Bash` output, base64-encoded image, etc.) routinely exceeds that, causing `LimitOverrunError` and crashing the rollout on long-tool-result turns.
- Pass `limit=16 * 1024 * 1024` through to `asyncio.create_subprocess_exec` so per-line buffer capacity matches realistic stream-json event sizes.
- Added an inline comment so the next person to look at this block knows why the limit is bumped.

## Test plan
- [ ] Smoke-run a leaderboard suite that exercises large `Read`/`Bash` outputs and confirm no `LimitOverrunError`.
- [ ] Spot-check that existing small-event rollouts behave identically (no perf regression — the limit only affects the max line size buffer, not steady-state memory).

👾 Generated with [Letta Code](https://letta.com)