### PR TITLE
refactor(models): Split models.py into focused submodules

### DIFF
--- a/letta_evals/models/__init__.py
+++ b/letta_evals/models/__init__.py
@@ -1,0 +1,112 @@
+"""Pydantic models for letta-evals.
+
+This package re-exports the full public surface so existing imports of the
+form ``from letta_evals.models import X`` continue to work. The models are
+grouped into focused submodules:
+
+- :mod:`letta_evals.models.sample` — :class:`Sample` (dataset input)
+- :mod:`letta_evals.models.specs` — config: target / grader / gate / suite
+  specs plus gate helpers
+- :mod:`letta_evals.models.results` — :data:`LettaMessageUnion`, per-sample
+  result models (:class:`TargetResult`, :class:`GradeResult`,
+  :class:`SampleResult`) and shared primitives (:class:`Usage`,
+  :class:`Timing`/:class:`TimingStats`, :class:`Error`/:class:`ErrorSummary`)
+- :mod:`letta_evals.models.summaries` — aggregate summary models and the
+  in-memory :class:`RunnerResult`/:class:`ModelRun` containers
+"""
+
+from letta_client.types import AgentState
+
+from letta_evals.models.results import (
+    Error,
+    ErrorSummary,
+    GradeResult,
+    LettaMessageUnion,
+    PerTurnGrade,
+    SampleResult,
+    TargetResult,
+    Timing,
+    TimingStats,
+    TurnTokenData,
+    Usage,
+)
+from letta_evals.models.sample import Sample
+from letta_evals.models.specs import (
+    BaseGraderSpec,
+    BaseTargetSpec,
+    GateSpec,
+    GraderSpec,
+    LettaAgentTargetSpec,
+    LettaCodeTargetSpec,
+    LettaJudgeGraderSpec,
+    LogicalGateSpec,
+    ModelJudgeGraderSpec,
+    SimpleCondition,
+    SimpleGateSpec,
+    SuiteSpec,
+    TargetSpec,
+    ToolGraderSpec,
+    WeightedAverageGateSpec,
+    _compare,
+    compute_gate_score,
+    normalize_weights,
+)
+from letta_evals.models.summaries import (
+    ModelRun,
+    ModelSummary,
+    PerRunSummary,
+    RunnerResult,
+    Summary,
+)
+
+__all__ = [
+    # re-exports from letta_client
+    "AgentState",
+    # sample
+    "Sample",
+    # specs — targets
+    "BaseTargetSpec",
+    "LettaAgentTargetSpec",
+    "LettaCodeTargetSpec",
+    "TargetSpec",
+    # specs — graders
+    "BaseGraderSpec",
+    "ToolGraderSpec",
+    "ModelJudgeGraderSpec",
+    "LettaJudgeGraderSpec",
+    "GraderSpec",
+    # specs — gates
+    "SimpleCondition",
+    "SimpleGateSpec",
+    "WeightedAverageGateSpec",
+    "LogicalGateSpec",
+    "GateSpec",
+    # specs — suite
+    "SuiteSpec",
+    # specs — gate helpers
+    "compute_gate_score",
+    "normalize_weights",
+    "_compare",
+    # results — messages
+    "LettaMessageUnion",
+    # results — target / grader output
+    "TurnTokenData",
+    "TargetResult",
+    "PerTurnGrade",
+    "GradeResult",
+    # results — per-sample primitives + aggregate companions
+    "Usage",
+    "Timing",
+    "TimingStats",
+    "Error",
+    "ErrorSummary",
+    # results — per-sample record
+    "SampleResult",
+    # summaries — aggregate
+    "PerRunSummary",
+    "ModelSummary",
+    "Summary",
+    # summaries — in-memory holders
+    "ModelRun",
+    "RunnerResult",
+]

--- a/letta_evals/models/results.py
+++ b/letta_evals/models/results.py
@@ -1,0 +1,215 @@
+"""Per-sample result and primitive models.
+
+Includes the message union type alias used throughout the codebase, the
+target/grader output models (TargetResult, GradeResult, PerTurnGrade), the
+per-sample primitives (Usage, Timing, Error) plus their aggregate companions
+(TimingStats, ErrorSummary — kept here so the per-sample/aggregate pairs stay
+co-located), and the per-sample SampleResult written to <model>.jsonl.
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+from letta_client.types import AgentState, ToolReturnMessage
+from letta_client.types.agents import (
+    ApprovalRequestMessage,
+    ApprovalResponseMessage,
+    AssistantMessage,
+    EventMessage,
+    HiddenReasoningMessage,
+    ReasoningMessage,
+    SummaryMessage,
+    SystemMessage,
+    ToolCallMessage,
+    UserMessage,
+)
+from pydantic import BaseModel, Field, field_validator
+
+from letta_evals.types import ErrorCategory
+
+# Type alias for message union (replaces LettaMessageUnion from v0.x SDK)
+LettaMessageUnion = Union[
+    SystemMessage,
+    UserMessage,
+    ReasoningMessage,
+    HiddenReasoningMessage,
+    ToolCallMessage,
+    ToolReturnMessage,
+    AssistantMessage,
+    ApprovalRequestMessage,
+    ApprovalResponseMessage,
+    SummaryMessage,
+    EventMessage,
+]
+
+
+# Target / Grader result models
+
+
+class TurnTokenData(BaseModel):
+    """Token-level data for a single message in a turn.
+
+    Used by training pipelines (e.g. GRPO) that need per-token IDs and
+    log-probabilities from the generation model.
+    """
+
+    role: str = Field(description="Message role: assistant, tool, tool_call, tool_return, etc.")
+    content: Optional[str] = Field(default=None, description="Text content of this message")
+    output_ids: Optional[List[int]] = Field(
+        default=None, description="Token IDs produced by the model for this message"
+    )
+    output_token_logprobs: Optional[List[Any]] = Field(
+        default=None,
+        description="Per-token log-probabilities. Each entry is either a float or a list whose first element is the logprob.",
+    )
+
+
+class TargetResult(BaseModel):
+    """Result from running a target."""
+
+    trajectory: List[List[LettaMessageUnion]] = Field(
+        description="List of conversation turns, each containing Letta messages"
+    )
+    agent_id: str = Field(description="ID of the agent that generated this trajectory")
+    model_name: str = Field(description="Model configuration name used for this target")
+    agent_usage: Optional[List[dict]] = Field(
+        default=None, description="Usage statistics emitted by the agent during the run"
+    )
+    agent_state: Optional[AgentState] = Field(
+        default=None, description="Agent state after running the target (includes memory blocks)"
+    )
+    run_ids: Optional[List[str]] = Field(
+        default=None, description="Run IDs for each input turn (needed for token-level data fetching in training)"
+    )
+    token_data: Optional[List[TurnTokenData]] = Field(
+        default=None,
+        description=(
+            "Token-level data (IDs + logprobs) for each message across all turns. "
+            "Only populated when return_token_data=True is passed to the target."
+        ),
+    )
+
+
+class PerTurnGrade(BaseModel):
+    """Grade result for a single turn in per-turn evaluation.
+
+    ``ground_truth`` is not stored here — look up ``sample.ground_truth[turn]``
+    using the per-sample ``sample_id``.
+    """
+
+    turn: int = Field(description="Turn index (0-based)")
+    score: float = Field(description="Score for this turn (0.0 to 1.0)")
+    rationale: Optional[str] = Field(default=None, description="Explanation for this turn's grade")
+    submission: str = Field(description="Extracted submission for this turn")
+
+
+class GradeResult(BaseModel):
+    """Grading result for one (sample, grader) pair."""
+
+    score: float = Field(description="Numeric score between 0.0 and 1.0")
+    rationale: Optional[str] = Field(default=None, description="Explanation of the grading decision")
+    metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional grading metadata")
+    per_turn_grades: Optional[List[PerTurnGrade]] = Field(
+        default=None, description="Per-turn grades for multi-turn evaluation (only populated for per-turn evaluations)"
+    )
+
+    @field_validator("score")
+    def validate_score(cls, v: float) -> float:
+        if v < 0.0 or v > 1.0:
+            raise ValueError(f"Score must be between 0.0 and 1.0, got {v}")
+        return v
+
+
+# Usage / Timing / Error primitives — used both per-sample and as aggregates.
+# The aggregate companions (TimingStats, ErrorSummary) live here so each
+# per-sample/aggregate pair stays co-located.
+
+
+class Usage(BaseModel):
+    """Token usage and cost. Used both per-sample and as a summed aggregate."""
+
+    prompt_tokens: int = Field(default=0, description="Prompt tokens used")
+    completion_tokens: int = Field(default=0, description="Completion tokens generated")
+    cached_input_tokens: int = Field(default=0, description="Cached input tokens served from cache")
+    cache_write_tokens: int = Field(default=0, description="Cache write tokens (Anthropic only)")
+    reasoning_tokens: int = Field(default=0, description="Reasoning/thinking tokens generated")
+    cost: Optional[float] = Field(default=None, description="Cost in dollars")
+
+
+class Timing(BaseModel):
+    """Per-sample timing (seconds)."""
+
+    total: float = Field(description="Total wall time for this sample")
+    target: float = Field(description="Wall time for target execution (agent creation + messages)")
+    extraction: Optional[float] = Field(default=None, description="Wall time for extraction across all graders")
+    per_grader: Optional[Dict[str, float]] = Field(default=None, description="Wall time per grader key")
+
+
+class TimingStats(BaseModel):
+    """Aggregate timing statistics across samples (seconds)."""
+
+    mean_total: float = Field(description="Mean total wall time per sample")
+    mean_target: float = Field(description="Mean target execution time per sample")
+    mean_extraction: Optional[float] = Field(default=None, description="Mean extraction time per sample")
+    p50_total: float = Field(description="Median total wall time per sample")
+    p95_total: float = Field(description="95th percentile total wall time per sample")
+    per_grader_mean: Optional[Dict[str, float]] = Field(default=None, description="Mean wall time per grader key")
+
+
+class Error(BaseModel):
+    """Structured error information for a failed sample."""
+
+    category: ErrorCategory = Field(description="Category of the error")
+    exception_type: str = Field(description="Python exception class name")
+    message: str = Field(description="Full error message")
+
+
+class ErrorSummary(BaseModel):
+    """Summary of errors across an evaluation run (or a single model)."""
+
+    total_errors: int = Field(description="Total number of samples that errored")
+    by_category: Dict[str, int] = Field(default_factory=dict, description="Error count by category")
+    by_exception_type: Dict[str, int] = Field(default_factory=dict, description="Error count by exception type")
+
+
+# Per-sample result. Lives in <model>.jsonl or <model>/run_<n>.jsonl.
+#
+# The model that produced this result is implicit in the file path; the
+# Sample object is stored only once at the top level (suite.json), and looked
+# up by ``sample_id``.
+
+
+class SampleResult(BaseModel):
+    """Result for a single sample evaluation."""
+
+    sample_id: int = Field(description="ID of the sample (look up the full Sample in suite.json)")
+    agent_id: Optional[str] = Field(default=None, description="ID of the agent that generated this trajectory")
+    trajectory: List[List[LettaMessageUnion]] = Field(description="Full conversation trajectory from the agent")
+    submissions: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Per-grader extracted submissions (keyed by grader name)",
+    )
+    grades: Dict[str, GradeResult] = Field(
+        default_factory=dict,
+        description="Per-grader grading results (keyed by grader name)",
+    )
+    usage: Optional[Usage] = Field(default=None, description="Token usage and cost for this sample")
+    timing: Timing = Field(description="Wall-clock timing for this sample")
+    error: Optional[Error] = Field(default=None, description="Structured error info if this sample failed")
+    # Optional extras — omitted from serialized output when None.
+    agent_usage: Optional[List[dict]] = Field(
+        default=None, description="Raw usage statistics emitted by the agent during the run"
+    )
+    agent_state: Optional[AgentState] = Field(
+        default=None,
+        description=(
+            "Agent state after running the target (includes memory blocks). "
+            "Only populated when at least one grader requires agent_state."
+        ),
+    )
+    token_data: Optional[List[TurnTokenData]] = Field(
+        default=None,
+        description=(
+            "Per-token IDs and logprobs across all turns in the trajectory. "
+            "Only populated when run_sample(return_token_data=True) is called."
+        ),
+    )

--- a/letta_evals/models/sample.py
+++ b/letta_evals/models/sample.py
@@ -1,0 +1,71 @@
+"""Dataset sample model.
+
+A :class:`Sample` is the unit of evaluation input: an ID, one or more user
+inputs, optional ground truth, and optional grader/extractor variables.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class Sample(BaseModel):
+    """Single evaluation sample."""
+
+    id: int = Field(description="Sample ID (0-based index from dataset)")
+    input: Union[str, List[str]] = Field(description="Input message(s) to send to the agent")
+    ground_truth: Optional[Union[str, List[str]]] = Field(
+        default=None,
+        description="Expected ground_truth response for grading. Can be a list for per-turn evaluation in multi-turn conversations.",
+    )
+    agent_args: Optional[Dict[str, Any]] = Field(default=None, description="Custom arguments for agent creation")
+    rubric_vars: Optional[Dict[str, Any]] = Field(
+        default=None, description="Variables for prompt substitution in rubric graders"
+    )
+    extra_vars: Optional[Dict[str, Any]] = Field(
+        default=None, description="Custom user-supplied variables. Useful when writing custom extractors, graders, etc."
+    )
+    rubric: Optional[str] = Field(
+        default=None,
+        description=(
+            "Per-sample rubric text. When set, overrides the grader-level rubric "
+            "(e.g. ``prompt`` / ``prompt_path``) for this sample. The rubric is "
+            "sent verbatim to the judge after template substitution."
+        ),
+    )
+    rubric_path: Optional[Path] = Field(
+        default=None,
+        description=(
+            "Per-sample rubric file path. Resolved by the dataset loader, which "
+            "reads the file contents into ``rubric``. Only one of ``rubric`` or "
+            "``rubric_path`` may be set per sample."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_ground_truth_format(self):
+        """Validate ground_truth format matches input format."""
+        # Reject str input with list ground_truth (doesn't make sense)
+        if isinstance(self.ground_truth, list) and not isinstance(self.input, list):
+            raise ValueError("ground_truth cannot be a list when input is a string")
+
+        # Ensure lengths match when both are lists
+        if isinstance(self.input, list) and isinstance(self.ground_truth, list):
+            if len(self.input) != len(self.ground_truth):
+                raise ValueError(
+                    f"input has {len(self.input)} items but ground_truth has {len(self.ground_truth)} items. "
+                    f"For per-turn evaluation, each input must have a corresponding ground_truth."
+                )
+
+        return self
+
+    @model_validator(mode="after")
+    def validate_rubric_fields(self):
+        """At most one of rubric / rubric_path may be set."""
+        if self.rubric is not None and self.rubric_path is not None:
+            raise ValueError(
+                "Sample cannot have both 'rubric' and 'rubric_path' set. "
+                "Use one or the other (the loader resolves rubric_path into rubric)."
+            )
+        return self

--- a/letta_evals/models/specs.py
+++ b/letta_evals/models/specs.py
@@ -1,25 +1,19 @@
+"""Configuration specs.
+
+Pydantic models for the suite YAML: target (agent), graders (tool / model
+judge / letta judge), gates (simple / weighted_average / logical), and the
+top-level :class:`SuiteSpec`. Also includes small gate helper functions used
+by metrics computation.
+"""
+
 import shlex
 from pathlib import Path
 from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
-from letta_client.types import AgentState, ToolReturnMessage
-from letta_client.types.agents import (
-    ApprovalRequestMessage,
-    ApprovalResponseMessage,
-    AssistantMessage,
-    EventMessage,
-    HiddenReasoningMessage,
-    ReasoningMessage,
-    SummaryMessage,
-    SystemMessage,
-    ToolCallMessage,
-    UserMessage,
-)
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from letta_evals.types import (
     Aggregation,
-    ErrorCategory,
     GateKind,
     GraderKind,
     LLMProvider,
@@ -28,86 +22,7 @@ from letta_evals.types import (
     TargetKind,
 )
 
-# Type alias for message union (replaces LettaMessageUnion from v0.x SDK)
-LettaMessageUnion = Union[
-    SystemMessage,
-    UserMessage,
-    ReasoningMessage,
-    HiddenReasoningMessage,
-    ToolCallMessage,
-    ToolReturnMessage,
-    AssistantMessage,
-    ApprovalRequestMessage,
-    ApprovalResponseMessage,
-    SummaryMessage,
-    EventMessage,
-]
-
-# Dataset models
-
-
-class Sample(BaseModel):
-    """Single evaluation sample."""
-
-    id: int = Field(description="Sample ID (0-based index from dataset)")
-    input: Union[str, List[str]] = Field(description="Input message(s) to send to the agent")
-    ground_truth: Optional[Union[str, List[str]]] = Field(
-        default=None,
-        description="Expected ground_truth response for grading. Can be a list for per-turn evaluation in multi-turn conversations.",
-    )
-    agent_args: Optional[Dict[str, Any]] = Field(default=None, description="Custom arguments for agent creation")
-    rubric_vars: Optional[Dict[str, Any]] = Field(
-        default=None, description="Variables for prompt substitution in rubric graders"
-    )
-    extra_vars: Optional[Dict[str, Any]] = Field(
-        default=None, description="Custom user-supplied variables. Useful when writing custom extractors, graders, etc."
-    )
-    rubric: Optional[str] = Field(
-        default=None,
-        description=(
-            "Per-sample rubric text. When set, overrides the grader-level rubric "
-            "(e.g. ``prompt`` / ``prompt_path``) for this sample. The rubric is "
-            "sent verbatim to the judge after template substitution."
-        ),
-    )
-    rubric_path: Optional[Path] = Field(
-        default=None,
-        description=(
-            "Per-sample rubric file path. Resolved by the dataset loader, which "
-            "reads the file contents into ``rubric``. Only one of ``rubric`` or "
-            "``rubric_path`` may be set per sample."
-        ),
-    )
-
-    @model_validator(mode="after")
-    def validate_ground_truth_format(self):
-        """Validate ground_truth format matches input format."""
-        # Reject str input with list ground_truth (doesn't make sense)
-        if isinstance(self.ground_truth, list) and not isinstance(self.input, list):
-            raise ValueError("ground_truth cannot be a list when input is a string")
-
-        # Ensure lengths match when both are lists
-        if isinstance(self.input, list) and isinstance(self.ground_truth, list):
-            if len(self.input) != len(self.ground_truth):
-                raise ValueError(
-                    f"input has {len(self.input)} items but ground_truth has {len(self.ground_truth)} items. "
-                    f"For per-turn evaluation, each input must have a corresponding ground_truth."
-                )
-
-        return self
-
-    @model_validator(mode="after")
-    def validate_rubric_fields(self):
-        """At most one of rubric / rubric_path may be set."""
-        if self.rubric is not None and self.rubric_path is not None:
-            raise ValueError(
-                "Sample cannot have both 'rubric' and 'rubric_path' set. "
-                "Use one or the other (the loader resolves rubric_path into rubric)."
-            )
-        return self
-
-
-# Config models
+# Target specs
 
 
 class BaseTargetSpec(BaseModel):
@@ -194,6 +109,9 @@ TargetSpec = Annotated[
     Union[LettaAgentTargetSpec, LettaCodeTargetSpec],
     Field(discriminator="kind"),
 ]
+
+
+# Grader specs
 
 
 class BaseGraderSpec(BaseModel):
@@ -308,7 +226,7 @@ GraderSpec = Annotated[
 ]
 
 
-# gate helper functions
+# Gate helper functions
 
 
 def _compare(a: float, op: MetricOp, b: float) -> bool:
@@ -343,7 +261,6 @@ def compute_gate_score(gate: "GateSpec", scores: Dict[str, float]) -> float:
     """
     if not scores:
         return 0.0
-    # Import locally to avoid circular ref at module level
     if hasattr(gate, "metric_key") and not hasattr(gate, "weights"):
         # SimpleGateSpec
         return scores.get(gate.metric_key, 0.0)
@@ -356,7 +273,7 @@ def compute_gate_score(gate: "GateSpec", scores: Dict[str, float]) -> float:
         return sum(scores.values()) / len(scores)
 
 
-# gate models
+# Gate specs
 
 
 class SimpleCondition(BaseModel):
@@ -430,6 +347,9 @@ GateSpec = Annotated[
     Union[SimpleGateSpec, WeightedAverageGateSpec, LogicalGateSpec],
     Field(discriminator="kind"),
 ]
+
+
+# Suite spec (top-level)
 
 
 class SuiteSpec(BaseModel):
@@ -536,251 +456,3 @@ class SuiteSpec(BaseModel):
             yaml_data["base_dir"] = base_dir
 
         return cls(**yaml_data)
-
-
-# Target/Grader result models
-
-
-class TurnTokenData(BaseModel):
-    """Token-level data for a single message in a turn.
-
-    Used by training pipelines (e.g. GRPO) that need per-token IDs and
-    log-probabilities from the generation model.
-    """
-
-    role: str = Field(description="Message role: assistant, tool, tool_call, tool_return, etc.")
-    content: Optional[str] = Field(default=None, description="Text content of this message")
-    output_ids: Optional[List[int]] = Field(
-        default=None, description="Token IDs produced by the model for this message"
-    )
-    output_token_logprobs: Optional[List[Any]] = Field(
-        default=None,
-        description="Per-token log-probabilities. Each entry is either a float or a list whose first element is the logprob.",
-    )
-
-
-class TargetResult(BaseModel):
-    """Result from running a target."""
-
-    trajectory: List[List[LettaMessageUnion]] = Field(
-        description="List of conversation turns, each containing Letta messages"
-    )
-    agent_id: str = Field(description="ID of the agent that generated this trajectory")
-    model_name: str = Field(description="Model configuration name used for this target")
-    agent_usage: Optional[List[dict]] = Field(
-        default=None, description="Usage statistics emitted by the agent during the run"
-    )
-    agent_state: Optional[AgentState] = Field(
-        default=None, description="Agent state after running the target (includes memory blocks)"
-    )
-    run_ids: Optional[List[str]] = Field(
-        default=None, description="Run IDs for each input turn (needed for token-level data fetching in training)"
-    )
-    token_data: Optional[List[TurnTokenData]] = Field(
-        default=None,
-        description=(
-            "Token-level data (IDs + logprobs) for each message across all turns. "
-            "Only populated when return_token_data=True is passed to the target."
-        ),
-    )
-
-
-class PerTurnGrade(BaseModel):
-    """Grade result for a single turn in per-turn evaluation.
-
-    ``ground_truth`` is not stored here — look up ``sample.ground_truth[turn]``
-    using the per-sample ``sample_id``.
-    """
-
-    turn: int = Field(description="Turn index (0-based)")
-    score: float = Field(description="Score for this turn (0.0 to 1.0)")
-    rationale: Optional[str] = Field(default=None, description="Explanation for this turn's grade")
-    submission: str = Field(description="Extracted submission for this turn")
-
-
-class GradeResult(BaseModel):
-    """Grading result for one (sample, grader) pair."""
-
-    score: float = Field(description="Numeric score between 0.0 and 1.0")
-    rationale: Optional[str] = Field(default=None, description="Explanation of the grading decision")
-    metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional grading metadata")
-    per_turn_grades: Optional[List[PerTurnGrade]] = Field(
-        default=None, description="Per-turn grades for multi-turn evaluation (only populated for per-turn evaluations)"
-    )
-
-    @field_validator("score")
-    def validate_score(cls, v: float) -> float:
-        if v < 0.0 or v > 1.0:
-            raise ValueError(f"Score must be between 0.0 and 1.0, got {v}")
-        return v
-
-
-# Usage / Timing / Error primitives — used both per-sample and as aggregates.
-
-
-class Usage(BaseModel):
-    """Token usage and cost. Used both per-sample and as a summed aggregate."""
-
-    prompt_tokens: int = Field(default=0, description="Prompt tokens used")
-    completion_tokens: int = Field(default=0, description="Completion tokens generated")
-    cached_input_tokens: int = Field(default=0, description="Cached input tokens served from cache")
-    cache_write_tokens: int = Field(default=0, description="Cache write tokens (Anthropic only)")
-    reasoning_tokens: int = Field(default=0, description="Reasoning/thinking tokens generated")
-    cost: Optional[float] = Field(default=None, description="Cost in dollars")
-
-
-class Timing(BaseModel):
-    """Per-sample timing (seconds)."""
-
-    total: float = Field(description="Total wall time for this sample")
-    target: float = Field(description="Wall time for target execution (agent creation + messages)")
-    extraction: Optional[float] = Field(default=None, description="Wall time for extraction across all graders")
-    per_grader: Optional[Dict[str, float]] = Field(default=None, description="Wall time per grader key")
-
-
-class TimingStats(BaseModel):
-    """Aggregate timing statistics across samples (seconds)."""
-
-    mean_total: float = Field(description="Mean total wall time per sample")
-    mean_target: float = Field(description="Mean target execution time per sample")
-    mean_extraction: Optional[float] = Field(default=None, description="Mean extraction time per sample")
-    p50_total: float = Field(description="Median total wall time per sample")
-    p95_total: float = Field(description="95th percentile total wall time per sample")
-    per_grader_mean: Optional[Dict[str, float]] = Field(default=None, description="Mean wall time per grader key")
-
-
-class Error(BaseModel):
-    """Structured error information for a failed sample."""
-
-    category: ErrorCategory = Field(description="Category of the error")
-    exception_type: str = Field(description="Python exception class name")
-    message: str = Field(description="Full error message")
-
-
-class ErrorSummary(BaseModel):
-    """Summary of errors across an evaluation run (or a single model)."""
-
-    total_errors: int = Field(description="Total number of samples that errored")
-    by_category: Dict[str, int] = Field(default_factory=dict, description="Error count by category")
-    by_exception_type: Dict[str, int] = Field(default_factory=dict, description="Error count by exception type")
-
-
-# Per-sample result. Lives in <model>.jsonl or <model>/run_<n>.jsonl.
-#
-# The model that produced this result is implicit in the file path; the
-# Sample object is stored only once at the top level (suite.json), and looked
-# up by ``sample_id``.
-
-
-class SampleResult(BaseModel):
-    """Result for a single sample evaluation."""
-
-    sample_id: int = Field(description="ID of the sample (look up the full Sample in suite.json)")
-    agent_id: Optional[str] = Field(default=None, description="ID of the agent that generated this trajectory")
-    trajectory: List[List[LettaMessageUnion]] = Field(description="Full conversation trajectory from the agent")
-    submissions: Dict[str, str] = Field(
-        default_factory=dict,
-        description="Per-grader extracted submissions (keyed by grader name)",
-    )
-    grades: Dict[str, GradeResult] = Field(
-        default_factory=dict,
-        description="Per-grader grading results (keyed by grader name)",
-    )
-    usage: Optional[Usage] = Field(default=None, description="Token usage and cost for this sample")
-    timing: Timing = Field(description="Wall-clock timing for this sample")
-    error: Optional[Error] = Field(default=None, description="Structured error info if this sample failed")
-    # Optional extras — omitted from serialized output when None.
-    agent_usage: Optional[List[dict]] = Field(
-        default=None, description="Raw usage statistics emitted by the agent during the run"
-    )
-    agent_state: Optional[AgentState] = Field(
-        default=None,
-        description=(
-            "Agent state after running the target (includes memory blocks). "
-            "Only populated when at least one grader requires agent_state."
-        ),
-    )
-    token_data: Optional[List[TurnTokenData]] = Field(
-        default=None,
-        description=(
-            "Per-token IDs and logprobs across all turns in the trajectory. "
-            "Only populated when run_sample(return_token_data=True) is called."
-        ),
-    )
-
-
-# Aggregate summary types. Live in summary.json (one shape regardless of
-# num_runs).
-
-
-class PerRunSummary(BaseModel):
-    """Per-run summary for a single model (multi-run only)."""
-
-    run: int = Field(description="Run index (1-based)")
-    score: float = Field(description="Primary gate metric score for this run (0-1)")
-    per_metric: Dict[str, float] = Field(description="Per-grader average score for this run (0-1)")
-    usage: Usage = Field(description="Aggregate usage for this run")
-    timing: TimingStats = Field(description="Aggregate timing for this run")
-    n_errors: int = Field(default=0, description="Number of errored samples in this run")
-
-
-class ModelSummary(BaseModel):
-    """Summary metrics for one model across one or more runs."""
-
-    model: str = Field(description="Model identifier")
-    n_total: int = Field(description="Total samples scheduled (success + error) per run")
-    n_attempted: int = Field(description="Samples completed without error (sum across runs)")
-    score: float = Field(description="Primary gate metric score (0-1, mean across runs)")
-    score_std: Optional[float] = Field(
-        default=None, description="Standard deviation of score across runs (multi-run only)"
-    )
-    per_metric: Dict[str, float] = Field(description="Per-grader average score (0-1, mean across runs)")
-    per_metric_std: Optional[Dict[str, float]] = Field(
-        default=None,
-        description="Standard deviation of per_metric values across runs (multi-run only)",
-    )
-    usage: Usage = Field(description="Aggregate usage (summed across runs)")
-    timing: TimingStats = Field(description="Aggregate timing (averaged across runs)")
-    errors: Optional[ErrorSummary] = Field(default=None, description="Error breakdown (only when errors > 0)")
-    runs: Optional[List[PerRunSummary]] = Field(
-        default=None,
-        description="Per-run breakdown (only present in per-model summary.json, not top-level)",
-    )
-
-
-class Summary(BaseModel):
-    """Top-level evaluation summary."""
-
-    suite: str = Field(description="Name of the evaluation suite")
-    models: List[ModelSummary] = Field(description="Per-model summary (one entry per model)")
-    gates_passed: bool = Field(description="Whether all gate criteria were satisfied")
-    runs_passed: Optional[int] = Field(default=None, description="Number of runs that passed the gate (multi-run only)")
-
-
-# In-memory holders. ``RunnerResult`` is what ``run_suite`` returns and what
-# the visualization layer consumes. Disk layout is owned by
-# ``letta_evals.streaming``.
-
-
-class ModelRun(BaseModel):
-    """In-memory results for one model (one or more runs)."""
-
-    model: str = Field(description="Model identifier")
-    results: List[SampleResult] = Field(
-        description="Sample results. For num_runs > 1 this is the last run; see ``runs`` for full history.",
-    )
-    runs: Optional[List[List[SampleResult]]] = Field(
-        default=None,
-        description="Per-run sample results, indexed as runs[run_idx][sample_idx] (only when num_runs > 1)",
-    )
-    summary: ModelSummary = Field(description="Aggregate summary for this model")
-
-
-class RunnerResult(BaseModel):
-    """Complete evaluation run result returned by ``run_suite``."""
-
-    suite_spec: SuiteSpec = Field(description="The full suite configuration that produced this run")
-    samples: List[Sample] = Field(description="The dataset, loaded once and shared across all model runs")
-    runs: Dict[str, ModelRun] = Field(description="Per-model run data, keyed by model identifier")
-    summary: Summary = Field(description="Top-level summary across all models")
-    gates_passed: bool = Field(description="Whether all gate criteria were satisfied")

--- a/letta_evals/models/summaries.py
+++ b/letta_evals/models/summaries.py
@@ -1,0 +1,88 @@
+"""Aggregate summary and in-memory run holders.
+
+``Summary`` / ``ModelSummary`` / ``PerRunSummary`` describe the on-disk
+summary.json layout produced by streaming. ``RunnerResult`` / ``ModelRun``
+are the in-memory shapes returned by ``run_suite`` and consumed by the
+visualization layer.
+"""
+
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from letta_evals.models.results import ErrorSummary, SampleResult, TimingStats, Usage
+from letta_evals.models.sample import Sample
+from letta_evals.models.specs import SuiteSpec
+
+
+class PerRunSummary(BaseModel):
+    """Per-run summary for a single model (multi-run only)."""
+
+    run: int = Field(description="Run index (1-based)")
+    score: float = Field(description="Primary gate metric score for this run (0-1)")
+    per_metric: Dict[str, float] = Field(description="Per-grader average score for this run (0-1)")
+    usage: Usage = Field(description="Aggregate usage for this run")
+    timing: TimingStats = Field(description="Aggregate timing for this run")
+    n_errors: int = Field(default=0, description="Number of errored samples in this run")
+
+
+class ModelSummary(BaseModel):
+    """Summary metrics for one model across one or more runs."""
+
+    model: str = Field(description="Model identifier")
+    n_total: int = Field(description="Total samples scheduled (success + error) per run")
+    n_attempted: int = Field(description="Samples completed without error (sum across runs)")
+    score: float = Field(description="Primary gate metric score (0-1, mean across runs)")
+    score_std: Optional[float] = Field(
+        default=None, description="Standard deviation of score across runs (multi-run only)"
+    )
+    per_metric: Dict[str, float] = Field(description="Per-grader average score (0-1, mean across runs)")
+    per_metric_std: Optional[Dict[str, float]] = Field(
+        default=None,
+        description="Standard deviation of per_metric values across runs (multi-run only)",
+    )
+    usage: Usage = Field(description="Aggregate usage (summed across runs)")
+    timing: TimingStats = Field(description="Aggregate timing (averaged across runs)")
+    errors: Optional[ErrorSummary] = Field(default=None, description="Error breakdown (only when errors > 0)")
+    runs: Optional[List[PerRunSummary]] = Field(
+        default=None,
+        description="Per-run breakdown (only present in per-model summary.json, not top-level)",
+    )
+
+
+class Summary(BaseModel):
+    """Top-level evaluation summary."""
+
+    suite: str = Field(description="Name of the evaluation suite")
+    models: List[ModelSummary] = Field(description="Per-model summary (one entry per model)")
+    gates_passed: bool = Field(description="Whether all gate criteria were satisfied")
+    runs_passed: Optional[int] = Field(default=None, description="Number of runs that passed the gate (multi-run only)")
+
+
+# In-memory holders. ``RunnerResult`` is what ``run_suite`` returns and what
+# the visualization layer consumes. Disk layout is owned by
+# ``letta_evals.streaming``.
+
+
+class ModelRun(BaseModel):
+    """In-memory results for one model (one or more runs)."""
+
+    model: str = Field(description="Model identifier")
+    results: List[SampleResult] = Field(
+        description="Sample results. For num_runs > 1 this is the last run; see ``runs`` for full history.",
+    )
+    runs: Optional[List[List[SampleResult]]] = Field(
+        default=None,
+        description="Per-run sample results, indexed as runs[run_idx][sample_idx] (only when num_runs > 1)",
+    )
+    summary: ModelSummary = Field(description="Aggregate summary for this model")
+
+
+class RunnerResult(BaseModel):
+    """Complete evaluation run result returned by ``run_suite``."""
+
+    suite_spec: SuiteSpec = Field(description="The full suite configuration that produced this run")
+    samples: List[Sample] = Field(description="The dataset, loaded once and shared across all model runs")
+    runs: Dict[str, ModelRun] = Field(description="Per-model run data, keyed by model identifier")
+    summary: Summary = Field(description="Top-level summary across all models")
+    gates_passed: bool = Field(description="Whether all gate criteria were satisfied")


### PR DESCRIPTION
## Summary

The 787-line `letta_evals/models.py` mixed dataset, config-spec, per-sample result, and aggregate summary models. After the recent data-model refactor (#254), it became worth splitting along its existing section boundaries to make the codebase easier to navigate.

Converted `models.py` → `models/` package, grouped by concern:

| File | Contents |
|---|---|
| `sample.py` | `Sample` |
| `specs.py` | All config specs (`TargetSpec`, `GraderSpec`, `GateSpec`, `SuiteSpec` families) + gate helpers (`compute_gate_score`, `normalize_weights`, `_compare`) |
| `results.py` | `LettaMessageUnion`, `TargetResult`, `GradeResult`, `PerTurnGrade`, `TurnTokenData`, `SampleResult`, and the `Usage` / `Timing`+`TimingStats` / `Error`+`ErrorSummary` primitives |
| `summaries.py` | `PerRunSummary`, `ModelSummary`, `Summary`, `ModelRun`, `RunnerResult` |
| `__init__.py` | Re-exports the full public surface |

### Properties

- **Zero churn for the ~37 importers.** All `from letta_evals.models import X` call sites keep working — `models/__init__.py` re-exports everything (including the test-visible `_compare`/`normalize_weights`).
- **No import cycles.** One-way deps: `summaries` → `sample` + `specs` + `results`; the other three submodules don't import from each other.
- **Per-sample/aggregate pairs stay co-located.** `Timing`/`TimingStats` and `Error`/`ErrorSummary` live together in `results.py`, so "where does this summary primitive live?" has one obvious answer.
- Git tracks the rename `models.py` → `models/specs.py` (specs is the largest chunk), preserving blame.

## Test plan

- [x] All 238 unit tests pass (`uv run pytest tests/ --ignore=tests/test_examples_e2e_live.py`)
- [x] `from letta_evals.models import *` smoke-checked for every previously-exported symbol, including `_compare`, `normalize_weights`, and `AgentState`
- [x] `import letta_evals` top-level still exposes all 44 symbols in `__all__`

👾 Generated with [Letta Code](https://letta.com)