### PR TITLE
fix: Preserve explicit dataset sample ids

### DIFF
--- a/letta_evals/datasets/loader.py
+++ b/letta_evals/datasets/loader.py
@@ -4,7 +4,30 @@ from typing import Iterator, List, Optional, Union
 
 import pandas as pd
 
-from letta_evals.models import Sample
+from letta_evals.models import Sample, SampleId
+
+
+def _normalize_sample_id(value) -> SampleId:
+    """Return a JSON-serializable sample id while preserving explicit dataset identity."""
+    if hasattr(value, "item"):
+        value = value.item()
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return value
+
+
+def _json_sample_id(data: dict, fallback: int) -> SampleId:
+    for field_name in ("sample_id", "id"):
+        if field_name in data and data[field_name] is not None:
+            return _normalize_sample_id(data[field_name])
+    return fallback
+
+
+def _csv_sample_id(df: pd.DataFrame, row, fallback: int) -> SampleId:
+    for field_name in ("sample_id", "id"):
+        if field_name in df.columns and not pd.isna(row.get(field_name)):
+            return _normalize_sample_id(row[field_name])
+    return fallback
 
 
 def _resolve_rubric_fields(
@@ -59,7 +82,7 @@ def load_jsonl(
                 line_index,
             )
             sample = Sample(
-                id=line_index,
+                id=_json_sample_id(data, line_index),
                 input=data.get("input") or data["prompt"],
                 ground_truth=data.get("ground_truth"),
                 agent_args=data.get("agent_args") or metadata.get("agent_args"),
@@ -169,7 +192,7 @@ def load_csv(
         # create sample
         try:
             sample = Sample(
-                id=int(idx),
+                id=_csv_sample_id(df, row, int(idx)),
                 input=input_value,
                 ground_truth=ground_truth,
                 agent_args=agent_args,

--- a/letta_evals/models/__init__.py
+++ b/letta_evals/models/__init__.py
@@ -30,7 +30,7 @@ from letta_evals.models.results import (
     TurnTokenData,
     Usage,
 )
-from letta_evals.models.sample import Sample
+from letta_evals.models.sample import Sample, SampleId
 from letta_evals.models.specs import (
     BaseGraderSpec,
     BaseTargetSpec,
@@ -64,6 +64,7 @@ __all__ = [
     "AgentState",
     # sample
     "Sample",
+    "SampleId",
     # specs — targets
     "BaseTargetSpec",
     "LettaAgentTargetSpec",

--- a/letta_evals/models/results.py
+++ b/letta_evals/models/results.py
@@ -24,6 +24,7 @@ from letta_client.types.agents import (
 )
 from pydantic import BaseModel, Field, field_validator
 
+from letta_evals.models.sample import SampleId
 from letta_evals.types import ErrorCategory
 
 # Type alias for message union (replaces LettaMessageUnion from v0.x SDK)
@@ -181,7 +182,7 @@ class ErrorSummary(BaseModel):
 class SampleResult(BaseModel):
     """Result for a single sample evaluation."""
 
-    sample_id: int = Field(description="ID of the sample (look up the full Sample in suite.json)")
+    sample_id: SampleId = Field(description="ID of the sample (look up the full Sample in suite.json)")
     agent_id: Optional[str] = Field(default=None, description="ID of the agent that generated this trajectory")
     trajectory: List[List[LettaMessageUnion]] = Field(description="Full conversation trajectory from the agent")
     submissions: Dict[str, str] = Field(

--- a/letta_evals/models/sample.py
+++ b/letta_evals/models/sample.py
@@ -9,11 +9,13 @@ from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field, model_validator
 
+SampleId = Union[int, str]
+
 
 class Sample(BaseModel):
     """Single evaluation sample."""
 
-    id: int = Field(description="Sample ID (0-based index from dataset)")
+    id: SampleId = Field(description="Sample ID from the dataset, or row index if the dataset does not provide one")
     input: Union[str, List[str]] = Field(description="Input message(s) to send to the agent")
     ground_truth: Optional[Union[str, List[str]]] = Field(
         default=None,

--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -33,6 +33,7 @@ from letta_evals.models import (
     PerTurnGrade,
     RunnerResult,
     Sample,
+    SampleId,
     SampleResult,
     SimpleCondition,
     SimpleGateSpec,
@@ -154,10 +155,10 @@ class Runner:
         self.progress_callback = progress_callback
         self.model_configs = self._load_model_configs()
         self.cached_results = cached_results
-        self._cached_trajectories: Dict[int, Dict[str, SampleResult]] = (
+        self._cached_trajectories: Dict[SampleId, Dict[str, SampleResult]] = (
             self._build_trajectory_cache() if cached_results else {}
         )
-        self._sample_lookup: Dict[int, Sample] = {}
+        self._sample_lookup: Dict[SampleId, Sample] = {}
         # ``stream_writer`` is shared across runs in multi-run mode; if not
         # provided, the runner builds its own. ``current_run`` is the 1-based
         # index of this run inside that shared writer.
@@ -355,9 +356,9 @@ class Runner:
 
     # ── cache ──
 
-    def _build_trajectory_cache(self) -> Dict[int, Dict[str, SampleResult]]:
+    def _build_trajectory_cache(self) -> Dict[SampleId, Dict[str, SampleResult]]:
         """Cache previous results indexed by sample_id → model → SampleResult."""
-        cache: Dict[int, Dict[str, SampleResult]] = defaultdict(dict)
+        cache: Dict[SampleId, Dict[str, SampleResult]] = defaultdict(dict)
         if self.cached_results:
             for model_id, model_run in self.cached_results.runs.items():
                 for result in model_run.results:
@@ -433,7 +434,7 @@ class Runner:
         agent_state: Optional[AgentState],
         grader: Grader,
         grader_key: str,
-        sample_id: int,
+        sample_id: SampleId,
         agent_id: str,
         model_name: str,
     ) -> tuple[GradeResult, str]:
@@ -506,7 +507,7 @@ class Runner:
         sample: Sample,
         trajectory: List[List[LettaMessageUnion]],
         agent_state: Optional[AgentState],
-        sample_id: int,
+        sample_id: SampleId,
         agent_id: str,
         model_name: str,
     ) -> tuple[Dict[str, GradeResult], Dict[str, str], Dict[str, float]]:

--- a/letta_evals/visualization/base.py
+++ b/letta_evals/visualization/base.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Dict, Optional
 
+from letta_evals.models.sample import SampleId
+
 
 class ProgressCallback(ABC):
     """Abstract base class for progress tracking during evaluation runs.
@@ -33,13 +35,13 @@ class ProgressCallback(ABC):
 
     @abstractmethod
     async def sample_started(
-        self, sample_id: int, agent_id: Optional[str] = None, model_name: Optional[str] = None
+        self, sample_id: SampleId, agent_id: Optional[str] = None, model_name: Optional[str] = None
     ) -> None:
         """Called when a sample evaluation starts."""
         ...
 
     async def agent_created(
-        self, sample_id: int, agent_id: str, model_name: Optional[str] = None, from_cache: bool = False
+        self, sample_id: SampleId, agent_id: str, model_name: Optional[str] = None, from_cache: bool = False
     ) -> None:
         """Called when an agent has been created/provisioned or resolved from cache.
 
@@ -49,7 +51,7 @@ class ProgressCallback(ABC):
 
     async def message_sending(
         self,
-        sample_id: int,
+        sample_id: SampleId,
         message_num: int,
         total_messages: int,
         agent_id: Optional[str] = None,
@@ -59,14 +61,14 @@ class ProgressCallback(ABC):
         pass
 
     async def grading_started(
-        self, sample_id: int, agent_id: Optional[str] = None, model_name: Optional[str] = None
+        self, sample_id: SampleId, agent_id: Optional[str] = None, model_name: Optional[str] = None
     ) -> None:
         """Called when grading of a sample begins."""
         pass
 
     async def turn_graded(
         self,
-        sample_id: int,
+        sample_id: SampleId,
         turn_num: int,
         total_turns: int,
         turn_score: float,
@@ -80,7 +82,7 @@ class ProgressCallback(ABC):
     @abstractmethod
     async def sample_completed(
         self,
-        sample_id: int,
+        sample_id: SampleId,
         agent_id: Optional[str] = None,
         score: Optional[float] = None,
         target_cost: Optional[float] = None,
@@ -95,7 +97,7 @@ class ProgressCallback(ABC):
     @abstractmethod
     async def sample_error(
         self,
-        sample_id: int,
+        sample_id: SampleId,
         error: str,
         agent_id: Optional[str] = None,
         model_name: Optional[str] = None,

--- a/letta_evals/visualization/noop_progress.py
+++ b/letta_evals/visualization/noop_progress.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Dict, Optional
 
+from letta_evals.models.sample import SampleId
 from letta_evals.visualization.base import ProgressCallback
 
 
@@ -9,13 +10,13 @@ class NoOpProgress(ProgressCallback):
     """No-output progress callback (silent)."""
 
     async def sample_started(
-        self, sample_id: int, agent_id: Optional[str] = None, model_name: Optional[str] = None
+        self, sample_id: SampleId, agent_id: Optional[str] = None, model_name: Optional[str] = None
     ) -> None:
         pass
 
     async def sample_completed(
         self,
-        sample_id: int,
+        sample_id: SampleId,
         agent_id: Optional[str] = None,
         score: Optional[float] = None,
         target_cost: Optional[float] = None,
@@ -28,7 +29,7 @@ class NoOpProgress(ProgressCallback):
 
     async def sample_error(
         self,
-        sample_id: int,
+        sample_id: SampleId,
         error: str,
         agent_id: Optional[str] = None,
         model_name: Optional[str] = None,

--- a/letta_evals/visualization/reducer.py
+++ b/letta_evals/visualization/reducer.py
@@ -4,6 +4,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Dict, Optional
 
+from letta_evals.models.sample import SampleId
 from letta_evals.visualization.state import (
     ProgressEvent,
     SampleProgress,
@@ -11,7 +12,7 @@ from letta_evals.visualization.state import (
     is_terminal_state,
 )
 
-SampleKey = tuple[int, Optional[str]]
+SampleKey = tuple[SampleId, Optional[str]]
 
 
 @dataclass
@@ -49,7 +50,7 @@ class ProgressStateReducer:
 
     def ensure_sample(
         self,
-        sample_id: int,
+        sample_id: SampleId,
         *,
         agent_id: Optional[str] = None,
         model_name: Optional[str] = None,
@@ -72,11 +73,11 @@ class ProgressStateReducer:
             sample.model_name = model_name
         return sample
 
-    def get_from_cache(self, sample_id: int, model_name: Optional[str] = None) -> bool:
+    def get_from_cache(self, sample_id: SampleId, model_name: Optional[str] = None) -> bool:
         sample = self.get_sample(sample_id, model_name)
         return sample.from_cache if sample is not None else False
 
-    def get_sample(self, sample_id: int, model_name: Optional[str] = None) -> Optional[SampleProgress]:
+    def get_sample(self, sample_id: SampleId, model_name: Optional[str] = None) -> Optional[SampleProgress]:
         key = (sample_id, model_name)
         if key in self.state.samples:
             return self.state.samples[key]
@@ -86,7 +87,7 @@ class ProgressStateReducer:
 
     def record_turn_grade(
         self,
-        sample_id: int,
+        sample_id: SampleId,
         *,
         turn_num: int,
         total_turns: int,
@@ -115,7 +116,7 @@ class ProgressStateReducer:
 
     def apply_sample_state_update(
         self,
-        sample_id: int,
+        sample_id: SampleId,
         state: SampleState,
         agent_id: Optional[str] = None,
         model_name: Optional[str] = None,

--- a/letta_evals/visualization/rich_progress.py
+++ b/letta_evals/visualization/rich_progress.py
@@ -17,6 +17,7 @@ from rich.progress import (
 )
 from rich.table import Table
 
+from letta_evals.models.sample import SampleId
 from letta_evals.visualization.base import ProgressCallback
 from letta_evals.visualization.reducer import ProgressRuntimeState, ProgressStateReducer
 from letta_evals.visualization.rich_renderer import RichProgressRenderer
@@ -245,7 +246,7 @@ class EvalProgress(ProgressCallback):
 
     async def update_sample_state(
         self,
-        sample_id: int,
+        sample_id: SampleId,
         state: SampleState,
         agent_id: Optional[str] = None,
         model_name: Optional[str] = None,
@@ -261,7 +262,9 @@ class EvalProgress(ProgressCallback):
             **kwargs,
         )
 
-    async def sample_started(self, sample_id: int, agent_id: Optional[str] = None, model_name: Optional[str] = None):
+    async def sample_started(
+        self, sample_id: SampleId, agent_id: Optional[str] = None, model_name: Optional[str] = None
+    ):
         """Mark sample as started"""
         self._reducer.ensure_sample(sample_id, agent_id=agent_id, model_name=model_name)
         # skip loading state if using cached trajectories
@@ -271,7 +274,7 @@ class EvalProgress(ProgressCallback):
             )
 
     async def agent_created(
-        self, sample_id: int, agent_id: str, model_name: Optional[str] = None, from_cache: bool = False
+        self, sample_id: SampleId, agent_id: str, model_name: Optional[str] = None, from_cache: bool = False
     ):
         """Update sample with agent_id once agent is provisioned."""
         await self.update_sample_state(
@@ -280,7 +283,7 @@ class EvalProgress(ProgressCallback):
 
     async def message_sending(
         self,
-        sample_id: int,
+        sample_id: SampleId,
         message_num: int,
         total_messages: int,
         agent_id: Optional[str] = None,
@@ -296,7 +299,9 @@ class EvalProgress(ProgressCallback):
             total_messages=total_messages,
         )
 
-    async def grading_started(self, sample_id: int, agent_id: Optional[str] = None, model_name: Optional[str] = None):
+    async def grading_started(
+        self, sample_id: SampleId, agent_id: Optional[str] = None, model_name: Optional[str] = None
+    ):
         """Mark sample as being graded"""
         existing_from_cache = self._reducer.get_from_cache(sample_id, model_name)
 
@@ -306,7 +311,7 @@ class EvalProgress(ProgressCallback):
 
     async def turn_graded(
         self,
-        sample_id: int,
+        sample_id: SampleId,
         turn_num: int,
         total_turns: int,
         turn_score: float,
@@ -337,7 +342,7 @@ class EvalProgress(ProgressCallback):
 
     async def sample_completed(
         self,
-        sample_id: int,
+        sample_id: SampleId,
         agent_id: Optional[str] = None,
         score: Optional[float] = None,
         target_cost: Optional[float] = None,
@@ -364,7 +369,7 @@ class EvalProgress(ProgressCallback):
 
     async def sample_error(
         self,
-        sample_id: int,
+        sample_id: SampleId,
         error: str,
         agent_id: Optional[str] = None,
         model_name: Optional[str] = None,

--- a/letta_evals/visualization/rich_renderer.py
+++ b/letta_evals/visualization/rich_renderer.py
@@ -23,6 +23,10 @@ from letta_evals.visualization.state import (
 )
 
 
+def _sample_id_sort_key(sample_id):
+    return (0, sample_id) if isinstance(sample_id, int) else (1, str(sample_id))
+
+
 class RichProgressRenderer:
     """Render the live Rich layout for evaluation progress."""
 
@@ -83,7 +87,7 @@ class RichProgressRenderer:
     ) -> List[SampleProgress]:
         """Select only currently active rows for the live top panel."""
         rows = [sample for sample in runtime_state.samples.values() if is_active_state(sample.state)]
-        rows.sort(key=lambda sample: (sample.model_name or "", sample.sample_id))
+        rows.sort(key=lambda sample: (sample.model_name or "", _sample_id_sort_key(sample.sample_id)))
         if limit is None:
             return rows
         return rows[:limit]
@@ -93,7 +97,13 @@ class RichProgressRenderer:
     ) -> List[SampleProgress]:
         """Select the most recent completed or errored rows for the bottom panel."""
         rows = [sample for sample in runtime_state.samples.values() if is_completed_state(sample.state)]
-        rows.sort(key=lambda sample: (-get_last_update_key(sample), sample.model_name or "", sample.sample_id))
+        rows.sort(
+            key=lambda sample: (
+                -get_last_update_key(sample),
+                sample.model_name or "",
+                _sample_id_sort_key(sample.sample_id),
+            )
+        )
         if limit is None:
             return rows
         return rows[:limit]

--- a/letta_evals/visualization/simple_progress.py
+++ b/letta_evals/visualization/simple_progress.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional
 
 from rich.console import Console
 
+from letta_evals.models.sample import SampleId
 from letta_evals.visualization.base import ProgressCallback
 from letta_evals.visualization.summary import (
     build_simple_sample_results_table,
@@ -44,14 +45,14 @@ class SimpleProgress(ProgressCallback):
         """Reset state for a new run."""
 
     async def sample_started(
-        self, sample_id: int, agent_id: Optional[str] = None, model_name: Optional[str] = None
+        self, sample_id: SampleId, agent_id: Optional[str] = None, model_name: Optional[str] = None
     ) -> None:
         model_text = f" [dim]({model_name})[/]" if model_name else ""
         agent_text = f" [dim]agent={agent_id}[/]" if agent_id else ""
         self.console.print(f"[bold cyan]▸ Sample [{sample_id}]{model_text}{agent_text}[/]")
 
     async def agent_created(
-        self, sample_id: int, agent_id: str, model_name: Optional[str] = None, from_cache: bool = False
+        self, sample_id: SampleId, agent_id: str, model_name: Optional[str] = None, from_cache: bool = False
     ) -> None:
         prefix = self._format_prefix(sample_id, agent_id, model_name)
         cache_text = " [dim](cached)[/]" if from_cache else ""
@@ -59,7 +60,7 @@ class SimpleProgress(ProgressCallback):
 
     async def message_sending(
         self,
-        sample_id: int,
+        sample_id: SampleId,
         message_num: int,
         total_messages: int,
         agent_id: Optional[str] = None,
@@ -69,14 +70,14 @@ class SimpleProgress(ProgressCallback):
         self.console.print(f"{prefix} [dim]•[/] Sending messages {message_num}/{total_messages}")
 
     async def grading_started(
-        self, sample_id: int, agent_id: Optional[str] = None, model_name: Optional[str] = None
+        self, sample_id: SampleId, agent_id: Optional[str] = None, model_name: Optional[str] = None
     ) -> None:
         prefix = self._format_prefix(sample_id, agent_id, model_name)
         self.console.print(f"{prefix} [dim]•[/] Grading...")
 
     async def sample_completed(
         self,
-        sample_id: int,
+        sample_id: SampleId,
         agent_id: Optional[str] = None,
         score: Optional[float] = None,
         target_cost: Optional[float] = None,
@@ -100,7 +101,7 @@ class SimpleProgress(ProgressCallback):
 
     async def sample_error(
         self,
-        sample_id: int,
+        sample_id: SampleId,
         error: str,
         agent_id: Optional[str] = None,
         model_name: Optional[str] = None,
@@ -131,7 +132,7 @@ class SimpleProgress(ProgressCallback):
         self.console.print(build_simple_sample_results_table(suite_spec, displayed_rows))
         print_remaining_samples_notice(self.console, total_samples, len(displayed_rows))
 
-    def _format_prefix(self, sample_id: int, agent_id: Optional[str], model_name: Optional[str]) -> str:
+    def _format_prefix(self, sample_id: SampleId, agent_id: Optional[str], model_name: Optional[str]) -> str:
         """format a compact prefix for substeps to show which sample they belong to."""
         parts = [f"[dim]\\[[/][cyan]{sample_id}[/][dim]][/]"]
         if model_name:

--- a/letta_evals/visualization/state.py
+++ b/letta_evals/visualization/state.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
+from letta_evals.models.sample import SampleId
+
 
 class SampleState(Enum):
     """States a sample can be in during evaluation."""
@@ -38,7 +40,7 @@ COMPLETED_SAMPLE_STATES = frozenset(
 class SampleProgress:
     """Track progress of an individual sample."""
 
-    sample_id: int
+    sample_id: SampleId
     state: SampleState = SampleState.QUEUED
     agent_id: Optional[str] = None
     model_name: Optional[str] = None

--- a/letta_evals/visualization/summary.py
+++ b/letta_evals/visualization/summary.py
@@ -114,6 +114,10 @@ def extract_score_and_rationale(grade: Any) -> tuple[Optional[float], str]:
 DisplayRow = Tuple[str, SampleResult]
 
 
+def _sample_id_sort_key(sample_id):
+    return (0, sample_id) if isinstance(sample_id, int) else (1, str(sample_id))
+
+
 def get_displayed_sample_results(result: Any) -> tuple[int, List[DisplayRow]]:
     """Flatten the per-model results into a sorted list for display.
 
@@ -127,7 +131,7 @@ def get_displayed_sample_results(result: Any) -> tuple[int, List[DisplayRow]]:
         for sample_result in model_run.results:
             rows.append((model_id, sample_result))
 
-    rows.sort(key=lambda row: (row[0], row[1].sample_id))
+    rows.sort(key=lambda row: (row[0], _sample_id_sort_key(row[1].sample_id)))
     return len(rows), rows[:MAX_SAMPLES_DISPLAY]
 
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -105,6 +105,26 @@ class TestLoadJsonl:
         assert samples[0].ground_truth == "world"
         assert samples[1].id == 1
 
+    def test_preserves_explicit_sample_id(self):
+        path = self._write_jsonl(
+            [
+                {"sample_id": 101, "input": "hello"},
+                {"sample_id": 205, "input": "foo"},
+            ]
+        )
+        samples = list(load_jsonl(path))
+        assert [s.id for s in samples] == [101, 205]
+
+    def test_preserves_explicit_string_sample_id(self):
+        path = self._write_jsonl([{"sample_id": "sample-a", "input": "hello"}])
+        samples = list(load_jsonl(path))
+        assert samples[0].id == "sample-a"
+
+    def test_preserves_explicit_id_when_sample_id_missing(self):
+        path = self._write_jsonl([{"id": "row-a", "input": "hello"}])
+        samples = list(load_jsonl(path))
+        assert samples[0].id == "row-a"
+
     def test_max_samples(self):
         path = self._write_jsonl([{"input": f"q{i}"} for i in range(10)])
         samples = list(load_jsonl(path, max_samples=3))
@@ -160,6 +180,21 @@ class TestLoadCsv:
         assert len(samples) == 2
         assert samples[0].input == "hello"
         assert samples[0].ground_truth == "world"
+
+    def test_preserves_explicit_numeric_sample_id(self):
+        path = self._write_csv("sample_id,input\n101,hello\n205,foo\n")
+        samples = list(load_csv(path))
+        assert [s.id for s in samples] == [101, 205]
+
+    def test_preserves_explicit_string_sample_id(self):
+        path = self._write_csv("sample_id,input\nsample-a,hello\nsample-b,foo\n")
+        samples = list(load_csv(path))
+        assert [s.id for s in samples] == ["sample-a", "sample-b"]
+
+    def test_preserves_explicit_id_when_sample_id_missing(self):
+        path = self._write_csv("id,input\nrow-a,hello\nrow-b,foo\n")
+        samples = list(load_csv(path))
+        assert [s.id for s in samples] == ["row-a", "row-b"]
 
     def test_max_samples(self):
         rows = "input\n" + "\n".join(f"q{i}" for i in range(10)) + "\n"

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -42,7 +42,7 @@ def _make_samples(n: int = 2):
     return [Sample(id=i, input=f"in-{i}", ground_truth=f"gt-{i}") for i in range(n)]
 
 
-def _make_result(sample_id: int, score: float) -> SampleResult:
+def _make_result(sample_id, score: float) -> SampleResult:
     return SampleResult(
         sample_id=sample_id,
         agent_id="agent-x",
@@ -123,6 +123,34 @@ class TestSingleRun:
             assert result.gates_passed is True
             assert "default" in result.runs
             assert result.runs["default"].results[0].grades["check"].score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_string_sample_id_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir)
+            samples = [Sample(id="sample-a", input="in-a", ground_truth="gt-a")]
+            writer = StreamingWriter(
+                output_path,
+                _make_suite(),
+                samples,
+                models=["default"],
+                num_runs=1,
+            )
+            await writer.initialize()
+
+            r = _make_result("sample-a", 1.0)
+            await writer.append_result(r, model="default")
+            await writer.write_summary(
+                Summary(
+                    suite="test-suite",
+                    models=[_summary_for("default", [r])],
+                    gates_passed=True,
+                )
+            )
+
+            result = await StreamingReader.to_runner_result(output_path)
+            assert result.samples[0].id == "sample-a"
+            assert result.runs["default"].results[0].sample_id == "sample-a"
 
     @pytest.mark.asyncio
     async def test_multiple_models_round_trip(self):

--- a/tests/test_visualization_summary.py
+++ b/tests/test_visualization_summary.py
@@ -7,6 +7,7 @@ from letta_evals.models import (
     LettaAgentTargetSpec,
     ModelRun,
     ModelSummary,
+    SampleId,
     SampleResult,
     SimpleGateSpec,
     SuiteSpec,
@@ -49,7 +50,7 @@ def _make_suite() -> SuiteSpec:
 
 
 def _sample_result(
-    sample_id: int, agent_id: str, accuracy: float, acc_rat: str, quality: float, q_rat: str
+    sample_id: SampleId, agent_id: str, accuracy: float, acc_rat: str, quality: float, q_rat: str
 ) -> SampleResult:
     return SampleResult(
         sample_id=sample_id,
@@ -125,6 +126,28 @@ def test_get_displayed_sample_results_sorts_by_model_then_sample() -> None:
     assert [(model_id, sr.sample_id) for model_id, sr in displayed] == [
         ("model-a", 0),
         ("model-z", 1),
+    ]
+
+
+def test_get_displayed_sample_results_sorts_string_sample_ids() -> None:
+    result = _make_result()
+    result.runs = {
+        "model-a": ModelRun(
+            model="model-a",
+            results=[
+                _sample_result("sample-b", "agent-b", accuracy=0.25, acc_rat="b", quality=0.75, q_rat="b"),
+                _sample_result("sample-a", "agent-a", accuracy=1.0, acc_rat="a", quality=0.5, q_rat="a"),
+            ],
+            summary=_model_summary("model-a", score=1.0, per_metric={"accuracy": 1.0, "quality": 0.5}),
+        )
+    }
+
+    total, displayed = get_displayed_sample_results(result)
+
+    assert total == 2
+    assert [(model_id, sr.sample_id) for model_id, sr in displayed] == [
+        ("model-a", "sample-a"),
+        ("model-a", "sample-b"),
     ]
 
 


### PR DESCRIPTION
## Summary
- Preserve explicit dataset sample identifiers from sample_id or id fields in JSONL/CSV loaders
- Allow sample IDs to be strings as well as integers so result artifacts can match datasets like skills-suite
- Carry widened sample IDs through runner/progress/summary paths and add regression coverage

## Tests
- uv run ruff check letta_evals tests/test_loader.py tests/test_streaming.py tests/test_visualization_summary.py
- uv run ruff format --check letta_evals tests/test_loader.py tests/test_streaming.py tests/test_visualization_summary.py
- uv run pytest tests/test_loader.py tests/test_streaming.py tests/test_visualization_summary.py tests/test_rich_renderer.py tests/test_visualization_reducer.py