### PR TITLE
fix(cli): Repair broken GateKind import and add --version flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Fixed — `letta-evals` CLI failed to import
+
+`cli.py` imported `GateKind` from `letta_evals.models`, but #254 moved it
+to `letta_evals.types`, so every `letta-evals` invocation failed at import
+with `ImportError: cannot import name 'GateKind'`. Now imports it from
+`letta_evals.types`.
+
+### Added — `letta-evals --version`
+
+A top-level `--version` flag prints the installed version (e.g.
+`letta-evals 0.17.0`) and exits.
+
 ### ⚠ BREAKING CHANGES — rubric grader redesign
 
 The `model_judge` and `letta_judge` graders now send the rubric **verbatim**

--- a/letta_evals/cli.py
+++ b/letta_evals/cli.py
@@ -8,13 +8,34 @@ import yaml
 from rich.console import Console
 from rich.table import Table
 
+from letta_evals import __version__
 from letta_evals.datasets.loader import load_dataset
-from letta_evals.models import GateKind, SuiteSpec
+from letta_evals.models import SuiteSpec
 from letta_evals.runner import run_suite
+from letta_evals.types import GateKind
 from letta_evals.visualization.factory import ProgressStyle
 
 app = typer.Typer(help="Letta Evals - Evaluation framework for Letta AI agents")
 console = Console()
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        console.print(f"letta-evals {__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show the letta-evals version and exit.",
+    ),
+) -> None:
+    """Letta Evals - Evaluation framework for Letta AI agents."""
 
 
 @app.command()


### PR DESCRIPTION
## What

Two small, related CLI fixes:

1. **Fix broken CLI import (regression).** `cli.py` imported `GateKind` from `letta_evals.models`, but #254 ("Simplify metrics/result data model and on-disk layout") moved `GateKind` to `letta_evals.types` and stopped re-exporting it from `models`. As a result, **every `letta-evals` invocation currently fails at import** on `main`:
   ```
   ImportError: cannot import name 'GateKind' from 'letta_evals.models'
   ```
   This imports it from `letta_evals.types` instead.

2. **Add `letta-evals --version`.** A top-level eager flag that prints the installed version (e.g. `letta-evals 0.17.0`, sourced from `letta_evals.__version__`) and exits.

## Why

`--version` is generally useful, and the upcoming Modal-sandbox feature's per-suite `sandbox.letta_evals_version` pin relies on `letta-evals --version` to assert the sandbox image's version matches the host before running samples. Pulling it into its own PR (off `main`) so it can merge independently of that larger change. The import fix is bundled because the CLI can't load at all without it — `--version` is unreachable otherwise.

## Test

```
$ letta-evals --version
letta-evals 0.17.0
$ letta-evals --help     # imports cleanly, all subcommands present
```
`ruff` clean.