### PR TITLE
fix(sandbox): Surface exec timeouts as SandboxTimeout

### DIFF
--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -733,6 +733,30 @@ class Runner:
             exec_timeout = self.suite.sandbox.timeout_sec
             result_exec = await sandbox.exec(command, env=exec_env, timeout_sec=exec_timeout)
 
+            if result_exec.return_code == -1:
+                # Modal's ContainerProcess.wait() returns -1 when the exec
+                # exceeds its deadline (timeout_sec). Surface it as a clear
+                # timeout rather than a generic non-zero exit.
+                msg = f"Sandbox exec exceeded timeout_sec={exec_timeout}"
+                logger.error(
+                    "Sandbox %s timed out for sample %s after %ss",
+                    sandbox.sandbox_id,
+                    sample_id,
+                    exec_timeout,
+                )
+                return SampleResult(
+                    sample_id=sample_id,
+                    trajectory=[],
+                    submissions={},
+                    grades={},
+                    timing=Timing(total=time.perf_counter() - t_sample_start, target=0.0),
+                    error=Error(
+                        category=ErrorCategory.TARGET,
+                        exception_type="SandboxTimeout",
+                        message=msg,
+                    ),
+                )
+
             if result_exec.return_code != 0:
                 msg = (result_exec.stderr or result_exec.stdout or "sandbox exec returned non-zero").strip()
                 category = (

--- a/tests/test_runner_sandbox_dispatch.py
+++ b/tests/test_runner_sandbox_dispatch.py
@@ -184,6 +184,28 @@ class TestRunSampleInSandbox:
         assert result.error is not None
         assert result.error.exception_type == "SandboxExecError"
 
+    def test_exec_timeout_returns_sandbox_timeout(self, tmp_path, monkeypatch):
+        """An exec returning -1 (Modal's exec-deadline sentinel) surfaces as a
+        SandboxTimeout (category=target), not a generic SandboxExecError."""
+        _write_suite_yaml(tmp_path)
+        runner = _make_runner_with_sandbox(tmp_path)
+        stub = _StubSandbox(exec_return_code=-1)
+        monkeypatch.setattr("letta_evals.sandbox.modal.ModalSandbox", lambda spec, session_id: stub)
+
+        sample = Sample(id="s1", input="hi", ground_truth="hi")
+        result = anyio.run(
+            runner._run_sample_in_sandbox,
+            sample,
+            "openai/gpt-a",
+            False,
+            0.0,
+        )
+
+        assert stub.stopped, "sandbox must be torn down on timeout"
+        assert result.error is not None
+        assert result.error.exception_type == "SandboxTimeout"
+        assert result.error.category.value == "target"
+
     def test_version_mismatch_short_circuits(self, tmp_path, monkeypatch):
         _write_suite_yaml(tmp_path)
         runner = _make_runner_with_sandbox(


### PR DESCRIPTION
## What

When an in-sandbox exec exceeds its deadline (`sandbox.timeout_sec`), Modal's `ContainerProcess.wait()` returns `-1` (it catches the asyncio timeout and sets `_returncode = -1`) rather than raising. Previously that `-1` fell through to the generic non-zero handler and surfaced as `SandboxExecError`.

The runner now detects `return_code == -1` and returns `Error(category=TARGET, exception_type="SandboxTimeout")` — implementing the `SandboxTimeout` row of the sandbox design's failure-modes table, which was the one item left unimplemented.

## Test

Added `test_exec_timeout_returns_sandbox_timeout`: a stubbed exec returning `-1` produces a `SandboxTimeout` error with `category=target`, and the sandbox is still torn down.