### PR TITLE
feat(sandbox): Forward LETTA_BASE_URL and document self-hosted servers

### DIFF
--- a/docs/examples/modal-sandbox/README.md
+++ b/docs/examples/modal-sandbox/README.md
@@ -103,9 +103,45 @@ resolves to a real file under `/mnt/suite/`.
   so extractors that read sandbox-filesystem state (e.g. agent memory
   git repos under `~/.letta/agents/<agent_id>/memory`) work without any
   artifact round-trip.
-- Local Letta server tunneling. The sandbox must reach a remote Letta
-  endpoint; users running a local Letta server should point at a
-  reachable URL.
+- Built-in reverse tunnels to a `localhost` server. Modal's tunnels are
+  inbound-only, so the sandbox can't dial your host's `localhost` directly.
+  A self-hosted/private server is still reachable — see
+  [Reaching a self-hosted Letta server](#reaching-a-self-hosted-letta-server).
+
+## Reaching a self-hosted Letta server
+
+By default the sandbox talks to Letta Cloud (`https://api.letta.com`). The
+sandbox runs in Modal's cloud and reaches the server over its normal
+**outbound** network (`block_network: false`), so any Letta endpoint reachable
+from Modal works. Point it with `target.base_url` in the suite YAML (or the
+`LETTA_BASE_URL` env var, which is auto-forwarded — `target.base_url` wins if
+both are set):
+
+```yaml
+target:
+  kind: letta_code
+  base_url: https://your-letta-server.example.com
+sandbox:
+  kind: modal
+  block_network: false
+```
+
+Depending on where the server runs:
+
+- **Publicly reachable** (cloud VM, load balancer, or a cloudflared/ngrok
+  tunnel in front of it) → set `base_url` to that URL.
+- **Private / on your own machine** → join the sandbox to your network with a
+  mesh VPN. Modal has a first-class Tailscale integration: install Tailscale in
+  a derived image, pass an auth key via a Modal Secret (`sandbox.secrets`),
+  bring it up at startup, and set `base_url` to the server's tailnet name/IP.
+  See [Add Modal Apps to Tailscale](https://modal.com/docs/examples/modal_tailscale).
+- **On Modal** → run letta-server in its own Modal app/sandbox exposed with a
+  tunnel (`encrypted_ports`) and point `base_url` at the tunnel URL.
+
+Modal's built-in tunnels are *inbound* (they expose a port running inside a
+container to the internet), not a reverse tunnel from the sandbox to your
+host's `localhost` — so a local server must be reachable via a mesh VPN or an
+exposed URL, not by pointing at `localhost`.
 
 ## Common failure modes
 

--- a/docs/examples/modal-sandbox/README.md
+++ b/docs/examples/modal-sandbox/README.md
@@ -110,12 +110,10 @@ resolves to a real file under `/mnt/suite/`.
 
 ## Reaching a self-hosted Letta server
 
-By default the sandbox talks to Letta Cloud (`https://api.letta.com`). The
-sandbox runs in Modal's cloud and reaches the server over its normal
-**outbound** network (`block_network: false`), so any Letta endpoint reachable
-from Modal works. Point it with `target.base_url` in the suite YAML (or the
-`LETTA_BASE_URL` env var, which is auto-forwarded — `target.base_url` wins if
-both are set):
+The sandbox reaches the Letta server over its outbound network
+(`block_network: false`, the default), so any endpoint reachable from Modal
+works. Set it via `target.base_url` (or the auto-forwarded `LETTA_BASE_URL`;
+`target.base_url` wins if both are set):
 
 ```yaml
 target:
@@ -126,22 +124,17 @@ sandbox:
   block_network: false
 ```
 
-Depending on where the server runs:
+- **Public URL** (cloud VM / load balancer) → use it directly.
+- **Local / private** → expose it with a tunnel and use that URL, e.g.
+  `cloudflared tunnel --url http://localhost:9005`; or join the sandbox to a
+  mesh VPN ([Modal + Tailscale](https://modal.com/docs/examples/modal_tailscale))
+  and use the tailnet address.
+- **On Modal** → expose letta-server via `encrypted_ports` and use the tunnel URL.
 
-- **Publicly reachable** (cloud VM, load balancer, or a cloudflared/ngrok
-  tunnel in front of it) → set `base_url` to that URL.
-- **Private / on your own machine** → join the sandbox to your network with a
-  mesh VPN. Modal has a first-class Tailscale integration: install Tailscale in
-  a derived image, pass an auth key via a Modal Secret (`sandbox.secrets`),
-  bring it up at startup, and set `base_url` to the server's tailnet name/IP.
-  See [Add Modal Apps to Tailscale](https://modal.com/docs/examples/modal_tailscale).
-- **On Modal** → run letta-server in its own Modal app/sandbox exposed with a
-  tunnel (`encrypted_ports`) and point `base_url` at the tunnel URL.
-
-Modal's built-in tunnels are *inbound* (they expose a port running inside a
-container to the internet), not a reverse tunnel from the sandbox to your
-host's `localhost` — so a local server must be reachable via a mesh VPN or an
-exposed URL, not by pointing at `localhost`.
+Modal tunnels are inbound-only — no reverse tunnel to your host's `localhost`,
+so a local server needs a tunnel or VPN. The server must also be recent enough
+for the image's `@letta-ai/letta-code` CLI; an old one silently fails agent
+creation (`No agent_id found in letta stream output`).
 
 ## Common failure modes
 

--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -67,11 +67,14 @@ logger = logging.getLogger(__name__)
 DEFAULT_MODEL_ID = "default"
 
 # Host env vars auto-forwarded into a Modal sandbox (when present) so the
-# in-sandbox target/graders can authenticate without pre-creating Modal
-# Secrets. Only these explicit names are forwarded — never the whole env.
-# Suite authors extend this via `sandbox.forward_env`. See _run_sample_in_sandbox.
+# in-sandbox target/graders can authenticate and reach the right Letta server
+# without pre-creating Modal Secrets. Only these explicit names are forwarded —
+# never the whole env. LETTA_BASE_URL is forwarded as a convenience but is only
+# used when the suite's target.base_url is unset (target.base_url takes
+# precedence). Suite authors extend this via `sandbox.forward_env`.
 DEFAULT_SANDBOX_FORWARD_ENV = (
     "LETTA_API_KEY",
+    "LETTA_BASE_URL",
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
     "GOOGLE_API_KEY",


### PR DESCRIPTION
## What

- **Forward `LETTA_BASE_URL`** into the sandbox (added to the env-forward allowlist). Used only when the suite's `target.base_url` is unset, so it never overrides an explicit URL.
- **Docs**: concise "Reaching a self-hosted Letta server" section in `docs/examples/modal-sandbox/README.md` — point `base_url` at any Modal-reachable endpoint; for a local/private server use a tunnel (`cloudflared tunnel --url http://localhost:PORT`) or a mesh VPN (Tailscale). Modal tunnels are inbound-only.

Validated end-to-end: a per-sample Modal sandbox drove a laptop-local letta-server through a cloudflared tunnel (two models, graded green). The self-hosted server must be recent enough for the image's `@letta-ai/letta-code` CLI.