### PR TITLE
feat(letta_code_target): Honor factory-injected MEMORY_DIR for run cwd

### DIFF
--- a/letta_evals/targets/letta_code_target.py
+++ b/letta_evals/targets/letta_code_target.py
@@ -114,6 +114,23 @@ class LettaCodeTarget(AbstractAgentTarget):
 
         return env
 
+    def _resolve_run_cwd(self, sample: Sample, agent_id: Optional[str]) -> str:
+        """Resolve the subprocess working directory.
+
+        In ``permission_mode == "memory"`` we cd into the memory root so relative
+        file paths resolve correctly. An agent factory may point memory operations
+        at a different repo than the agent's own MemFS (e.g. a seeded "fake" repo)
+        by injecting ``MEMORY_DIR`` via ``sample.extra_vars`` — honor that path so
+        the subprocess starts in the repo it will actually read/write. Otherwise
+        fall back to the agent's own memory root, or the configured base dir.
+        """
+        if self.permission_mode == "memory" and agent_id:
+            injected_memory_dir = ((sample.extra_vars or {}).get("env") or {}).get("MEMORY_DIR") or (
+                sample.extra_vars or {}
+            ).get("memory_dir")
+            return str(injected_memory_dir or Path.home() / ".letta" / "agents" / agent_id / "memory")
+        return str(self.base_dir)
+
     async def run(
         self,
         sample: Sample,
@@ -194,12 +211,9 @@ class LettaCodeTarget(AbstractAgentTarget):
                 events = []
                 stderr_chunks = []
 
-                # When using memory permission mode, also cd into the agent's
-                # memory root so relative file paths resolve correctly.
-                if self.permission_mode == "memory" and factory_agent_id:
-                    run_cwd = str(Path.home() / ".letta" / "agents" / factory_agent_id / "memory")
-                else:
-                    run_cwd = str(self.base_dir)
+                # Resolve the subprocess cwd (honors a factory-injected MEMORY_DIR
+                # in memory permission mode; see _resolve_run_cwd).
+                run_cwd = self._resolve_run_cwd(sample, factory_agent_id)
 
                 # run the letta command with prompt piped via stdin
                 #

--- a/tests/test_letta_code_target_env_overrides.py
+++ b/tests/test_letta_code_target_env_overrides.py
@@ -190,3 +190,46 @@ def test_build_env_does_not_mutate_os_environ(tmp_path):
 
     # The injected key must NOT have leaked into the process's actual environment.
     assert "NEW_TEST_VAR" not in os.environ
+
+
+# --- _resolve_run_cwd ------------------------------------------------------
+
+
+def test_run_cwd_defaults_to_base_dir_without_memory_mode(tmp_path):
+    target = _make_target(tmp_path)
+    sample = _make_sample()
+
+    assert target._resolve_run_cwd(sample, agent_id="agent-abc") == str(tmp_path)
+
+
+def test_run_cwd_uses_agent_memory_root_in_memory_mode(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    target = _make_target(tmp_path, permission_mode="memory")
+    sample = _make_sample()
+
+    expected = str(Path(tmp_path) / ".letta" / "agents" / "agent-abc" / "memory")
+    assert target._resolve_run_cwd(sample, agent_id="agent-abc") == expected
+
+
+def test_run_cwd_honors_injected_memory_dir_env(tmp_path):
+    target = _make_target(tmp_path, permission_mode="memory")
+    fake = str(tmp_path / "fake" / "repo")
+    sample = _make_sample(extra_vars={"env": {"MEMORY_DIR": fake}})
+
+    assert target._resolve_run_cwd(sample, agent_id="agent-abc") == fake
+
+
+def test_run_cwd_honors_injected_memory_dir_non_env_key(tmp_path):
+    target = _make_target(tmp_path, permission_mode="memory")
+    fake = str(tmp_path / "fake" / "repo")
+    sample = _make_sample(extra_vars={"memory_dir": fake})
+
+    assert target._resolve_run_cwd(sample, agent_id="agent-abc") == fake
+
+
+def test_run_cwd_without_agent_id_uses_base_dir(tmp_path):
+    target = _make_target(tmp_path, permission_mode="memory")
+    sample = _make_sample(extra_vars={"env": {"MEMORY_DIR": str(tmp_path / "x")}})
+
+    # No agent id -> cannot be in memory-cwd mode, fall back to base dir.
+    assert target._resolve_run_cwd(sample, agent_id=None) == str(tmp_path)


### PR DESCRIPTION
## Summary
- Memory-mode subprocess cwd now honors a factory-injected `MEMORY_DIR` (from `sample.extra_vars["env"]["MEMORY_DIR"]`, falling back to the non-env `memory_dir` key), so the process starts in the repo it actually reads/writes.
- Falls back to the agent`s own memory root, then the configured working dir, preserving existing behavior.
- Extracts the cwd logic into a testable `_resolve_run_cwd` helper and adds unit tests.

## Test plan
- [x] `pytest tests/test_letta_code_target_env_overrides.py` (20 passed, incl. 5 new `_resolve_run_cwd` tests)

👾 Generated with [Letta Code](https://letta.com)