### PR TITLE
feat(token-data): Preserve model input token data

### DIFF
--- a/letta_evals/models/results.py
+++ b/letta_evals/models/results.py
@@ -55,6 +55,10 @@ class TurnTokenData(BaseModel):
 
     role: str = Field(description="Message role: assistant, tool, tool_call, tool_return, etc.")
     content: Optional[str] = Field(default=None, description="Text content of this message")
+    input_ids: Optional[List[int]] = Field(
+        default=None,
+        description="Exact token IDs used as the model input/prefix for this generation",
+    )
     output_ids: Optional[List[int]] = Field(
         default=None, description="Token IDs produced by the model for this message"
     )

--- a/letta_evals/targets/letta_agent.py
+++ b/letta_evals/targets/letta_agent.py
@@ -231,11 +231,13 @@ class LettaAgentTarget(AbstractAgentTarget):
                 )
                 for msg in messages:
                     output_ids = getattr(msg, "output_ids", None)
+                    input_ids = getattr(msg, "input_ids", None)
                     output_token_logprobs = getattr(msg, "output_token_logprobs", None)
                     if output_ids:
                         token_data.append(
                             TurnTokenData(
                                 role=getattr(msg, "role", "assistant"),
+                                input_ids=input_ids,
                                 output_ids=output_ids,
                                 output_token_logprobs=output_token_logprobs,
                             )

--- a/letta_evals/targets/letta_code_target.py
+++ b/letta_evals/targets/letta_code_target.py
@@ -391,6 +391,7 @@ class LettaCodeTarget(AbstractAgentTarget):
                         token_data.append(
                             TurnTokenData(
                                 role=role,
+                                input_ids=turn.get("input_ids"),
                                 output_ids=output_ids,
                                 output_token_logprobs=turn.get("output_token_logprobs"),
                             )

--- a/tests/test_runner_token_data.py
+++ b/tests/test_runner_token_data.py
@@ -160,6 +160,7 @@ def test_t0_3_sample_result_validates_with_token_data_populated():
         TurnTokenData(
             role="assistant_message",
             content="hello",
+            input_ids=[100, 101],
             output_ids=[1, 2, 3],
             output_token_logprobs=[(-0.1,), (-0.2,), (-0.3,)],
         )
@@ -173,6 +174,7 @@ def test_t0_3_sample_result_validates_with_token_data_populated():
         token_data=token_data,
     )
     assert result.token_data == token_data
+    assert result.token_data[0].input_ids == [100, 101]
     assert result.token_data[0].output_ids == [1, 2, 3]
 
 
@@ -190,11 +192,19 @@ def test_t0_3_sample_result_round_trips_through_pydantic():
         submissions={"acc": "x"},
         grades={"acc": GradeResult(score=1.0)},
         timing=Timing(total=0.0, target=0.0),
-        token_data=[TurnTokenData(role="tool_call_message", content="t", output_ids=[9, 10])],
+        token_data=[
+            TurnTokenData(
+                role="tool_call_message",
+                content="t",
+                input_ids=[7, 8],
+                output_ids=[9, 10],
+            )
+        ],
     )
     dumped = original.model_dump()
     revived = SampleResult.model_validate(dumped)
     assert revived.token_data is not None
+    assert revived.token_data[0].input_ids == [7, 8]
     assert revived.token_data[0].output_ids == [9, 10]
 
 


### PR DESCRIPTION
## Summary
- Add optional input token IDs to target token data records.
- Preserve input token IDs when fetching token metadata from Letta-backed targets.
- Extend token-data round-trip tests to cover input token IDs.

## Test plan
- [x] uv run pytest tests/test_runner_token_data.py -q
- [x] Live metadata fetch verified against a local Letta server

👾 Generated with [Letta Code](https://letta.com)