### PR TITLE
fix(sandbox): Repair letta-code simple edit e2e

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Configure Modal
         if: matrix.suite-path == 'examples/letta-code-simple-edit/suite.yaml'
         env:
-          MODAL_TOKEN_ID: ${{ vars.MODAL_TOKEN_ID || secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: |
           test -n "$MODAL_TOKEN_ID" || (echo "MODAL_TOKEN_ID is not configured" >&2; exit 1)

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -81,6 +81,8 @@ jobs:
           LETTA_PROJECT_ID: ${{ secrets.LETTA_PROJECT_ID }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: |
           .venv/bin/pytest tests/test_examples_e2e_live.py::test_single_suite \
             --suite-path=${{ github.workspace }}/${{ matrix.suite-path }} \

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -75,14 +75,21 @@ jobs:
         run: |
           uv sync --extra dev
 
+      - name: Configure Modal
+        if: matrix.suite-path == 'examples/letta-code-simple-edit/suite.yaml'
+        env:
+          MODAL_TOKEN_ID: ${{ vars.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: |
+          printf '[letta]\ntoken_id = "%s"\ntoken_secret = "%s"\nactive = true\nenvironment = "main"\nimage_builder_version = "2025.06"\n' \
+            "$MODAL_TOKEN_ID" "$MODAL_TOKEN_SECRET" > ~/.modal.toml
+
       - name: Run e2e test for ${{ matrix.suite-path }}
         env:
           LETTA_API_KEY: ${{ secrets.LETTA_API_KEY }}
           LETTA_PROJECT_ID: ${{ secrets.LETTA_PROJECT_ID }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: |
           .venv/bin/pytest tests/test_examples_e2e_live.py::test_single_suite \
             --suite-path=${{ github.workspace }}/${{ matrix.suite-path }} \

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -78,9 +78,11 @@ jobs:
       - name: Configure Modal
         if: matrix.suite-path == 'examples/letta-code-simple-edit/suite.yaml'
         env:
-          MODAL_TOKEN_ID: ${{ vars.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_ID: ${{ vars.MODAL_TOKEN_ID || secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: |
+          test -n "$MODAL_TOKEN_ID" || (echo "MODAL_TOKEN_ID is not configured" >&2; exit 1)
+          test -n "$MODAL_TOKEN_SECRET" || (echo "MODAL_TOKEN_SECRET is not configured" >&2; exit 1)
           printf '[letta]\ntoken_id = "%s"\ntoken_secret = "%s"\nactive = true\nenvironment = "main"\nimage_builder_version = "2025.06"\n' \
             "$MODAL_TOKEN_ID" "$MODAL_TOKEN_SECRET" > ~/.modal.toml
 

--- a/letta_evals/sandbox/Dockerfile
+++ b/letta_evals/sandbox/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
 
 # letta-evals provides the in-sandbox `letta-evals run --sample ...` entrypoint.
 # letta-client is its Letta SDK dependency.
-RUN pip install --no-cache-dir letta-evals letta-client
+RUN pip install --no-cache-dir --upgrade "letta-evals>=0.19.0" letta-client
 
 # letta-code is the agent harness invoked by the LettaCodeTarget.
 # Install globally so the `letta` CLI is on $PATH inside the sandbox.

--- a/letta_evals/sandbox/Dockerfile
+++ b/letta_evals/sandbox/Dockerfile
@@ -26,8 +26,7 @@ RUN apt-get update \
 
 # letta-evals provides the in-sandbox `letta-evals run --sample ...` entrypoint.
 # letta-client is its Letta SDK dependency.
-RUN pip install --no-cache-dir letta-evals letta-client \
-    && pip install --no-cache-dir --upgrade --force-reinstall typing_extensions==4.15.0
+RUN pip install --no-cache-dir letta-evals letta-client
 
 # letta-code is the agent harness invoked by the LettaCodeTarget.
 # Install globally so the `letta` CLI is on $PATH inside the sandbox.

--- a/letta_evals/sandbox/Dockerfile
+++ b/letta_evals/sandbox/Dockerfile
@@ -26,7 +26,9 @@ RUN apt-get update \
 
 # letta-evals provides the in-sandbox `letta-evals run --sample ...` entrypoint.
 # letta-client is its Letta SDK dependency.
-RUN pip install --no-cache-dir letta-evals letta-client
+RUN pip install --no-cache-dir letta-evals letta-client \
+    && pip install --no-cache-dir --upgrade --force-reinstall typing_extensions==4.15.0 \
+    && python -c "import typing_extensions; assert hasattr(typing_extensions, 'Sentinel')"
 
 # letta-code is the agent harness invoked by the LettaCodeTarget.
 # Install globally so the `letta` CLI is on $PATH inside the sandbox.

--- a/letta_evals/sandbox/Dockerfile
+++ b/letta_evals/sandbox/Dockerfile
@@ -27,8 +27,7 @@ RUN apt-get update \
 # letta-evals provides the in-sandbox `letta-evals run --sample ...` entrypoint.
 # letta-client is its Letta SDK dependency.
 RUN pip install --no-cache-dir letta-evals letta-client \
-    && pip install --no-cache-dir --upgrade --force-reinstall typing_extensions==4.15.0 \
-    && python -c "import typing_extensions; assert hasattr(typing_extensions, 'Sentinel')"
+    && pip install --no-cache-dir --upgrade --force-reinstall typing_extensions==4.15.0
 
 # letta-code is the agent harness invoked by the LettaCodeTarget.
 # Install globally so the `letta` CLI is on $PATH inside the sandbox.


### PR DESCRIPTION
## Summary
- Configure Modal for the live E2E job by writing `~/.modal.toml` from `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET` secrets
- Require `letta-evals>=0.19.0` in the default Modal sandbox image so the in-sandbox CLI supports `letta-evals run --sample ... --output-json ...`

## Test plan
- [x] `/home/devanshjain/evals/.venv/bin/ruff check .`
- [x] `/home/devanshjain/evals/.venv/bin/ruff format --check .`
- [x] `PYTHONPATH=. /home/devanshjain/evals/.venv/bin/pytest tests/test_modal_sandbox.py -q`

👾 Generated with [Letta Code](https://letta.com)
