### PR TITLE
refactor(models): Standardize model handle naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Letta Evals provides Python decorators for extending the framework:
 - **@suite_setup**: Run initialization code before evaluation starts. Supports three signatures:
   - `() -> None` - Run once at the start with no parameters
   - `(client: AsyncLetta) -> None` - Run once at the start with client access
-  - `(client: AsyncLetta, model_name: str) -> None` - Run once per model when evaluating multiple models (useful for model-specific setup like creating isolated working directories)
+  - `(client: AsyncLetta, model_handle: str) -> None` - Run once per model when evaluating multiple models (useful for model-specific setup like creating isolated working directories)
 
 See [`examples/custom-tool-grader-and-extractor/`](examples/custom-tool-grader-and-extractor/) for implementation examples.
 
@@ -201,7 +201,7 @@ See [`examples/custom-tool-grader-and-extractor/`](examples/custom-tool-grader-a
       - anthropic/claude-sonnet-4-5-20250929
       - gpt-5-low
   ```
-  The framework automatically creates isolated working directories for each model to prevent interference between concurrent evaluations. When combined with `@suite_setup` functions that accept `model_name`, you can perform model-specific initialization for each evaluation run.
+  The framework automatically creates isolated working directories for each model to prevent interference between concurrent evaluations. When combined with `@suite_setup` functions that accept `model_handle`, you can perform model-specific initialization for each evaluation run.
 
 **Can I use this in CI/CD pipelines?**
 

--- a/examples/letta-code-simple-edit/README.md
+++ b/examples/letta-code-simple-edit/README.md
@@ -28,7 +28,7 @@ This ensures each test starts with the original buggy code.
 **Note:** The `@suite_setup` decorator supports three signatures:
 - `() -> None` - No parameters (shown above)
 - `(client: AsyncLetta) -> None` - With client access
-- `(client: AsyncLetta, model_name: str) -> None` - With client and model name (runs once per model when testing multiple models)
+- `(client: AsyncLetta, model_handle: str) -> None` - With client and model handle (runs once per model when testing multiple models)
 
 ### 2. Evaluation Phase
 

--- a/examples/programmatic-agent-creation/README.md
+++ b/examples/programmatic-agent-creation/README.md
@@ -70,7 +70,7 @@ async def prepare_evaluation(client: AsyncLetta) -> None:
 - Supports three signatures:
   - `() -> None` - No parameters
   - `(client: AsyncLetta) -> None` - With client (shown above)
-  - `(client: AsyncLetta, model_name: str) -> None` - With client and model name (runs once per model when testing multiple models)
+  - `(client: AsyncLetta, model_handle: str) -> None` - With client and model handle (runs once per model when testing multiple models)
 
 ### Step 2: Agent Factory (`create_agent.py:create_inventory_agent`)
 

--- a/letta_evals/decorators.py
+++ b/letta_evals/decorators.py
@@ -196,7 +196,7 @@ def suite_setup(func: Callable) -> Callable:
     Supports three signatures:
     - async () -> None (no parameters)
     - async (client: AsyncLetta) -> None (with client parameter)
-    - async (client: AsyncLetta, model_name: str) -> None (with client and model_name parameters)
+    - async (client: AsyncLetta, model_handle: str) -> None (with client and model_handle parameters)
     Also supports sync versions of all three.
 
     Usage:
@@ -211,16 +211,16 @@ def suite_setup(func: Callable) -> Callable:
             pass
 
         @suite_setup
-        async def prepare_evaluation_with_model(client: AsyncLetta, model_name: str) -> None:
-            # perform setup operations with client and model_name
-            print(f"Setting up for model: {model_name}")
+        async def prepare_evaluation_with_model(client: AsyncLetta, model_handle: str) -> None:
+            # perform setup operations with client and model_handle
+            print(f"Setting up for model: {model_handle}")
     """
     sig = inspect.signature(func)
     params = list(sig.parameters.values())
 
     if len(params) not in (0, 1, 2):
         raise TypeError(
-            f"Suite setup {func.__name__} must have 0, 1, or 2 parameters (client, model_name), got {len(params)}"
+            f"Suite setup {func.__name__} must have 0, 1, or 2 parameters (client, model_handle), got {len(params)}"
         )
 
     if len(params) == 1:
@@ -229,9 +229,9 @@ def suite_setup(func: Callable) -> Callable:
             raise TypeError(f"Suite setup {func.__name__} must have parameter named 'client', got {param_names}")
     elif len(params) == 2:
         param_names = [p.name for p in params]
-        if param_names != ["client", "model_name"]:
+        if param_names != ["client", "model_handle"]:
             raise TypeError(
-                f"Suite setup {func.__name__} must have parameters named 'client' and 'model_name', got {param_names}"
+                f"Suite setup {func.__name__} must have parameters named 'client' and 'model_handle', got {param_names}"
             )
 
     if sig.return_annotation != inspect.Signature.empty:

--- a/letta_evals/models/results.py
+++ b/letta_evals/models/results.py
@@ -75,7 +75,7 @@ class TargetResult(BaseModel):
         description="List of conversation turns, each containing Letta messages"
     )
     agent_id: str = Field(description="ID of the agent that generated this trajectory")
-    model_name: str = Field(description="Model configuration name used for this target")
+    model_handle: str = Field(description="Model handle used for this target")
     agent_usage: Optional[List[dict]] = Field(
         default=None, description="Usage statistics emitted by the agent during the run"
     )

--- a/letta_evals/pricing.py
+++ b/letta_evals/pricing.py
@@ -200,12 +200,12 @@ def load_pricing_table() -> Dict[str, ModelPricing]:
     return _PRICING
 
 
-def _candidate_keys(model_name: str) -> List[str]:
-    """Generate the ordered list of litellm keys to probe for a Letta model name."""
-    candidates: List[str] = [model_name]
+def _candidate_keys(model_handle: str) -> List[str]:
+    """Generate the ordered list of litellm keys to probe for a Letta model handle."""
+    candidates: List[str] = [model_handle]
 
-    if "/" in model_name:
-        provider, model_part = model_name.split("/", 1)
+    if "/" in model_handle:
+        provider, model_part = model_handle.split("/", 1)
         prefixes = _PROVIDER_CANDIDATES.get(provider, [""])
         for prefix in prefixes:
             candidates.append(f"{prefix}{model_part}")
@@ -217,11 +217,11 @@ def _candidate_keys(model_name: str) -> List[str]:
     else:
         # No provider prefix - try each known pattern based on the leading token
         for marker, prefixes in _BARE_NAME_PROVIDERS.items():
-            if model_name.startswith(marker):
+            if model_handle.startswith(marker):
                 for prefix in prefixes:
-                    candidates.append(f"{prefix}{model_name}")
-                    stripped = _DATE_PATTERN.sub("", model_name)
-                    if stripped != model_name:
+                    candidates.append(f"{prefix}{model_handle}")
+                    stripped = _DATE_PATTERN.sub("", model_handle)
+                    if stripped != model_handle:
                         candidates.append(f"{prefix}{stripped}")
                 break
 
@@ -235,27 +235,27 @@ def _candidate_keys(model_name: str) -> List[str]:
     return deduped
 
 
-def resolve_model(model_name: str) -> Optional[ModelPricing]:
-    """Resolve a Letta-style model name to a ModelPricing entry, or None if unknown.
+def resolve_model(model_handle: str) -> Optional[ModelPricing]:
+    """Resolve a Letta-style model handle to a ModelPricing entry, or None if unknown.
 
     Resolution order:
         1. ``MODEL_PRICE_OVERRIDES`` exact match.
         2. Strip effort suffix (-low, -medium, -high, -xhigh, -max) and recurse.
         3. Try provider-prefix candidates against the litellm JSON.
     """
-    if not model_name:
+    if not model_handle:
         return None
 
-    if model_name in MODEL_PRICE_OVERRIDES:
-        return MODEL_PRICE_OVERRIDES[model_name]
+    if model_handle in MODEL_PRICE_OVERRIDES:
+        return MODEL_PRICE_OVERRIDES[model_handle]
 
     # Strip effort suffix and try again (recursively, once)
-    stripped = _EFFORT_PATTERN.sub("", model_name)
-    if stripped != model_name:
+    stripped = _EFFORT_PATTERN.sub("", model_handle)
+    if stripped != model_handle:
         return resolve_model(stripped)
 
     table = load_pricing_table()
-    for candidate in _candidate_keys(model_name):
+    for candidate in _candidate_keys(model_handle):
         if candidate in table:
             return table[candidate]
 
@@ -319,14 +319,14 @@ def _bill_record(
     return non_cached * in_rate + cached * cache_read_rate + cache_write * cache_create_rate + completion * out_rate
 
 
-def calculate_cost_from_agent_usage(model_name: str, agent_usage: Optional[List[dict]]) -> float:
+def calculate_cost_from_agent_usage(model_handle: str, agent_usage: Optional[List[dict]]) -> float:
     """Calculate total cost from agent_usage data.
 
     Bills cache reads, cache writes, and tiered (>200k context) pricing per LLM
     call, using rates from the litellm pricing JSON.
 
     Args:
-        model_name: Name of the model
+        model_handle: Name of the model
         agent_usage: List of usage statistics from the agent run
 
     Returns:
@@ -336,9 +336,9 @@ def calculate_cost_from_agent_usage(model_name: str, agent_usage: Optional[List[
     if not agent_usage:
         return 0.0
 
-    pricing = resolve_model(model_name)
+    pricing = resolve_model(model_handle)
     if pricing is None:
-        logger.debug(f"No pricing information available for model: {model_name}")
+        logger.debug(f"No pricing information available for model: {model_handle}")
         return 0.0
 
     total_cost = 0.0

--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -245,7 +245,7 @@ class Runner:
 
     # ── setup ──
 
-    async def _run_setup(self, model_name: Optional[str] = None) -> None:
+    async def _run_setup(self, model_handle: Optional[str] = None) -> None:
         if not self.suite.setup_script:
             return
 
@@ -257,20 +257,20 @@ class Runner:
             param_count = getattr(setup_func, "_suite_setup_param_count", 1)
 
             log_msg = f"Running setup script: {self.suite.setup_script}"
-            if model_name and param_count == 2:
-                log_msg += f" for model: {model_name}"
+            if model_handle and param_count == 2:
+                log_msg += f" for model: {model_handle}"
             logger.info(log_msg)
 
             if inspect.iscoroutinefunction(setup_func):
                 if param_count == 2:
-                    await setup_func(self.client, model_name)
+                    await setup_func(self.client, model_handle)
                 elif param_count == 1:
                     await setup_func(self.client)
                 else:
                     await setup_func()
             else:
                 if param_count == 2:
-                    setup_func(self.client, model_name)
+                    setup_func(self.client, model_handle)
                 elif param_count == 1:
                     setup_func(self.client)
                 else:
@@ -307,7 +307,7 @@ class Runner:
         Optional[AgentState],
         Optional[list],
     ]:
-        """Return (trajectory, agent_id, model_name, agent_usage, agent_state, token_data)."""
+        """Return (trajectory, agent_id, model_handle, agent_usage, agent_state, token_data)."""
         sample_id = sample.id
 
         if self.cached_results:
@@ -324,7 +324,7 @@ class Runner:
             if cached_result is not None:
                 if self.progress_callback:
                     await self.progress_callback.agent_created(
-                        sample_id, agent_id=cached_result.agent_id, model_name=model_handle, from_cache=True
+                        sample_id, agent_id=cached_result.agent_id, model_handle=model_handle, from_cache=True
                     )
                 return (
                     cached_result.trajectory,
@@ -346,7 +346,7 @@ class Runner:
         return (
             target_result.trajectory,
             target_result.agent_id,
-            target_result.model_name,
+            target_result.model_handle,
             target_result.agent_usage,
             target_result.agent_state,
             target_result.token_data,
@@ -363,7 +363,7 @@ class Runner:
         grader_key: str,
         sample_id: SampleId,
         agent_id: str,
-        model_name: str,
+        model_handle: str,
     ) -> tuple[GradeResult, str]:
         """Grade each turn independently and return averaged GradeResult + combined submission."""
         ground_truths = sample.ground_truth  # type: List[str]
@@ -406,7 +406,7 @@ class Runner:
                     turn_score=turn_grade.score,
                     grader_key=grader_key,
                     agent_id=agent_id,
-                    model_name=model_name,
+                    model_handle=model_handle,
                 )
 
         turn_scores = [g.score for g in per_turn_grades]
@@ -436,7 +436,7 @@ class Runner:
         agent_state: Optional[AgentState],
         sample_id: SampleId,
         agent_id: str,
-        model_name: str,
+        model_handle: str,
     ) -> tuple[Dict[str, GradeResult], Dict[str, str], Dict[str, float]]:
         """Grade a sample across all graders. Returns (grades, submissions, per_grader_time)."""
         grades_dict: Dict[str, GradeResult] = {}
@@ -450,7 +450,7 @@ class Runner:
 
             if is_per_turn:
                 grade, submission = await self._grade_per_turn(
-                    sample, trajectory, agent_state, grader, key, sample_id, agent_id, model_name
+                    sample, trajectory, agent_state, grader, key, sample_id, agent_id, model_handle
                 )
             else:
                 grade, submission = await grader.grade(sample, trajectory, agent_state=agent_state)
@@ -786,7 +786,7 @@ class Runner:
             t_sample_start = time.perf_counter()
             try:  # noqa: SIM105 — outer try/finally for agent cleanup
                 if self.progress_callback:
-                    await self.progress_callback.sample_started(sample_id, model_name=model_handle)
+                    await self.progress_callback.sample_started(sample_id, model_handle=model_handle)
 
                 if self.suite.sandbox is not None:
                     result = await self._run_sample_in_sandbox(sample, model_handle, return_token_data, t_sample_start)
@@ -801,7 +801,7 @@ class Runner:
                                 sample_id,
                                 result.error.message,
                                 agent_id=result.agent_id,
-                                model_name=model_handle,
+                                model_handle=model_handle,
                                 target_cost=cost,
                             )
                         else:
@@ -814,7 +814,7 @@ class Runner:
                                 agent_id=result.agent_id,
                                 score=primary_score,
                                 target_cost=cost,
-                                model_name=model_handle,
+                                model_handle=model_handle,
                                 metric_scores=metric_scores,
                                 rationale=primary_rationale,
                                 metric_rationales=metric_rationales,
@@ -826,7 +826,7 @@ class Runner:
                 (
                     trajectory,
                     agent_id,
-                    model_name,
+                    model_handle,
                     agent_usage,
                     agent_state,
                     token_data,
@@ -837,18 +837,20 @@ class Runner:
                     return_token_data=return_token_data,
                 )
 
-                cost = calculate_cost_from_agent_usage(model_name, agent_usage) if model_name else None
+                cost = calculate_cost_from_agent_usage(model_handle, agent_usage) if model_handle else None
                 prompt_tokens, completion_tokens, cached_input_tokens, cache_write_tokens, reasoning_tokens = (
                     extract_token_counts(agent_usage)
                 )
                 target_time = time.perf_counter() - t_sample_start
 
                 if self.progress_callback:
-                    await self.progress_callback.grading_started(sample_id, agent_id=agent_id, model_name=model_name)
+                    await self.progress_callback.grading_started(
+                        sample_id, agent_id=agent_id, model_handle=model_handle
+                    )
 
                 phase = ErrorCategory.GRADING
                 grades_dict, submissions_dict, per_grader_time = await self._grade_sample(
-                    sample, trajectory, agent_state, sample_id, agent_id, model_name
+                    sample, trajectory, agent_state, sample_id, agent_id, model_handle
                 )
 
                 error = self._detect_errors(grades_dict, trajectory, submissions_dict)
@@ -860,7 +862,7 @@ class Runner:
                         sample_id,
                         error.message,
                         agent_id=agent_id,
-                        model_name=model_name,
+                        model_handle=model_handle,
                         target_cost=cost if cost and cost > 0 else None,
                     )
 
@@ -872,7 +874,7 @@ class Runner:
                         agent_id=agent_id,
                         score=primary_score,
                         target_cost=cost if cost and cost > 0 else None,
-                        model_name=model_name,
+                        model_handle=model_handle,
                         metric_scores=metric_scores,
                         rationale=primary_rationale,
                         metric_rationales=metric_rationales,
@@ -923,10 +925,10 @@ class Runner:
                     exception_type=type(cause).__name__,
                     message=error_message,
                 )
-                result_model_name = locals().get("model_name") or model_handle
+                result_model_handle = locals().get("model_handle") or model_handle
                 cost = (
-                    calculate_cost_from_agent_usage(result_model_name, agent_usage)
-                    if result_model_name and agent_usage
+                    calculate_cost_from_agent_usage(result_model_handle, agent_usage)
+                    if result_model_handle and agent_usage
                     else None
                 )
                 prompt_tokens, completion_tokens, cached_input_tokens, cache_write_tokens, reasoning_tokens = (
@@ -937,7 +939,7 @@ class Runner:
                         sample_id,
                         error_message,
                         agent_id=agent_id,
-                        model_name=result_model_name,
+                        model_handle=result_model_handle,
                         target_cost=cost if cost and cost > 0 else None,
                     )
                 usage = _build_usage(
@@ -1017,7 +1019,7 @@ class Runner:
         For multi-run mode the orchestrator (``_execute_runs``) constructs a
         Runner per run and shares one StreamingWriter across them.
         """
-        # Setup-once (when setup doesn't need model_name).
+        # Setup-once (when setup doesn't need model_handle).
         setup_needs_model = False
         if self.suite.setup_script:
             setup_func = load_object(self.suite.setup_script, self.suite.base_dir)
@@ -1054,7 +1056,7 @@ class Runner:
             async with anyio.create_task_group() as tg:
                 for model_handle in self.model_handles:
                     if setup_needs_model:
-                        await self._run_setup(model_name=model_handle)
+                        await self._run_setup(model_handle=model_handle)
 
                     model_id = _model_id_for(model_handle)
 

--- a/letta_evals/targets/letta_code_target.py
+++ b/letta_evals/targets/letta_code_target.py
@@ -169,7 +169,7 @@ class LettaCodeTarget(AbstractAgentTarget):
                     logger.info(f"Created agent {factory_agent_id} via agent_factory for sample {sample.id}")
                     if progress_callback:
                         await progress_callback.agent_created(
-                            sample.id, agent_id=factory_agent_id, model_name=self.model_handle
+                            sample.id, agent_id=factory_agent_id, model_handle=self.model_handle
                         )
 
                 # construct prompt after factory call so agent_factory can modify sample if needed
@@ -257,11 +257,11 @@ class LettaCodeTarget(AbstractAgentTarget):
                                     logger.info(f"Captured agent_id {agent_id} from stream init event")
                                     if progress_callback and agent_id:
                                         await progress_callback.agent_created(
-                                            sample.id, agent_id=agent_id, model_name=self.model_handle
+                                            sample.id, agent_id=agent_id, model_handle=self.model_handle
                                         )
                                 if progress_callback and agent_id:
                                     await progress_callback.message_sending(
-                                        sample.id, 1, len(inputs), agent_id=agent_id, model_name=self.model_handle
+                                        sample.id, 1, len(inputs), agent_id=agent_id, model_handle=self.model_handle
                                     )
                         except json.JSONDecodeError:
                             logger.warning(f"Non-JSON stream output: {line[:200]}")
@@ -340,7 +340,7 @@ class LettaCodeTarget(AbstractAgentTarget):
                 return TargetResult(
                     trajectory=trajectory,
                     agent_id=agent_id,
-                    model_name=self.model_handle,
+                    model_handle=self.model_handle,
                     agent_usage=usage_stats if usage_stats else None,
                     agent_state=agent_state,
                     token_data=token_data,

--- a/letta_evals/visualization/base.py
+++ b/letta_evals/visualization/base.py
@@ -35,13 +35,13 @@ class ProgressCallback(ABC):
 
     @abstractmethod
     async def sample_started(
-        self, sample_id: SampleId, agent_id: Optional[str] = None, model_name: Optional[str] = None
+        self, sample_id: SampleId, agent_id: Optional[str] = None, model_handle: Optional[str] = None
     ) -> None:
         """Called when a sample evaluation starts."""
         ...
 
     async def agent_created(
-        self, sample_id: SampleId, agent_id: str, model_name: Optional[str] = None, from_cache: bool = False
+        self, sample_id: SampleId, agent_id: str, model_handle: Optional[str] = None, from_cache: bool = False
     ) -> None:
         """Called when an agent has been created/provisioned or resolved from cache.
 
@@ -55,13 +55,13 @@ class ProgressCallback(ABC):
         message_num: int,
         total_messages: int,
         agent_id: Optional[str] = None,
-        model_name: Optional[str] = None,
+        model_handle: Optional[str] = None,
     ) -> None:
         """Called when sending messages to the agent."""
         pass
 
     async def grading_started(
-        self, sample_id: SampleId, agent_id: Optional[str] = None, model_name: Optional[str] = None
+        self, sample_id: SampleId, agent_id: Optional[str] = None, model_handle: Optional[str] = None
     ) -> None:
         """Called when grading of a sample begins."""
         pass
@@ -74,7 +74,7 @@ class ProgressCallback(ABC):
         turn_score: float,
         grader_key: Optional[str] = None,
         agent_id: Optional[str] = None,
-        model_name: Optional[str] = None,
+        model_handle: Optional[str] = None,
     ) -> None:
         """Called when a single turn is graded in per-turn evaluation mode."""
         pass
@@ -86,7 +86,7 @@ class ProgressCallback(ABC):
         agent_id: Optional[str] = None,
         score: Optional[float] = None,
         target_cost: Optional[float] = None,
-        model_name: Optional[str] = None,
+        model_handle: Optional[str] = None,
         metric_scores: Optional[Dict[str, float]] = None,
         rationale: Optional[str] = None,
         metric_rationales: Optional[Dict[str, str]] = None,
@@ -100,7 +100,7 @@ class ProgressCallback(ABC):
         sample_id: SampleId,
         error: str,
         agent_id: Optional[str] = None,
-        model_name: Optional[str] = None,
+        model_handle: Optional[str] = None,
         target_cost: Optional[float] = None,
     ) -> None:
         """Called when a sample evaluation encounters an error."""

--- a/letta_evals/visualization/noop_progress.py
+++ b/letta_evals/visualization/noop_progress.py
@@ -10,7 +10,7 @@ class NoOpProgress(ProgressCallback):
     """No-output progress callback (silent)."""
 
     async def sample_started(
-        self, sample_id: SampleId, agent_id: Optional[str] = None, model_name: Optional[str] = None
+        self, sample_id: SampleId, agent_id: Optional[str] = None, model_handle: Optional[str] = None
     ) -> None:
         pass
 
@@ -20,7 +20,7 @@ class NoOpProgress(ProgressCallback):
         agent_id: Optional[str] = None,
         score: Optional[float] = None,
         target_cost: Optional[float] = None,
-        model_name: Optional[str] = None,
+        model_handle: Optional[str] = None,
         metric_scores: Optional[Dict[str, float]] = None,
         rationale: Optional[str] = None,
         metric_rationales: Optional[Dict[str, str]] = None,
@@ -32,7 +32,7 @@ class NoOpProgress(ProgressCallback):
         sample_id: SampleId,
         error: str,
         agent_id: Optional[str] = None,
-        model_name: Optional[str] = None,
+        model_handle: Optional[str] = None,
         target_cost: Optional[float] = None,
     ) -> None:
         pass

--- a/letta_evals/visualization/reducer.py
+++ b/letta_evals/visualization/reducer.py
@@ -53,35 +53,35 @@ class ProgressStateReducer:
         sample_id: SampleId,
         *,
         agent_id: Optional[str] = None,
-        model_name: Optional[str] = None,
+        model_handle: Optional[str] = None,
     ) -> SampleProgress:
-        key = (sample_id, model_name)
+        key = (sample_id, model_handle)
 
-        if model_name is not None:
+        if model_handle is not None:
             old_key = (sample_id, None)
             if old_key in self.state.samples and key not in self.state.samples:
                 self.state.samples[key] = self.state.samples.pop(old_key)
-                self.state.samples[key].model_name = model_name
+                self.state.samples[key].model_handle = model_handle
 
         if key not in self.state.samples:
-            self.state.samples[key] = SampleProgress(sample_id, agent_id=agent_id, model_name=model_name)
+            self.state.samples[key] = SampleProgress(sample_id, agent_id=agent_id, model_handle=model_handle)
 
         sample = self.state.samples[key]
         if agent_id is not None and sample.agent_id != agent_id:
             sample.agent_id = agent_id
-        if model_name is not None and sample.model_name != model_name:
-            sample.model_name = model_name
+        if model_handle is not None and sample.model_handle != model_handle:
+            sample.model_handle = model_handle
         return sample
 
-    def get_from_cache(self, sample_id: SampleId, model_name: Optional[str] = None) -> bool:
-        sample = self.get_sample(sample_id, model_name)
+    def get_from_cache(self, sample_id: SampleId, model_handle: Optional[str] = None) -> bool:
+        sample = self.get_sample(sample_id, model_handle)
         return sample.from_cache if sample is not None else False
 
-    def get_sample(self, sample_id: SampleId, model_name: Optional[str] = None) -> Optional[SampleProgress]:
-        key = (sample_id, model_name)
+    def get_sample(self, sample_id: SampleId, model_handle: Optional[str] = None) -> Optional[SampleProgress]:
+        key = (sample_id, model_handle)
         if key in self.state.samples:
             return self.state.samples[key]
-        if model_name is not None:
+        if model_handle is not None:
             return self.state.samples.get((sample_id, None))
         return None
 
@@ -94,9 +94,9 @@ class ProgressStateReducer:
         turn_score: float,
         grader_key: Optional[str] = None,
         agent_id: Optional[str] = None,
-        model_name: Optional[str] = None,
+        model_handle: Optional[str] = None,
     ) -> SampleProgress:
-        sample = self.ensure_sample(sample_id, agent_id=agent_id, model_name=model_name)
+        sample = self.ensure_sample(sample_id, agent_id=agent_id, model_handle=model_handle)
         if sample.turn_scores is None:
             sample.turn_scores = {}
 
@@ -119,11 +119,11 @@ class ProgressStateReducer:
         sample_id: SampleId,
         state: SampleState,
         agent_id: Optional[str] = None,
-        model_name: Optional[str] = None,
+        model_handle: Optional[str] = None,
         **kwargs,
     ) -> ReducerResult:
         """Apply a state transition inside the single-threaded reducer."""
-        sample = self.ensure_sample(sample_id, agent_id=agent_id, model_name=model_name)
+        sample = self.ensure_sample(sample_id, agent_id=agent_id, model_handle=model_handle)
         previous_state = sample.state
         sample.state = state
 

--- a/letta_evals/visualization/rich_progress.py
+++ b/letta_evals/visualization/rich_progress.py
@@ -117,7 +117,7 @@ class EvalProgress(ProgressCallback):
         )
 
         # initialize samples placeholder - actual entries will be created as evaluations start
-        # no longer pre-populate since we need model_name for the key
+        # no longer pre-populate since we need model_handle for the key
 
         self.live = Live(
             console=self.console,
@@ -249,7 +249,7 @@ class EvalProgress(ProgressCallback):
         sample_id: SampleId,
         state: SampleState,
         agent_id: Optional[str] = None,
-        model_name: Optional[str] = None,
+        model_handle: Optional[str] = None,
         **kwargs,
     ):
         """Queue a state transition for the reducer task."""
@@ -258,27 +258,27 @@ class EvalProgress(ProgressCallback):
             sample_id=sample_id,
             state=state,
             agent_id=agent_id,
-            model_name=model_name,
+            model_handle=model_handle,
             **kwargs,
         )
 
     async def sample_started(
-        self, sample_id: SampleId, agent_id: Optional[str] = None, model_name: Optional[str] = None
+        self, sample_id: SampleId, agent_id: Optional[str] = None, model_handle: Optional[str] = None
     ):
         """Mark sample as started"""
-        self._reducer.ensure_sample(sample_id, agent_id=agent_id, model_name=model_name)
+        self._reducer.ensure_sample(sample_id, agent_id=agent_id, model_handle=model_handle)
         # skip loading state if using cached trajectories
         if not self.cached_mode:
             await self.update_sample_state(
-                sample_id, SampleState.LOADING_AGENT, agent_id=agent_id, model_name=model_name
+                sample_id, SampleState.LOADING_AGENT, agent_id=agent_id, model_handle=model_handle
             )
 
     async def agent_created(
-        self, sample_id: SampleId, agent_id: str, model_name: Optional[str] = None, from_cache: bool = False
+        self, sample_id: SampleId, agent_id: str, model_handle: Optional[str] = None, from_cache: bool = False
     ):
         """Update sample with agent_id once agent is provisioned."""
         await self.update_sample_state(
-            sample_id, SampleState.LOADING_AGENT, agent_id=agent_id, model_name=model_name, from_cache=from_cache
+            sample_id, SampleState.LOADING_AGENT, agent_id=agent_id, model_handle=model_handle, from_cache=from_cache
         )
 
     async def message_sending(
@@ -287,26 +287,26 @@ class EvalProgress(ProgressCallback):
         message_num: int,
         total_messages: int,
         agent_id: Optional[str] = None,
-        model_name: Optional[str] = None,
+        model_handle: Optional[str] = None,
     ):
         """Update message sending progress"""
         await self.update_sample_state(
             sample_id,
             SampleState.SENDING_MESSAGES,
             agent_id=agent_id,
-            model_name=model_name,
+            model_handle=model_handle,
             messages_sent=message_num,
             total_messages=total_messages,
         )
 
     async def grading_started(
-        self, sample_id: SampleId, agent_id: Optional[str] = None, model_name: Optional[str] = None
+        self, sample_id: SampleId, agent_id: Optional[str] = None, model_handle: Optional[str] = None
     ):
         """Mark sample as being graded"""
-        existing_from_cache = self._reducer.get_from_cache(sample_id, model_name)
+        existing_from_cache = self._reducer.get_from_cache(sample_id, model_handle)
 
         await self.update_sample_state(
-            sample_id, SampleState.GRADING, agent_id=agent_id, model_name=model_name, from_cache=existing_from_cache
+            sample_id, SampleState.GRADING, agent_id=agent_id, model_handle=model_handle, from_cache=existing_from_cache
         )
 
     async def turn_graded(
@@ -317,7 +317,7 @@ class EvalProgress(ProgressCallback):
         turn_score: float,
         grader_key: Optional[str] = None,
         agent_id: Optional[str] = None,
-        model_name: Optional[str] = None,
+        model_handle: Optional[str] = None,
     ):
         """Update progress for per-turn grading"""
         sample = self._reducer.record_turn_grade(
@@ -327,14 +327,14 @@ class EvalProgress(ProgressCallback):
             turn_score=turn_score,
             grader_key=grader_key,
             agent_id=agent_id,
-            model_name=model_name,
+            model_handle=model_handle,
         )
 
         await self.update_sample_state(
             sample_id,
             SampleState.GRADING_TURNS,
             agent_id=agent_id,
-            model_name=model_name,
+            model_handle=model_handle,
             from_cache=sample.from_cache,
             turns_graded=turn_num + 1,  # turn_num is 0-indexed
             total_turns=total_turns,
@@ -346,19 +346,19 @@ class EvalProgress(ProgressCallback):
         agent_id: Optional[str] = None,
         score: Optional[float] = None,
         target_cost: Optional[float] = None,
-        model_name: Optional[str] = None,
+        model_handle: Optional[str] = None,
         metric_scores: Optional[Dict[str, float]] = None,
         rationale: Optional[str] = None,
         metric_rationales: Optional[Dict[str, str]] = None,
     ):
         """Mark sample as completed"""
-        existing_from_cache = self._reducer.get_from_cache(sample_id, model_name)
+        existing_from_cache = self._reducer.get_from_cache(sample_id, model_handle)
 
         await self.update_sample_state(
             sample_id,
             SampleState.COMPLETED,
             agent_id=agent_id,
-            model_name=model_name,
+            model_handle=model_handle,
             score=score,
             target_cost=target_cost,
             rationale=rationale,
@@ -372,7 +372,7 @@ class EvalProgress(ProgressCallback):
         sample_id: SampleId,
         error: str,
         agent_id: Optional[str] = None,
-        model_name: Optional[str] = None,
+        model_handle: Optional[str] = None,
         target_cost: Optional[float] = None,
     ):
         """Mark sample as having an error"""
@@ -380,7 +380,7 @@ class EvalProgress(ProgressCallback):
             sample_id,
             SampleState.ERROR,
             agent_id=agent_id,
-            model_name=model_name,
+            model_handle=model_handle,
             error=error,
             target_cost=target_cost,
         )

--- a/letta_evals/visualization/rich_renderer.py
+++ b/letta_evals/visualization/rich_renderer.py
@@ -87,7 +87,7 @@ class RichProgressRenderer:
     ) -> List[SampleProgress]:
         """Select only currently active rows for the live top panel."""
         rows = [sample for sample in runtime_state.samples.values() if is_active_state(sample.state)]
-        rows.sort(key=lambda sample: (sample.model_name or "", _sample_id_sort_key(sample.sample_id)))
+        rows.sort(key=lambda sample: (sample.model_handle or "", _sample_id_sort_key(sample.sample_id)))
         if limit is None:
             return rows
         return rows[:limit]
@@ -100,7 +100,7 @@ class RichProgressRenderer:
         rows.sort(
             key=lambda sample: (
                 -get_last_update_key(sample),
-                sample.model_name or "",
+                sample.model_handle or "",
                 _sample_id_sort_key(sample.sample_id),
             )
         )
@@ -412,7 +412,7 @@ class RichProgressRenderer:
             row_data = [
                 sample_num,
                 sample.agent_id or "-",
-                sample.model_name or "-",
+                sample.model_handle or "-",
             ]
             row_data.extend([self._get_state_text(sample), *cells, time_text, details])
             table.add_row(*row_data)

--- a/letta_evals/visualization/simple_progress.py
+++ b/letta_evals/visualization/simple_progress.py
@@ -45,16 +45,16 @@ class SimpleProgress(ProgressCallback):
         """Reset state for a new run."""
 
     async def sample_started(
-        self, sample_id: SampleId, agent_id: Optional[str] = None, model_name: Optional[str] = None
+        self, sample_id: SampleId, agent_id: Optional[str] = None, model_handle: Optional[str] = None
     ) -> None:
-        model_text = f" [dim]({model_name})[/]" if model_name else ""
+        model_text = f" [dim]({model_handle})[/]" if model_handle else ""
         agent_text = f" [dim]agent={agent_id}[/]" if agent_id else ""
         self.console.print(f"[bold cyan]▸ Sample [{sample_id}]{model_text}{agent_text}[/]")
 
     async def agent_created(
-        self, sample_id: SampleId, agent_id: str, model_name: Optional[str] = None, from_cache: bool = False
+        self, sample_id: SampleId, agent_id: str, model_handle: Optional[str] = None, from_cache: bool = False
     ) -> None:
-        prefix = self._format_prefix(sample_id, agent_id, model_name)
+        prefix = self._format_prefix(sample_id, agent_id, model_handle)
         cache_text = " [dim](cached)[/]" if from_cache else ""
         self.console.print(f"{prefix} [dim]•[/] Agent created{cache_text}")
 
@@ -64,15 +64,15 @@ class SimpleProgress(ProgressCallback):
         message_num: int,
         total_messages: int,
         agent_id: Optional[str] = None,
-        model_name: Optional[str] = None,
+        model_handle: Optional[str] = None,
     ) -> None:
-        prefix = self._format_prefix(sample_id, agent_id, model_name)
+        prefix = self._format_prefix(sample_id, agent_id, model_handle)
         self.console.print(f"{prefix} [dim]•[/] Sending messages {message_num}/{total_messages}")
 
     async def grading_started(
-        self, sample_id: SampleId, agent_id: Optional[str] = None, model_name: Optional[str] = None
+        self, sample_id: SampleId, agent_id: Optional[str] = None, model_handle: Optional[str] = None
     ) -> None:
-        prefix = self._format_prefix(sample_id, agent_id, model_name)
+        prefix = self._format_prefix(sample_id, agent_id, model_handle)
         self.console.print(f"{prefix} [dim]•[/] Grading...")
 
     async def sample_completed(
@@ -81,12 +81,12 @@ class SimpleProgress(ProgressCallback):
         agent_id: Optional[str] = None,
         score: Optional[float] = None,
         target_cost: Optional[float] = None,
-        model_name: Optional[str] = None,
+        model_handle: Optional[str] = None,
         metric_scores: Optional[Dict[str, float]] = None,
         rationale: Optional[str] = None,
         metric_rationales: Optional[Dict[str, str]] = None,
     ) -> None:
-        prefix = self._format_prefix(sample_id, agent_id, model_name)
+        prefix = self._format_prefix(sample_id, agent_id, model_handle)
         status = "[bold cyan]✓ DONE[/]"
         parts = [f"{prefix} {status}"]
 
@@ -104,10 +104,10 @@ class SimpleProgress(ProgressCallback):
         sample_id: SampleId,
         error: str,
         agent_id: Optional[str] = None,
-        model_name: Optional[str] = None,
+        model_handle: Optional[str] = None,
         target_cost: Optional[float] = None,
     ) -> None:
-        prefix = self._format_prefix(sample_id, agent_id, model_name)
+        prefix = self._format_prefix(sample_id, agent_id, model_handle)
         self.console.print(f"{prefix} [bold yellow]⚠ ERROR[/]: {error}")
 
     async def suite_completed(self, result):
@@ -132,11 +132,11 @@ class SimpleProgress(ProgressCallback):
         self.console.print(build_simple_sample_results_table(suite_spec, displayed_rows))
         print_remaining_samples_notice(self.console, total_samples, len(displayed_rows))
 
-    def _format_prefix(self, sample_id: SampleId, agent_id: Optional[str], model_name: Optional[str]) -> str:
+    def _format_prefix(self, sample_id: SampleId, agent_id: Optional[str], model_handle: Optional[str]) -> str:
         """format a compact prefix for substeps to show which sample they belong to."""
         parts = [f"[dim]\\[[/][cyan]{sample_id}[/][dim]][/]"]
-        if model_name:
-            parts.append(f"[dim]({model_name})[/]")
+        if model_handle:
+            parts.append(f"[dim]({model_handle})[/]")
         if agent_id:
             parts.append(f"[dim]agent={agent_id}[/]")
         return "".join(parts)

--- a/letta_evals/visualization/state.py
+++ b/letta_evals/visualization/state.py
@@ -43,7 +43,7 @@ class SampleProgress:
     sample_id: SampleId
     state: SampleState = SampleState.QUEUED
     agent_id: Optional[str] = None
-    model_name: Optional[str] = None
+    model_handle: Optional[str] = None
     score: Optional[float] = None
     target_cost: Optional[float] = None
     rationale: Optional[str] = None

--- a/tests/test_rich_renderer.py
+++ b/tests/test_rich_renderer.py
@@ -77,7 +77,7 @@ def test_model_judge_renderer_moves_rubric_model_into_header_and_uses_fixed_colu
         sample_id=0,
         state=SampleState.COMPLETED,
         agent_id="agent-with-a-very-long-id",
-        model_name="target-model-with-a-long-name",
+        model_handle="target-model-with-a-long-name",
         metric_scores={"accuracy": 1.0},
         metric_rationales={"accuracy": "This is a deliberately long rationale that should be truncated by Rich."},
         rationale="unused",

--- a/tests/test_runner_token_data.py
+++ b/tests/test_runner_token_data.py
@@ -98,7 +98,7 @@ def _make_target_result(
     return TargetResult(
         trajectory=[[]],
         agent_id="agent-fake-1",
-        model_name="fake/model",
+        model_handle="fake/model",
         agent_usage=None,
         agent_state=agent_state,
         run_ids=None,

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -190,7 +190,7 @@ class TestSingleRun:
 
     @pytest.mark.asyncio
     async def test_safe_segment_for_slash_in_model(self):
-        """Model names with slashes are sanitised to filenames."""
+        """Model handles with slashes are sanitised to filenames."""
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = Path(tmpdir)
             writer = StreamingWriter(

--- a/tests/test_visualization_reducer.py
+++ b/tests/test_visualization_reducer.py
@@ -64,20 +64,20 @@ def test_duplicate_terminal_updates_do_not_double_count_target_cost() -> None:
     assert reducer.state.total_target_cost == 0.02
 
 
-def test_ensure_sample_migrates_placeholder_when_model_name_arrives() -> None:
+def test_ensure_sample_migrates_placeholder_when_model_handle_arrives() -> None:
     reducer = ProgressStateReducer(ProgressRuntimeState())
     reducer.ensure_sample(2, agent_id="agent-1")
 
-    sample = reducer.ensure_sample(2, agent_id="agent-1", model_name="gpt-5")
+    sample = reducer.ensure_sample(2, agent_id="agent-1", model_handle="gpt-5")
 
     assert (2, None) not in reducer.state.samples
     assert reducer.state.samples[(2, "gpt-5")] is sample
-    assert sample.model_name == "gpt-5"
+    assert sample.model_handle == "gpt-5"
 
 
 def test_get_from_cache_checks_model_specific_and_placeholder_entries() -> None:
     reducer = ProgressStateReducer(ProgressRuntimeState())
-    reducer.ensure_sample(3, model_name=None).from_cache = True
+    reducer.ensure_sample(3, model_handle=None).from_cache = True
 
     assert reducer.get_from_cache(3, None) is True
     assert reducer.get_from_cache(3, "gpt-5") is True
@@ -94,9 +94,9 @@ def test_record_turn_grade_initializes_and_updates_turn_scores() -> None:
         turn_score=0.8,
         grader_key="safety",
         agent_id="agent-4",
-        model_name="gpt-5",
+        model_handle="gpt-5",
     )
 
     assert sample.agent_id == "agent-4"
-    assert sample.model_name == "gpt-5"
+    assert sample.model_handle == "gpt-5"
     assert sample.turn_scores == {"safety": [None, 0.8, None]}


### PR DESCRIPTION
## Summary
- Rename target result, runner, pricing, and progress callback plumbing from `model_name` to `model_handle`
- Update `@suite_setup` to use `model_handle` as the two-argument setup parameter
- Refresh docs and tests to match suite `model_handles` terminology

## Test plan
- [x] `/home/devanshjain/evals/.venv/bin/ruff format --check .`
- [x] `/home/devanshjain/evals/.venv/bin/ruff check .`
- [x] `/home/devanshjain/evals/.venv/bin/python -m pytest -q`

👾 Generated with [Letta Code](https://letta.com)