### PR TITLE
chore(cleanup): Remove stale migration checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,19 +211,6 @@ See [`examples/custom-tool-grader-and-extractor/`](examples/custom-tool-grader-a
 
 Contributions are welcome! If you have an interesting eval or feature, please submit an issue or contact us on [Discord](https://discord.gg/letta).
 
-## Migration note: `letta_agent` target removal
-
-`target.kind: letta_agent` has been removed. Use the Letta Code target for all target execution:
-
-```yaml
-target:
-  kind: letta_code
-  model_handles:
-    - openai/gpt-4.1-mini
-```
-
-Suites that previously used `agent_id` or `agent_file` on the target must migrate to `letta_code`. If you need per-sample setup or seeded agent state, use `agent_script` with an `@agent_factory` function that returns the agent ID for Letta Code to run with.
-
 ## License
 
 This project is licensed under the MIT License. By contributing to evals, you are agreeing to make your evaluation logic and data under the same MIT license as this repository. You must have adequate rights to upload any data used in an eval. Letta reserves the right to use this data in future service improvements to our product.

--- a/tests/test_modal_sandbox.py
+++ b/tests/test_modal_sandbox.py
@@ -112,20 +112,6 @@ class TestModalSandboxSpec:
 
 
 class TestSuiteSpecWithSandbox:
-    def test_legacy_agent_target_kind_is_rejected(self):
-        yaml_data = _minimal_suite_yaml()
-        yaml_data["target"] = {"kind": "letta" + "_agent", "agent_id": "agent-test"}
-
-        with pytest.raises(ValueError):
-            SuiteSpec.from_yaml(yaml_data)
-
-    def test_legacy_agent_file_target_field_is_rejected(self):
-        yaml_data = _minimal_suite_yaml()
-        yaml_data["target"]["agent_file"] = "agent.af"
-
-        with pytest.raises(ValueError):
-            SuiteSpec.from_yaml(yaml_data)
-
     def test_sandbox_absent_keeps_field_none(self):
         yaml_data = _minimal_suite_yaml()
         del yaml_data["sandbox"]


### PR DESCRIPTION
## Summary
- Remove the obsolete README migration note for the old `letta_agent` target
- Delete legacy target rejection tests for `letta_agent` and `agent_file`
- Clean local pycache artifacts from the worktree; none were tracked

## Test plan
- [x] `/home/devanshjain/evals/.venv/bin/ruff format --check .`
- [x] `/home/devanshjain/evals/.venv/bin/ruff check .`
- [x] `/home/devanshjain/evals/.venv/bin/python -m pytest -q`

👾 Generated with [Letta Code](https://letta.com)