### PR TITLE
refactor(targets): Simplify letta_code target spec

### DIFF
--- a/letta_evals/__init__.py
+++ b/letta_evals/__init__.py
@@ -23,7 +23,6 @@ from letta_evals.models import (
     SuiteSpec,
     Summary,
     TargetResult,
-    TargetSpec,
     Timing,
     TimingStats,
     TurnTokenData,
@@ -39,7 +38,6 @@ from letta_evals.types import (
     LLMProvider,
     LogicalOp,
     MetricOp,
-    TargetKind,
 )
 from letta_evals.visualization.factory import ProgressStyle, create_progress_callback
 
@@ -78,9 +76,7 @@ __all__ = [
     "SampleResult",
     "Summary",
     "SuiteSpec",
-    "TargetKind",
     "TargetResult",
-    "TargetSpec",
     "Timing",
     "TimingStats",
     "ToolGrader",

--- a/letta_evals/models/__init__.py
+++ b/letta_evals/models/__init__.py
@@ -33,7 +33,6 @@ from letta_evals.models.results import (
 from letta_evals.models.sample import Sample, SampleId
 from letta_evals.models.specs import (
     BaseGraderSpec,
-    BaseTargetSpec,
     GateSpec,
     GraderSpec,
     LettaCodeTargetSpec,
@@ -44,7 +43,6 @@ from letta_evals.models.specs import (
     SimpleCondition,
     SimpleGateSpec,
     SuiteSpec,
-    TargetSpec,
     ToolGraderSpec,
     WeightedAverageGateSpec,
     _compare,
@@ -66,9 +64,7 @@ __all__ = [
     "Sample",
     "SampleId",
     # specs — targets
-    "BaseTargetSpec",
     "LettaCodeTargetSpec",
-    "TargetSpec",
     # specs — graders
     "BaseGraderSpec",
     "ToolGraderSpec",

--- a/letta_evals/models/specs.py
+++ b/letta_evals/models/specs.py
@@ -19,18 +19,17 @@ from letta_evals.types import (
     LLMProvider,
     LogicalOp,
     MetricOp,
-    TargetKind,
 )
 
-# Target specs
+# Target spec
 
 
-class BaseTargetSpec(BaseModel):
-    """Base target configuration with common fields."""
+class LettaCodeTargetSpec(BaseModel):
+    """Letta code target configuration."""
 
     model_config = ConfigDict(extra="forbid")
 
-    kind: TargetKind = Field(description="Type of target")
+    kind: Literal["letta_code"] = "letta_code"
     base_url: str = Field(default="http://localhost:8283", description="Letta server URL")
     api_key: Optional[str] = Field(default=None, description="API key for authentication")
     timeout: float = Field(default=300.0, description="Request timeout in seconds")
@@ -49,12 +48,6 @@ class BaseTargetSpec(BaseModel):
     # internal field for path resolution
     base_dir: Optional[Path] = Field(default=None, exclude=True)
 
-
-class LettaCodeTargetSpec(BaseTargetSpec):
-    """Letta code target configuration."""
-
-    kind: Literal[TargetKind.LETTA_CODE] = TargetKind.LETTA_CODE
-
     allowed_tools: Optional[List[str]] = Field(
         default=None, description="List of allowed tools for letta code (e.g., ['Bash', 'Read'])"
     )
@@ -68,9 +61,6 @@ class LettaCodeTargetSpec(BaseTargetSpec):
         default=None,
         description="Permission mode for letta code (e.g., 'memory' to scope writes to memory roots).",
     )
-
-
-TargetSpec = LettaCodeTargetSpec
 
 
 # Sandbox specs
@@ -333,7 +323,7 @@ class SuiteSpec(BaseModel):
     name: str = Field(description="Name of the evaluation suite")
     description: Optional[str] = Field(default=None, description="Description of what this suite evaluates")
     dataset: Path = Field(description="Path to JSONL dataset file")
-    target: TargetSpec = Field(description="Target configuration")
+    target: LettaCodeTargetSpec = Field(description="Target configuration")
     graders: Optional[Dict[str, GraderSpec]] = Field(default=None, description="Multiple graders keyed by metric name")
     gate: GateSpec = Field(description="Pass/fail criteria for avg_score (required)")
 

--- a/letta_evals/types.py
+++ b/letta_evals/types.py
@@ -1,10 +1,6 @@
 from enum import Enum
 
 
-class TargetKind(str, Enum):
-    LETTA_CODE = "letta_code"
-
-
 class GraderKind(str, Enum):
     TOOL = "tool"
     MODEL_JUDGE = "model_judge"

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -9,7 +9,7 @@ from letta_evals.models import (
     SuiteSpec,
     ToolGraderSpec,
 )
-from letta_evals.types import GateKind, GraderKind, MetricOp, TargetKind
+from letta_evals.types import GateKind, GraderKind, MetricOp
 
 
 def _make_suite(target_spec, cleanup: bool = False) -> SuiteSpec:
@@ -30,20 +30,20 @@ def _make_suite(target_spec, cleanup: bool = False) -> SuiteSpec:
 class TestSuiteSpecCleanupField:
     def test_defaults_to_false(self):
         suite = _make_suite(
-            LettaCodeTargetSpec(kind=TargetKind.LETTA_CODE, model_handles=["openai/gpt-4.1-mini"]),
+            LettaCodeTargetSpec(model_handles=["openai/gpt-4.1-mini"]),
         )
         assert suite.cleanup is False
 
     def test_explicit_true(self):
         suite = _make_suite(
-            LettaCodeTargetSpec(kind=TargetKind.LETTA_CODE, model_handles=["openai/gpt-4.1-mini"]),
+            LettaCodeTargetSpec(model_handles=["openai/gpt-4.1-mini"]),
             cleanup=True,
         )
         assert suite.cleanup is True
 
     def test_explicit_false(self):
         suite = _make_suite(
-            LettaCodeTargetSpec(kind=TargetKind.LETTA_CODE, model_handles=["openai/gpt-4.1-mini"]),
+            LettaCodeTargetSpec(model_handles=["openai/gpt-4.1-mini"]),
             cleanup=False,
         )
         assert suite.cleanup is False
@@ -67,7 +67,7 @@ class TestShouldCleanupAgent:
 
     def test_cleanup_false_letta_code(self):
         suite = _make_suite(
-            LettaCodeTargetSpec(kind=TargetKind.LETTA_CODE, model_handles=["openai/gpt-4.1-mini"]),
+            LettaCodeTargetSpec(model_handles=["openai/gpt-4.1-mini"]),
             cleanup=False,
         )
         runner = self._make_runner(suite)
@@ -75,7 +75,7 @@ class TestShouldCleanupAgent:
 
     def test_cleanup_true_letta_code(self):
         suite = _make_suite(
-            LettaCodeTargetSpec(kind=TargetKind.LETTA_CODE, model_handles=["openai/gpt-4.1-mini"]),
+            LettaCodeTargetSpec(model_handles=["openai/gpt-4.1-mini"]),
             cleanup=True,
         )
         runner = self._make_runner(suite)
@@ -84,7 +84,6 @@ class TestShouldCleanupAgent:
     def test_cleanup_true_letta_code_agent_script(self):
         suite = _make_suite(
             LettaCodeTargetSpec(
-                kind=TargetKind.LETTA_CODE,
                 agent_script="setup.py:factory",
                 model_handles=["openai/gpt-4.1-mini"],
             ),

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -19,14 +19,14 @@ from letta_evals.models import (
     ToolGraderSpec,
 )
 from letta_evals.streaming import StreamingReader, StreamingWriter
-from letta_evals.types import Aggregation, GateKind, MetricOp, TargetKind
+from letta_evals.types import Aggregation, GateKind, MetricOp
 
 
 def _make_suite() -> SuiteSpec:
     return SuiteSpec(
         name="test-suite",
         dataset="ignored",
-        target=LettaCodeTargetSpec(kind=TargetKind.LETTA_CODE, model_handles=["openai/gpt-4.1-mini"]),
+        target=LettaCodeTargetSpec(model_handles=["openai/gpt-4.1-mini"]),
         graders={"check": ToolGraderSpec(function="exact_match", display_name="Check")},
         gate=SimpleGateSpec(
             kind=GateKind.SIMPLE,

--- a/tests/test_visualization_summary.py
+++ b/tests/test_visualization_summary.py
@@ -16,12 +16,7 @@ from letta_evals.models import (
     ToolGraderSpec,
     Usage,
 )
-from letta_evals.types import (
-    Aggregation,
-    GateKind,
-    MetricOp,
-    TargetKind,
-)
+from letta_evals.types import Aggregation, GateKind, MetricOp
 from letta_evals.visualization.summary import (
     build_rich_sample_results_table,
     build_simple_sample_results_table,
@@ -34,7 +29,7 @@ def _make_suite() -> SuiteSpec:
     return SuiteSpec(
         name="test-suite",
         dataset="ignored",
-        target=LettaCodeTargetSpec(kind=TargetKind.LETTA_CODE, model_handles=["openai/gpt-4.1-mini"]),
+        target=LettaCodeTargetSpec(model_handles=["openai/gpt-4.1-mini"]),
         graders={
             "accuracy": ToolGraderSpec(function="exact_match", display_name="Accuracy"),
             "quality": ToolGraderSpec(function="exact_match", display_name="Quality"),


### PR DESCRIPTION
## Summary
- Collapse `BaseTargetSpec` into `LettaCodeTargetSpec`
- Remove stale `TargetKind` and `TargetSpec` exports now that `letta_code` is the only target
- Update Python-side tests to rely on the default `kind: "letta_code"`

## Compatibility
- Suite YAML remains unchanged: `target.kind: letta_code` continues to parse normally

## Test plan
- [x] `/home/devanshjain/evals/.venv/bin/ruff format --check .`
- [x] `/home/devanshjain/evals/.venv/bin/ruff check .`
- [x] `/home/devanshjain/evals/.venv/bin/python -m pytest -q`

👾 Generated with [Letta Code](https://letta.com)