### PR TITLE
refactor(progress): Pass SampleResult to completion callbacks

### DIFF
--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -362,30 +362,10 @@ class Runner:
                     # not emitted in v1 because the host only sees the final
                     # SampleResult JSON.
                     if self.progress_callback:
-                        cost = result.usage.cost if (result.usage and result.usage.cost) else None
                         if result.error is not None:
-                            await self.progress_callback.sample_error(
-                                sample_id,
-                                result.error.message,
-                                agent_id=result.agent_id,
-                                model_handle=model_handle,
-                                target_cost=cost,
-                            )
+                            await self.progress_callback.sample_error(result, model_handle=model_handle)
                         else:
-                            primary_score = next(iter(result.grades.values())).score if result.grades else 0.0
-                            primary_rationale = next(iter(result.grades.values())).rationale if result.grades else None
-                            metric_scores = {k: v.score for k, v in result.grades.items()}
-                            metric_rationales = {k: (v.rationale or "") for k, v in result.grades.items()}
-                            await self.progress_callback.sample_completed(
-                                sample_id,
-                                agent_id=result.agent_id,
-                                score=primary_score,
-                                target_cost=cost,
-                                model_handle=model_handle,
-                                metric_scores=metric_scores,
-                                rationale=primary_rationale,
-                                metric_rationales=metric_rationales,
-                            )
+                            await self.progress_callback.sample_completed(result, model_handle=model_handle)
                     return result
 
                 phase = ErrorCategory.TARGET
@@ -428,32 +408,6 @@ class Runner:
                 )
 
                 error = detect_errors(grades_dict, trajectory, submissions_dict)
-                primary_score = next(iter(grades_dict.values())).score if grades_dict else 0.0
-                primary_rationale = next(iter(grades_dict.values())).rationale if grades_dict else None
-
-                if error and self.progress_callback:
-                    await self.progress_callback.sample_error(
-                        sample_id,
-                        error.message,
-                        agent_id=agent_id,
-                        model_handle=model_handle,
-                        target_cost=cost if cost and cost > 0 else None,
-                    )
-
-                if error is None and self.progress_callback:
-                    metric_scores = {k: v.score for k, v in grades_dict.items()}
-                    metric_rationales = {k: (v.rationale or "") for k, v in grades_dict.items()}
-                    await self.progress_callback.sample_completed(
-                        sample_id,
-                        agent_id=agent_id,
-                        score=primary_score,
-                        target_cost=cost if cost and cost > 0 else None,
-                        model_handle=model_handle,
-                        metric_scores=metric_scores,
-                        rationale=primary_rationale,
-                        metric_rationales=metric_rationales,
-                    )
-
                 total_time = time.perf_counter() - t_sample_start
                 extraction_time = sum(gr.metadata.get("extraction_time", 0.0) for gr in grades_dict.values())
 
@@ -472,7 +426,7 @@ class Runner:
                     per_grader=per_grader_time if per_grader_time else None,
                 )
 
-                return SampleResult(
+                result = SampleResult(
                     sample_id=sample_id,
                     agent_id=agent_id,
                     trajectory=trajectory,
@@ -485,6 +439,12 @@ class Runner:
                     agent_state=agent_state,
                     token_data=token_data,
                 )
+                if self.progress_callback:
+                    if result.error is not None:
+                        await self.progress_callback.sample_error(result, model_handle=model_handle)
+                    else:
+                        await self.progress_callback.sample_completed(result, model_handle=model_handle)
+                return result
             except Exception as e:
                 if isinstance(e, TargetError) and e.agent_id:
                     agent_id = e.agent_id
@@ -508,14 +468,6 @@ class Runner:
                 prompt_tokens, completion_tokens, cached_input_tokens, cache_write_tokens, reasoning_tokens = (
                     extract_token_counts(agent_usage)
                 )
-                if self.progress_callback:
-                    await self.progress_callback.sample_error(
-                        sample_id,
-                        error_message,
-                        agent_id=agent_id,
-                        model_handle=result_model_handle,
-                        target_cost=cost if cost and cost > 0 else None,
-                    )
                 usage = _build_usage(
                     cost=cost,
                     prompt_tokens=prompt_tokens,
@@ -528,7 +480,7 @@ class Runner:
                     total=time.perf_counter() - t_sample_start,
                     target=0.0,
                 )
-                return SampleResult(
+                result = SampleResult(
                     sample_id=sample_id,
                     agent_id=agent_id,
                     trajectory=[],
@@ -539,6 +491,9 @@ class Runner:
                     error=error,
                     agent_usage=agent_usage,
                 )
+                if self.progress_callback:
+                    await self.progress_callback.sample_error(result, model_handle=result_model_handle)
+                return result
             finally:
                 if self._should_cleanup_agent() and agent_id:
                     try:

--- a/letta_evals/visualization/base.py
+++ b/letta_evals/visualization/base.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Dict, Optional
+from typing import Optional
 
+from letta_evals.models import SampleResult
 from letta_evals.models.sample import SampleId
 
 
@@ -80,28 +81,11 @@ class ProgressCallback(ABC):
         pass
 
     @abstractmethod
-    async def sample_completed(
-        self,
-        sample_id: SampleId,
-        agent_id: Optional[str] = None,
-        score: Optional[float] = None,
-        target_cost: Optional[float] = None,
-        model_handle: Optional[str] = None,
-        metric_scores: Optional[Dict[str, float]] = None,
-        rationale: Optional[str] = None,
-        metric_rationales: Optional[Dict[str, str]] = None,
-    ) -> None:
+    async def sample_completed(self, result: SampleResult, model_handle: Optional[str] = None) -> None:
         """Called when a sample evaluation completes successfully."""
         ...
 
     @abstractmethod
-    async def sample_error(
-        self,
-        sample_id: SampleId,
-        error: str,
-        agent_id: Optional[str] = None,
-        model_handle: Optional[str] = None,
-        target_cost: Optional[float] = None,
-    ) -> None:
+    async def sample_error(self, result: SampleResult, model_handle: Optional[str] = None) -> None:
         """Called when a sample evaluation encounters an error."""
         ...

--- a/letta_evals/visualization/factory.py
+++ b/letta_evals/visualization/factory.py
@@ -40,7 +40,7 @@ def create_progress_callback(
         return NoOpProgress()
 
     if style == ProgressStyle.SIMPLE:
-        return SimpleProgress(suite_name=suite.name, total_samples=total_evaluations, console=console)
+        return SimpleProgress(suite=suite, total_samples=total_evaluations, console=console)
 
     # RICH (default for CLI)
     # Determine grader kind label for header
@@ -59,9 +59,10 @@ def create_progress_callback(
                 break
 
     progress = EvalProgress(
+        suite=suite,
         suite_name=suite.name,
         total_samples=total_evaluations,
-        target_kind=suite.target.kind.value,
+        target_kind=suite.target.kind,
         grader_kind=grader_kind_label,
         rubric_model=rubric_model,
         max_concurrent=max_concurrent,

--- a/letta_evals/visualization/noop_progress.py
+++ b/letta_evals/visualization/noop_progress.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import Dict, Optional
+from typing import Optional
 
+from letta_evals.models import SampleResult
 from letta_evals.models.sample import SampleId
 from letta_evals.visualization.base import ProgressCallback
 
@@ -14,25 +15,8 @@ class NoOpProgress(ProgressCallback):
     ) -> None:
         pass
 
-    async def sample_completed(
-        self,
-        sample_id: SampleId,
-        agent_id: Optional[str] = None,
-        score: Optional[float] = None,
-        target_cost: Optional[float] = None,
-        model_handle: Optional[str] = None,
-        metric_scores: Optional[Dict[str, float]] = None,
-        rationale: Optional[str] = None,
-        metric_rationales: Optional[Dict[str, str]] = None,
-    ) -> None:
+    async def sample_completed(self, result: SampleResult, model_handle: Optional[str] = None) -> None:
         pass
 
-    async def sample_error(
-        self,
-        sample_id: SampleId,
-        error: str,
-        agent_id: Optional[str] = None,
-        model_handle: Optional[str] = None,
-        target_cost: Optional[float] = None,
-    ) -> None:
+    async def sample_error(self, result: SampleResult, model_handle: Optional[str] = None) -> None:
         pass

--- a/letta_evals/visualization/progress_fields.py
+++ b/letta_evals/visualization/progress_fields.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from letta_evals.models import GateSpec, SampleResult, compute_gate_score
+
+
+@dataclass(frozen=True)
+class SampleProgressFields:
+    """Display fields derived from a completed SampleResult."""
+
+    score: float
+    target_cost: Optional[float]
+    rationale: Optional[str]
+    metric_scores: dict[str, float]
+    metric_rationales: dict[str, str]
+
+
+def sample_progress_fields(gate: GateSpec, result: SampleResult) -> SampleProgressFields:
+    """Build visualization fields from the SampleResult source of truth."""
+    metric_scores = {key: grade.score for key, grade in result.grades.items()}
+    metric_rationales = {key: (grade.rationale or "") for key, grade in result.grades.items()}
+    only_grade = next(iter(result.grades.values())) if len(result.grades) == 1 else None
+    cost = result.usage.cost if result.usage and result.usage.cost and result.usage.cost > 0 else None
+
+    return SampleProgressFields(
+        score=compute_gate_score(gate, metric_scores),
+        target_cost=cost,
+        rationale=only_grade.rationale if only_grade else None,
+        metric_scores=metric_scores,
+        metric_rationales=metric_rationales,
+    )

--- a/letta_evals/visualization/rich_progress.py
+++ b/letta_evals/visualization/rich_progress.py
@@ -17,8 +17,10 @@ from rich.progress import (
 )
 from rich.table import Table
 
+from letta_evals.models import SampleResult
 from letta_evals.models.sample import SampleId
 from letta_evals.visualization.base import ProgressCallback
+from letta_evals.visualization.progress_fields import sample_progress_fields
 from letta_evals.visualization.reducer import ProgressRuntimeState, ProgressStateReducer
 from letta_evals.visualization.rich_renderer import RichProgressRenderer
 from letta_evals.visualization.state import (
@@ -42,6 +44,7 @@ class EvalProgress(ProgressCallback):
 
     def __init__(
         self,
+        suite,
         suite_name: str,
         total_samples: int,
         target_kind: str = "agent",
@@ -53,6 +56,7 @@ class EvalProgress(ProgressCallback):
         cached_mode: bool = False,
         metric_labels: Optional[Dict[str, str]] = None,
     ):
+        self.suite = suite
         self.total_samples = total_samples
         self.console = console or Console()
         self.frame_interval = (1.0 / update_freq) if update_freq > 0 else 0.25
@@ -340,46 +344,32 @@ class EvalProgress(ProgressCallback):
             total_turns=total_turns,
         )
 
-    async def sample_completed(
-        self,
-        sample_id: SampleId,
-        agent_id: Optional[str] = None,
-        score: Optional[float] = None,
-        target_cost: Optional[float] = None,
-        model_handle: Optional[str] = None,
-        metric_scores: Optional[Dict[str, float]] = None,
-        rationale: Optional[str] = None,
-        metric_rationales: Optional[Dict[str, str]] = None,
-    ):
+    async def sample_completed(self, result: SampleResult, model_handle: Optional[str] = None):
         """Mark sample as completed"""
-        existing_from_cache = self._reducer.get_from_cache(sample_id, model_handle)
+        fields = sample_progress_fields(self.suite.gate, result)
+        existing_from_cache = self._reducer.get_from_cache(result.sample_id, model_handle)
 
         await self.update_sample_state(
-            sample_id,
+            result.sample_id,
             SampleState.COMPLETED,
-            agent_id=agent_id,
+            agent_id=result.agent_id,
             model_handle=model_handle,
-            score=score,
-            target_cost=target_cost,
-            rationale=rationale,
+            score=fields.score,
+            target_cost=fields.target_cost,
+            rationale=fields.rationale,
             from_cache=existing_from_cache,
-            metric_scores=metric_scores,
-            metric_rationales=metric_rationales,
+            metric_scores=fields.metric_scores,
+            metric_rationales=fields.metric_rationales,
         )
 
-    async def sample_error(
-        self,
-        sample_id: SampleId,
-        error: str,
-        agent_id: Optional[str] = None,
-        model_handle: Optional[str] = None,
-        target_cost: Optional[float] = None,
-    ):
+    async def sample_error(self, result: SampleResult, model_handle: Optional[str] = None):
         """Mark sample as having an error"""
+        target_cost = result.usage.cost if result.usage and result.usage.cost and result.usage.cost > 0 else None
+        error = result.error.message if result.error else "Unknown error"
         await self.update_sample_state(
-            sample_id,
+            result.sample_id,
             SampleState.ERROR,
-            agent_id=agent_id,
+            agent_id=result.agent_id,
             model_handle=model_handle,
             error=error,
             target_cost=target_cost,

--- a/letta_evals/visualization/simple_progress.py
+++ b/letta_evals/visualization/simple_progress.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import Dict, Optional
+from typing import Optional
 
 from rich.console import Console
 
+from letta_evals.models import SampleResult, SuiteSpec
 from letta_evals.models.sample import SampleId
 from letta_evals.visualization.base import ProgressCallback
+from letta_evals.visualization.progress_fields import sample_progress_fields
 from letta_evals.visualization.summary import (
     build_simple_sample_results_table,
     format_gate_description,
@@ -23,8 +25,9 @@ class SimpleProgress(ProgressCallback):
     evaluation progress easy to scan in logs.
     """
 
-    def __init__(self, suite_name: str, total_samples: int, console: Optional[Console] = None):
-        self.suite_name = suite_name
+    def __init__(self, suite: SuiteSpec, total_samples: int, console: Optional[Console] = None):
+        self.suite = suite
+        self.suite_name = suite.name
         self.total_samples = total_samples
         self.console = console or Console()
 
@@ -75,40 +78,22 @@ class SimpleProgress(ProgressCallback):
         prefix = self._format_prefix(sample_id, agent_id, model_handle)
         self.console.print(f"{prefix} [dim]•[/] Grading...")
 
-    async def sample_completed(
-        self,
-        sample_id: SampleId,
-        agent_id: Optional[str] = None,
-        score: Optional[float] = None,
-        target_cost: Optional[float] = None,
-        model_handle: Optional[str] = None,
-        metric_scores: Optional[Dict[str, float]] = None,
-        rationale: Optional[str] = None,
-        metric_rationales: Optional[Dict[str, str]] = None,
-    ) -> None:
-        prefix = self._format_prefix(sample_id, agent_id, model_handle)
+    async def sample_completed(self, result: SampleResult, model_handle: Optional[str] = None) -> None:
+        fields = sample_progress_fields(self.suite.gate, result)
+        prefix = self._format_prefix(result.sample_id, result.agent_id, model_handle)
         status = "[bold cyan]✓ DONE[/]"
-        parts = [f"{prefix} {status}"]
+        parts = [f"{prefix} {status}", f"score={fields.score:.2f}"]
 
-        if score is not None:
-            parts.append(f"score={score:.2f}")
-
-        if metric_scores:
-            metric_bits = ", ".join(f"{k}={v:.2f}" for k, v in metric_scores.items())
+        if fields.metric_scores:
+            metric_bits = ", ".join(f"{k}={v:.2f}" for k, v in fields.metric_scores.items())
             parts.append(metric_bits)
 
         self.console.print("  ".join(parts))
 
-    async def sample_error(
-        self,
-        sample_id: SampleId,
-        error: str,
-        agent_id: Optional[str] = None,
-        model_handle: Optional[str] = None,
-        target_cost: Optional[float] = None,
-    ) -> None:
-        prefix = self._format_prefix(sample_id, agent_id, model_handle)
-        self.console.print(f"{prefix} [bold yellow]⚠ ERROR[/]: {error}")
+    async def sample_error(self, result: SampleResult, model_handle: Optional[str] = None) -> None:
+        prefix = self._format_prefix(result.sample_id, result.agent_id, model_handle)
+        message = result.error.message if result.error else "Unknown error"
+        self.console.print(f"{prefix} [bold yellow]⚠ ERROR[/]: {message}")
 
     async def suite_completed(self, result):
         """Display summary results after evaluation completes"""

--- a/tests/test_rich_progress.py
+++ b/tests/test_rich_progress.py
@@ -6,8 +6,19 @@ import time
 import pytest
 from rich.console import Console
 
+from letta_evals.models import LettaCodeTargetSpec, SimpleGateSpec, SuiteSpec
 from letta_evals.visualization.rich_progress import EvalProgress
 from letta_evals.visualization.state import SampleState
+
+
+def _suite() -> SuiteSpec:
+    return SuiteSpec(
+        name="demo",
+        dataset="ignored",
+        target=LettaCodeTargetSpec(model_handles=["openai/gpt-4.1-mini"]),
+        graders={},
+        gate=SimpleGateSpec(kind="simple", metric_key="score", aggregation="avg_score", op="gte", value=0.5),
+    )
 
 
 class DummyLive:
@@ -25,6 +36,7 @@ class DummyLive:
 @pytest.mark.asyncio
 async def test_event_loop_batches_burst_updates_into_single_refresh() -> None:
     progress = EvalProgress(
+        suite=_suite(),
         suite_name="demo",
         total_samples=1,
         console=Console(width=120, height=20, force_terminal=False),
@@ -54,6 +66,7 @@ async def test_event_loop_batches_burst_updates_into_single_refresh() -> None:
 @pytest.mark.asyncio
 async def test_stop_flushes_dirty_state_immediately() -> None:
     progress = EvalProgress(
+        suite=_suite(),
         suite_name="demo",
         total_samples=1,
         console=Console(width=120, height=20, force_terminal=False),
@@ -80,6 +93,7 @@ async def test_stop_flushes_dirty_state_immediately() -> None:
 @pytest.mark.asyncio
 async def test_stats_capture_queue_pressure_under_concurrency() -> None:
     progress = EvalProgress(
+        suite=_suite(),
         suite_name="demo",
         total_samples=15,
         console=Console(width=120, height=20, force_terminal=False),
@@ -107,6 +121,7 @@ async def test_stats_capture_queue_pressure_under_concurrency() -> None:
 @pytest.mark.asyncio
 async def test_render_loop_refreshes_timer_without_new_events() -> None:
     progress = EvalProgress(
+        suite=_suite(),
         suite_name="demo",
         total_samples=1,
         console=Console(width=120, height=20, force_terminal=False),


### PR DESCRIPTION
## Summary
- Change `ProgressCallback.sample_completed` and `sample_error` to receive `SampleResult` directly
- Derive visualization display fields from `SampleResult`, including gate-aligned scalar score and per-metric scores/rationales
- Simplify runner progress callback call sites so completion/error events fire after building the `SampleResult`
- Update built-in progress callbacks and tests for the new callback shape

## Test plan
- [x] `/home/devanshjain/evals/.venv/bin/ruff format --check .`
- [x] `/home/devanshjain/evals/.venv/bin/ruff check .`
- [x] `/home/devanshjain/evals/.venv/bin/python -m pytest -q`

👾 Generated with [Letta Code](https://letta.com)