### PR TITLE
fix(token-data): Request chronological Letta Code runs

### DIFF
--- a/letta_evals/targets/letta_code_target.py
+++ b/letta_evals/targets/letta_code_target.py
@@ -374,12 +374,19 @@ class LettaCodeTarget(AbstractAgentTarget):
         token_data: list[TurnTokenData] = []
         try:
             # Fetch ALL runs for this agent — client tools cause each tool-call
-            # round-trip to be a separate run, so token IDs are scattered.
-            runs_page = await self.client.runs.list(agent_id=agent_id, limit=100)
+            # round-trip to be a separate run, so token IDs are scattered. Ask
+            # the API for chronological order so we reconstruct the rollout in
+            # the same order it happened.
+            runs_page = await self.client.runs.list(
+                agent_id=agent_id,
+                limit=100,
+                order_by="created_at",
+                order="asc",
+            )
             if not runs_page.items:
                 return token_data
 
-            # Token IDs are stored in run.metadata.result.turns (populated by SGLang native adapter)
+            # Token IDs are stored in run.metadata.result.turns (populated by SGLang native adapter).
             for run_summary in runs_page.items:
                 run = await self.client.runs.retrieve(run_id=run_summary.id)
                 result = (run.metadata or {}).get("result", {})

--- a/tests/test_letta_code_target_token_data.py
+++ b/tests/test_letta_code_target_token_data.py
@@ -1,0 +1,58 @@
+"""Unit tests for LettaCodeTarget token-data reconstruction."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from letta_evals.targets.letta_code_target import LettaCodeTarget
+
+
+def _run_summary(run_id: str) -> SimpleNamespace:
+    return SimpleNamespace(id=run_id)
+
+
+def _run_with_turn(token_id: int) -> SimpleNamespace:
+    return SimpleNamespace(
+        metadata={
+            "result": {
+                "turns": [
+                    {
+                        "role": "assistant",
+                        "input_ids": [token_id - 1],
+                        "output_ids": [token_id],
+                        "output_token_logprobs": [-0.1],
+                    }
+                ]
+            }
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_token_data_requests_runs_chronologically(tmp_path):
+    """Ask the runs API for oldest-first order before reconstructing token_data."""
+    older = _run_summary("run-older")
+    newer = _run_summary("run-newer")
+
+    client = MagicMock()
+    client.runs.list = AsyncMock(return_value=SimpleNamespace(items=[older, newer]))
+    client.runs.retrieve = AsyncMock(
+        side_effect=lambda *, run_id: {
+            "run-older": _run_with_turn(100),
+            "run-newer": _run_with_turn(200),
+        }[run_id]
+    )
+
+    target = LettaCodeTarget(client=client, model_handle="fake/model", base_dir=tmp_path)
+
+    token_data = await target._fetch_token_data("agent-123")
+
+    client.runs.list.assert_awaited_once_with(
+        agent_id="agent-123",
+        limit=100,
+        order_by="created_at",
+        order="asc",
+    )
+    assert [turn.output_ids for turn in token_data] == [[100], [200]]
+    assert [call.kwargs["run_id"] for call in client.runs.retrieve.await_args_list] == ["run-older", "run-newer"]


### PR DESCRIPTION
## Summary
- request Letta Code runs ordered by `created_at` ascending from the runs API
- preserve chronological token-data reconstruction across CLI/tool round-trip runs
- add a focused unit test covering the SDK-side ordering request

## Tests
- `.venv/bin/python -m pytest tests/test_letta_code_target_token_data.py tests/test_runner_token_data.py`
- `.venv/bin/python -m ruff check letta_evals/targets/letta_code_target.py tests/test_letta_code_target_token_data.py`

Branch was created from `letta-evals-v0.19.0` for the `0.19.0post1` maintenance fix.