### PR TITLE
fix(targets): Fetch token-data runs oldest-first for sequence extension

### DIFF
--- a/letta_evals/targets/letta_code_target.py
+++ b/letta_evals/targets/letta_code_target.py
@@ -4,7 +4,7 @@ import logging
 import os
 import shlex
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import anyio
 from letta_client import AsyncLetta
@@ -77,6 +77,25 @@ class LettaCodeTarget:
         # suite.sandbox (Modal), which runs the in-sandbox CLI from /mnt/suite.
         self.base_dir = base_dir or Path.cwd()
         self.flags = shlex.split(flags) if flags else []
+
+    @staticmethod
+    def _run_sort_key(run_summary: Any) -> tuple[str, str]:
+        """Return a stable chronological sort key for run summaries.
+
+        Letta server defaults for ``runs.list`` have varied across local
+        development branches. Token data must be processed oldest-to-newest so
+        Tinker sequence-extension can merge consecutive assistant generations.
+        Normalize timestamps to strings so mixed SDK/server timestamp types do
+        not make sorting fail.
+        """
+        created_at = getattr(run_summary, "created_at", None)
+        if hasattr(created_at, "isoformat"):
+            created_key = created_at.isoformat()
+        elif created_at is None:
+            created_key = ""
+        else:
+            created_key = str(created_at)
+        return created_key, str(getattr(run_summary, "id", ""))
 
     def _build_subprocess_env(self, sample: Sample, agent_id: Optional[str]) -> dict[str, str]:
         """Build subprocess env: os.environ -> target-managed -> sample.extra_vars["env"]."""
@@ -375,12 +394,17 @@ class LettaCodeTarget:
         try:
             # Fetch ALL runs for this agent — client tools cause each tool-call
             # round-trip to be a separate run, so token IDs are scattered.
-            runs_page = await self.client.runs.list(agent_id=agent_id, limit=100)
+            try:
+                runs_page = await self.client.runs.list(agent_id=agent_id, limit=100, order="asc")
+            except TypeError:
+                # Older generated clients may not expose the ``order`` kwarg.
+                # Fall back to the legacy call and sort locally below.
+                runs_page = await self.client.runs.list(agent_id=agent_id, limit=100)
             if not runs_page.items:
                 return token_data
 
             # Token IDs are stored in run.metadata.result.turns (populated by SGLang native adapter)
-            for run_summary in runs_page.items:
+            for run_summary in sorted(runs_page.items, key=self._run_sort_key):
                 run = await self.client.runs.retrieve(run_id=run_summary.id)
                 result = (run.metadata or {}).get("result", {})
                 for turn in result.get("turns") or []:

--- a/tests/test_letta_code_target_token_data.py
+++ b/tests/test_letta_code_target_token_data.py
@@ -1,0 +1,104 @@
+"""Unit tests for LettaCodeTarget token-data fetching."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from letta_evals.targets.letta_code_target import LettaCodeTarget
+
+
+class _FakeRuns:
+    def __init__(self, *, items, runs_by_id, reject_order: bool = False):
+        self.items = items
+        self.runs_by_id = runs_by_id
+        self.reject_order = reject_order
+        self.list_calls = []
+        self.retrieve_ids = []
+
+    async def list(self, **kwargs):
+        self.list_calls.append(kwargs)
+        if self.reject_order and "order" in kwargs:
+            raise TypeError("list() got an unexpected keyword argument 'order'")
+        return SimpleNamespace(items=self.items)
+
+    async def retrieve(self, *, run_id):
+        self.retrieve_ids.append(run_id)
+        return self.runs_by_id[run_id]
+
+
+def _run_summary(run_id: str, created_at: datetime):
+    return SimpleNamespace(id=run_id, created_at=created_at)
+
+
+def _run_with_turns(*turns):
+    return SimpleNamespace(metadata={"result": {"turns": list(turns)}})
+
+
+def _assistant_turn(input_ids, output_ids):
+    return {
+        "role": "assistant",
+        "input_ids": input_ids,
+        "output_ids": output_ids,
+        "output_token_logprobs": [[-0.1, token_id, None] for token_id in output_ids],
+    }
+
+
+def _tool_turn(content="tool output"):
+    return {"role": "tool", "content": content}
+
+
+def _make_target(fake_runs: _FakeRuns) -> LettaCodeTarget:
+    return LettaCodeTarget(
+        client=SimpleNamespace(runs=fake_runs),
+        model_handle="tinker/Qwen/Qwen3.6-35B-A3B",
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_token_data_requests_and_processes_runs_chronologically():
+    older = _run_summary("run-older", datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc))
+    newer = _run_summary("run-newer", datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc))
+    fake_runs = _FakeRuns(
+        # Simulate a server/client returning newest-first despite the requested
+        # order. _fetch_token_data should still sort locally before retrieval.
+        items=[newer, older],
+        runs_by_id={
+            "run-older": _run_with_turns(_assistant_turn([10, 11], [12]), _tool_turn("first tool")),
+            "run-newer": _run_with_turns(_assistant_turn([10, 11, 12, 13], [14])),
+        },
+    )
+
+    token_data = await _make_target(fake_runs)._fetch_token_data("agent-123")
+
+    assert fake_runs.list_calls == [{"agent_id": "agent-123", "limit": 100, "order": "asc"}]
+    assert fake_runs.retrieve_ids == ["run-older", "run-newer"]
+    assert [turn.role for turn in token_data] == ["assistant", "tool", "assistant"]
+    assert token_data[0].input_ids == [10, 11]
+    assert token_data[0].output_ids == [12]
+    assert token_data[1].content == "first tool"
+    assert token_data[2].input_ids == [10, 11, 12, 13]
+    assert token_data[2].output_ids == [14]
+
+
+@pytest.mark.asyncio
+async def test_fetch_token_data_sorts_locally_when_client_lacks_order_kwarg():
+    older = _run_summary("run-older", datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc))
+    newer = _run_summary("run-newer", datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc))
+    fake_runs = _FakeRuns(
+        items=[newer, older],
+        runs_by_id={
+            "run-older": _run_with_turns(_assistant_turn([1], [2])),
+            "run-newer": _run_with_turns(_assistant_turn([1, 2, 3], [4])),
+        },
+        reject_order=True,
+    )
+
+    token_data = await _make_target(fake_runs)._fetch_token_data("agent-123")
+
+    assert fake_runs.list_calls == [
+        {"agent_id": "agent-123", "limit": 100, "order": "asc"},
+        {"agent_id": "agent-123", "limit": 100},
+    ]
+    assert fake_runs.retrieve_ids == ["run-older", "run-newer"]
+    assert [turn.output_ids for turn in token_data] == [[2], [4]]


### PR DESCRIPTION
## Summary
- `LettaCodeTarget._fetch_token_data` consumed `runs.list()` in the server-default order, which is **newest-first** on current Letta servers. Since each client-tool round-trip is a separate run, processing them newest-first reverses the trajectory.
- Reversed order breaks prefix-compatibility between consecutive assistant generations, so Tinker sequence-extension cannot merge them. This showed up as `data/datums_per_rollout` ≈ assistant turns (e.g. ~15–18) instead of ~1, inflating the number of training datums per rollout.
- Fix: request `order="asc"` explicitly and defensively sort run summaries by `created_at` locally, so token data is always reconstructed oldest-to-newest regardless of server/client defaults.

## Details
- A `TypeError` fallback covers older generated clients that do not expose the `order` kwarg; in that case we still sort locally.
- A real-rollout diagnostic confirmed the cause: under API/default order, adjacent prefix compatibility was `0/9`; reversing to chronological made it `9/9`, and simulated datum construction dropped from 10 datums to 1.
- This explains the divergence from the memory-reflection run, whose environment supplied chronological token data (so `datums_per_rollout` ≈ 1.25).

## Test plan
- [x] `pytest tests/test_letta_code_target_token_data.py tests/test_letta_code_target_env_overrides.py` (22 passed)
- [x] `ruff check` on changed files
- [x] Verified installed `letta_client.AsyncLetta().runs.list` exposes the `order` kwarg

👾 Generated with [Letta Code](https://letta.com)