### PR TITLE
refactor(models): Remove unused TargetResult run IDs

### DIFF
--- a/letta_evals/models/results.py
+++ b/letta_evals/models/results.py
@@ -82,9 +82,6 @@ class TargetResult(BaseModel):
     agent_state: Optional[AgentState] = Field(
         default=None, description="Agent state after running the target (includes memory blocks)"
     )
-    run_ids: Optional[List[str]] = Field(
-        default=None, description="Run IDs for each input turn (needed for token-level data fetching in training)"
-    )
     token_data: Optional[List[TurnTokenData]] = Field(
         default=None,
         description=(

--- a/tests/test_runner_token_data.py
+++ b/tests/test_runner_token_data.py
@@ -101,7 +101,6 @@ def _make_target_result(
         model_handle="fake/model",
         agent_usage=None,
         agent_state=agent_state,
-        run_ids=None,
         token_data=token_data,
     )
 


### PR DESCRIPTION
## Summary
- remove the unused `TargetResult.run_ids` field
- update the token-data runner fixture now that run IDs are not part of the target result contract
- leaves #219 fully superseded/stale rather than something to revive

## Tests
- `uv run --frozen --extra dev pytest tests/test_runner_token_data.py tests/test_letta_code_target_token_data.py -q`
- `uv run --frozen --extra dev ruff check`