### PR TITLE
fix(sandbox): Preserve selected suite file

### DIFF
--- a/letta_evals/cli.py
+++ b/letta_evals/cli.py
@@ -151,7 +151,7 @@ def run(
     try:
         with open(suite_path, "r") as f:
             yaml_data = yaml.safe_load(f)
-        suite = SuiteSpec.from_yaml(yaml_data, base_dir=suite_path.parent)
+        suite = SuiteSpec.from_yaml(yaml_data, base_dir=suite_path.parent, suite_path=suite_path)
 
         effective_max_concurrent = (
             max_concurrent
@@ -273,7 +273,7 @@ def validate(suite_path: Path = typer.Argument(..., help="Path to suite YAML fil
         with open(suite_path, "r") as f:
             yaml_data = yaml.safe_load(f)
 
-        suite = SuiteSpec.from_yaml(yaml_data, base_dir=suite_path.parent)
+        suite = SuiteSpec.from_yaml(yaml_data, base_dir=suite_path.parent, suite_path=suite_path)
         console.print(f"[green]✓ Suite '{suite.name}' is valid[/green]")
 
         console.print("\n[bold]Configuration:[/bold]")
@@ -375,7 +375,7 @@ async def _run_single_sample(
     if model_handle is not None:
         yaml_data.setdefault("target", {})["model_handles"] = [model_handle]
 
-    suite = SuiteSpec.from_yaml(yaml_data, base_dir=suite_path.parent)
+    suite = SuiteSpec.from_yaml(yaml_data, base_dir=suite_path.parent, suite_path=suite_path)
 
     with open(sample_path, "r") as f:
         sample = Sample.model_validate(_json.load(f))

--- a/letta_evals/models/specs.py
+++ b/letta_evals/models/specs.py
@@ -233,8 +233,9 @@ class SuiteSpec(BaseModel):
         ),
     )
 
-    # internal field for path resolution
+    # internal fields for path resolution / dispatch
     base_dir: Optional[Path] = Field(default=None, exclude=True)
+    suite_path: Optional[Path] = Field(default=None, exclude=True)
 
     @model_validator(mode="before")
     @classmethod
@@ -244,7 +245,12 @@ class SuiteSpec(BaseModel):
         return data
 
     @classmethod
-    def from_yaml(cls, yaml_data: Dict[str, Any], base_dir: Optional[Path] = None) -> "SuiteSpec":
+    def from_yaml(
+        cls,
+        yaml_data: Dict[str, Any],
+        base_dir: Optional[Path] = None,
+        suite_path: Optional[Path] = None,
+    ) -> "SuiteSpec":
         """Create from parsed YAML data."""
         if base_dir:
             # resolve dataset path
@@ -290,5 +296,8 @@ class SuiteSpec(BaseModel):
                 yaml_data["graders"] = resolved_graders
 
             yaml_data["base_dir"] = base_dir
+
+        if suite_path is not None:
+            yaml_data["suite_path"] = suite_path
 
         return cls(**yaml_data)

--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -676,7 +676,7 @@ async def run_suite(
     with open(suite_path, "r") as f:
         yaml_data = yaml.safe_load(f)
 
-    suite = SuiteSpec.from_yaml(yaml_data, base_dir=suite_path.parent)
+    suite = SuiteSpec.from_yaml(yaml_data, base_dir=suite_path.parent, suite_path=suite_path)
 
     actual_num_runs = num_runs if num_runs is not None else (suite.num_runs or 1)
 

--- a/letta_evals/sandbox/dispatch.py
+++ b/letta_evals/sandbox/dispatch.py
@@ -28,22 +28,21 @@ DEFAULT_SANDBOX_FORWARD_ENV = (
 )
 
 
-def suite_yaml_filename(suite: SuiteSpec) -> str:
-    """Locate the suite YAML inside ``base_dir`` so we can reference it remotely.
+def suite_yaml_remote_path(suite: SuiteSpec) -> str:
+    """Return the in-sandbox path for the suite file the host loaded."""
+    if suite.suite_path is None:
+        return "/mnt/suite/suite.yaml"
 
-    Convention: the suite file lives directly inside ``base_dir`` (this is how
-    ``run_suite`` sets ``base_dir = suite_path.parent``). Prefer files whose
-    name starts with ``suite`` and fall back to the first YAML file.
-    """
     base = suite.base_dir
     if base is None:
-        return "suite.yaml"
-    candidates = sorted(list(base.glob("*.yaml")) + list(base.glob("*.yml")))
-    if not candidates:
-        return "suite.yaml"
-    suite_like = [p for p in candidates if p.name.startswith("suite")]
-    chosen = suite_like[0] if suite_like else candidates[0]
-    return chosen.name
+        return f"/mnt/suite/{suite.suite_path.name}"
+
+    try:
+        relative_suite_path = suite.suite_path.relative_to(base)
+    except ValueError:
+        relative_suite_path = suite.suite_path.resolve().relative_to(base.resolve())
+
+    return f"/mnt/suite/{relative_suite_path.as_posix()}"
 
 
 def sandbox_error_result(
@@ -64,7 +63,7 @@ def sandbox_error_result(
 
 
 def build_sandbox_command(suite: SuiteSpec, model_handle: Optional[str]) -> str:
-    suite_yaml_remote = f"/mnt/suite/{suite_yaml_filename(suite)}"
+    suite_yaml_remote = suite_yaml_remote_path(suite)
     cmd_parts = [
         "letta-evals",
         "run",

--- a/tests/test_runner_sandbox_dispatch.py
+++ b/tests/test_runner_sandbox_dispatch.py
@@ -12,6 +12,7 @@ from typing import Optional
 from unittest.mock import MagicMock
 
 import anyio
+import pytest
 
 from letta_evals.models import (
     GradeResult,
@@ -21,7 +22,7 @@ from letta_evals.models import (
     SampleResult,
     Timing,
 )
-from letta_evals.runner import Runner
+from letta_evals.runner import Runner, run_suite
 from letta_evals.sandbox.base import ExecResult
 from letta_evals.sandbox.dispatch import run_sample_in_sandbox
 
@@ -79,12 +80,17 @@ class _StubSandbox:
             f.write(result.model_dump_json())
 
 
-def _make_runner_with_sandbox(tmp_path: Path, sandbox_spec: Optional[ModalSandboxSpec] = None) -> Runner:
+def _make_runner_with_sandbox(
+    tmp_path: Path,
+    sandbox_spec: Optional[ModalSandboxSpec] = None,
+    suite_filename: str = "suite.yaml",
+) -> Runner:
     """Construct a Runner via __new__ with only what run_sample dispatch reads."""
     runner = Runner.__new__(Runner)
     runner.suite = MagicMock()
     runner.suite.name = "test-suite"
     runner.suite.base_dir = tmp_path
+    runner.suite.suite_path = tmp_path / suite_filename
     runner.suite.sandbox = sandbox_spec or ModalSandboxSpec(image="img:test", timeout_sec=60)
     runner.suite.cleanup = False
     runner.suite.target = MagicMock()
@@ -103,9 +109,15 @@ def _make_runner_with_sandbox(tmp_path: Path, sandbox_spec: Optional[ModalSandbo
     return runner
 
 
-def _write_suite_yaml(base: Path) -> None:
-    """Drop a suite.yaml in base so suite_yaml_filename has something to glob."""
-    (base / "suite.yaml").write_text("name: test-suite\n")
+def _write_suite_yaml(base: Path, filename: str = "suite.yaml") -> None:
+    """Drop a suite YAML in base so the sandbox command can reference it."""
+    (base / filename).write_text("name: test-suite\n")
+
+
+def _sandbox_cli_command(stub: _StubSandbox) -> str:
+    cli_commands = [c[0] for c in stub.execs if "letta-evals" in c[0] and "--sample" in c[0]]
+    assert cli_commands, stub.execs
+    return cli_commands[0]
 
 
 class TestRunSampleInSandbox:
@@ -131,9 +143,7 @@ class TestRunSampleInSandbox:
         # Sample JSON uploaded to /mnt/sample.json.
         assert any(remote == "/mnt/sample.json" for _, remote in stub.uploaded_files)
         # CLI command references the suite + sample + output paths and the model handle.
-        cli_commands = [c[0] for c in stub.execs if "letta-evals" in c[0] and "--sample" in c[0]]
-        assert cli_commands, stub.execs
-        cmd = cli_commands[0]
+        cmd = _sandbox_cli_command(stub)
         assert "/mnt/suite/suite.yaml" in cmd
         assert "/mnt/sample.json" in cmd
         assert "/mnt/result.json" in cmd
@@ -141,6 +151,61 @@ class TestRunSampleInSandbox:
         # Result round-tripped.
         assert result.sample_id == "s1"
         assert result.grades["acc"].score == 1.0
+
+    @pytest.mark.parametrize("suite_filename", ["suite.yaml", "suite-mini.yaml"])
+    def test_preserves_exact_suite_file_when_multiple_suite_yamls_exist(
+        self, tmp_path, monkeypatch, suite_filename
+    ):
+        _write_suite_yaml(tmp_path, "suite.yaml")
+        _write_suite_yaml(tmp_path, "suite-mini.yaml")
+        runner = _make_runner_with_sandbox(tmp_path, suite_filename=suite_filename)
+        stub = _StubSandbox()
+        monkeypatch.setattr("letta_evals.sandbox.dispatch.ModalSandbox", lambda spec, session_id: stub)
+
+        sample = Sample(id="s1", input="hi", ground_truth="hi")
+        anyio.run(run_sample_in_sandbox, runner.suite, sample, "openai/gpt-a", False, 0.0)
+
+        cmd = _sandbox_cli_command(stub)
+        assert f"/mnt/suite/{suite_filename}" in cmd
+
+        other_suite_filename = "suite-mini.yaml" if suite_filename == "suite.yaml" else "suite.yaml"
+        assert f"/mnt/suite/{other_suite_filename}" not in cmd
+
+    def test_run_suite_records_loaded_suite_path(self, tmp_path, monkeypatch):
+        dataset = tmp_path / "data.jsonl"
+        dataset.write_text('{"input": "hi", "ground_truth": "hi"}\n')
+        suite_path = tmp_path / "suite-mini.yaml"
+        suite_path.write_text(
+            """
+name: test-suite
+dataset: data.jsonl
+target:
+  kind: letta_code
+  model_handles:
+    - openai/gpt-4.1-mini
+graders:
+  acc:
+    kind: tool
+    function: exact_match
+reward:
+  kind: metric
+  metric_key: acc
+sandbox:
+  kind: modal
+  image: img:test
+"""
+        )
+        captured = {}
+
+        async def fake_execute_runs(**kwargs):
+            captured["suite"] = kwargs["suite"]
+            return object()
+
+        monkeypatch.setattr("letta_evals.runner._execute_runs", fake_execute_runs)
+
+        anyio.run(run_suite, suite_path, 1)
+
+        assert captured["suite"].suite_path == suite_path
 
     def test_forwards_allowlisted_env_vars(self, tmp_path, monkeypatch):
         """Allowlisted host env vars (+ forward_env extras) reach the in-sandbox

--- a/tests/test_runner_sandbox_dispatch.py
+++ b/tests/test_runner_sandbox_dispatch.py
@@ -153,9 +153,7 @@ class TestRunSampleInSandbox:
         assert result.grades["acc"].score == 1.0
 
     @pytest.mark.parametrize("suite_filename", ["suite.yaml", "suite-mini.yaml"])
-    def test_preserves_exact_suite_file_when_multiple_suite_yamls_exist(
-        self, tmp_path, monkeypatch, suite_filename
-    ):
+    def test_preserves_exact_suite_file_when_multiple_suite_yamls_exist(self, tmp_path, monkeypatch, suite_filename):
         _write_suite_yaml(tmp_path, "suite.yaml")
         _write_suite_yaml(tmp_path, "suite-mini.yaml")
         runner = _make_runner_with_sandbox(tmp_path, suite_filename=suite_filename)


### PR DESCRIPTION
## Summary
- store the exact loaded suite YAML path on `SuiteSpec`
- pass that path through CLI/run-suite loading
- build sandbox commands from the stored path instead of scanning the suite directory
- add regression coverage for directories with both `suite.yaml` and `suite-mini.yaml`

Closes #292.

## Tests
- `PYTHONPATH=$PWD /Users/devanshjain/Desktop/evals/.venv/bin/python -m pytest`
- `/Users/devanshjain/Desktop/evals/.venv/bin/ruff check letta_evals tests/test_runner_sandbox_dispatch.py tests/test_modal_sandbox.py tests/test_cli_single_sample.py`
