### PR TITLE
refactor: Make SampleResult inherit from TargetResult

### DIFF
--- a/letta_evals/models/results.py
+++ b/letta_evals/models/results.py
@@ -22,7 +22,7 @@ from letta_client.types.agents import (
     ToolCallMessage,
     UserMessage,
 )
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_serializer
 
 from letta_evals.models.sample import SampleId
 from letta_evals.types import ErrorCategory
@@ -194,12 +194,22 @@ class RewardOutput(BaseModel):
 # up by ``sample_id``.
 
 
-class SampleResult(BaseModel):
-    """Result for a single sample evaluation."""
+class SampleResult(TargetResult):
+    """Result for a single sample evaluation.
+
+    Extends ``TargetResult`` (the agent-run output) with grading, reward,
+    usage, timing, and error. ``agent_id`` and ``model_handle`` are relaxed to
+    optional here because a sample can fail before the target produces either.
+    The inherited ``trajectory``, ``agent_usage``, ``agent_state``, and
+    ``token_data`` carry over unchanged.
+    """
 
     sample_id: SampleId = Field(description="ID of the sample (look up the full Sample in suite.json)")
     agent_id: Optional[str] = Field(default=None, description="ID of the agent that generated this trajectory")
-    trajectory: List[List[LettaMessageUnion]] = Field(description="Full conversation trajectory from the agent")
+    model_handle: Optional[str] = Field(
+        default=None,
+        description="Model handle used for this sample (also implied by the output file path)",
+    )
     submissions: Dict[str, str] = Field(
         default_factory=dict,
         description="Per-grader extracted submissions (keyed by grader name)",
@@ -215,21 +225,14 @@ class SampleResult(BaseModel):
     usage: Optional[Usage] = Field(default=None, description="Token usage and cost for this sample")
     timing: Timing = Field(description="Wall-clock timing for this sample")
     error: Optional[Error] = Field(default=None, description="Structured error info if this sample failed")
-    # Optional extras — omitted from serialized output when None.
-    agent_usage: Optional[List[dict]] = Field(
-        default=None, description="Raw usage statistics emitted by the agent during the run"
-    )
-    agent_state: Optional[AgentState] = Field(
-        default=None,
-        description=(
-            "Agent state after running the target (includes memory blocks). "
-            "Only populated when at least one grader requires agent_state."
-        ),
-    )
-    token_data: Optional[List[TurnTokenData]] = Field(
-        default=None,
-        description=(
-            "Per-token IDs and logprobs across all turns in the trajectory. "
-            "Only populated when run_sample(return_token_data=True) is called."
-        ),
-    )
+
+    @model_serializer(mode="wrap")
+    def _serialize_identity_first(self, handler):
+        """Surface sample_id and agent_id first in serialized output.
+
+        Inheritance puts TargetResult's fields ahead of these, so reorder on
+        dump to keep <model>.jsonl rows readable (identity leads each line).
+        """
+        data = handler(self)
+        leading = {key: data.pop(key) for key in ("sample_id", "agent_id") if key in data}
+        return {**leading, **data}

--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -459,6 +459,7 @@ class Runner:
                 result = SampleResult(
                     sample_id=sample_id,
                     agent_id=agent_id,
+                    model_handle=model_handle,
                     trajectory=trajectory,
                     submissions=submissions_dict,
                     grades=grades_dict,
@@ -514,6 +515,7 @@ class Runner:
                 result = SampleResult(
                     sample_id=sample_id,
                     agent_id=agent_id,
+                    model_handle=result_model_handle,
                     trajectory=[],
                     submissions={},
                     grades={},

--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -18,9 +18,7 @@ from letta_evals.graders.rubric import RubricGrader
 from letta_evals.graders.tool import ToolGrader
 from letta_evals.metrics import summarize_model, summarize_runs
 from letta_evals.models import (
-    AgentState,
     Error,
-    LettaMessageUnion,
     MetricRewardSpec,
     ModelJudgeGraderSpec,
     ModelRun,
@@ -31,6 +29,7 @@ from letta_evals.models import (
     SampleResult,
     SuiteSpec,
     Summary,
+    TargetResult,
     Timing,
     ToolGraderSpec,
     Usage,
@@ -283,15 +282,8 @@ class Runner:
         model_handle: Optional[str],
         retrieve_agent_state: bool = False,
         return_token_data: bool = False,
-    ) -> tuple[
-        List[List[LettaMessageUnion]],
-        str,
-        str,
-        Optional[list[dict]],
-        Optional[AgentState],
-        Optional[list],
-    ]:
-        """Return (trajectory, agent_id, model_handle, agent_usage, agent_state, token_data)."""
+    ) -> TargetResult:
+        """Return the target run for this sample, served from cache when available."""
         sample_id = sample.id
 
         if self.cached_results:
@@ -310,30 +302,17 @@ class Runner:
                     await self.progress_callback.agent_created(
                         sample_id, agent_id=cached_result.agent_id, model_handle=model_handle, from_cache=True
                     )
-                return (
-                    cached_result.trajectory,
-                    cached_result.agent_id,
-                    model_handle or DEFAULT_MODEL_ID,
-                    getattr(cached_result, "agent_usage", None),
-                    getattr(cached_result, "agent_state", None),
-                    getattr(cached_result, "token_data", None),
-                )
+                # cached_result is a SampleResult (a TargetResult subclass); the
+                # requested handle wins over whatever the cache recorded.
+                return cached_result.model_copy(update={"model_handle": model_handle or DEFAULT_MODEL_ID})
 
         target = self._create_letta_code_target(model_handle)
-        target_result = await target.run(
+        return await target.run(
             sample,
             progress_callback=self.progress_callback,
             project_id=self.project_id,
             retrieve_agent_state=retrieve_agent_state,
             return_token_data=return_token_data,
-        )
-        return (
-            target_result.trajectory,
-            target_result.agent_id,
-            target_result.model_handle,
-            target_result.agent_usage,
-            target_result.agent_state,
-            target_result.token_data,
         )
 
     # ── per-sample driver ──
@@ -373,19 +352,18 @@ class Runner:
 
                 phase = ErrorCategory.TARGET
                 retrieve_agent_state = self._requires_agent_state()
-                (
-                    trajectory,
-                    agent_id,
-                    model_handle,
-                    agent_usage,
-                    agent_state,
-                    token_data,
-                ) = await self._get_or_run_trajectory(
+                target_result = await self._get_or_run_trajectory(
                     sample,
                     model_handle,
                     retrieve_agent_state=retrieve_agent_state,
                     return_token_data=return_token_data,
                 )
+                trajectory = target_result.trajectory
+                agent_id = target_result.agent_id
+                model_handle = target_result.model_handle
+                agent_usage = target_result.agent_usage
+                agent_state = target_result.agent_state
+                token_data = target_result.token_data
 
                 cost = calculate_cost_from_agent_usage(model_handle, agent_usage) if model_handle else None
                 prompt_tokens, completion_tokens, cached_input_tokens, cache_write_tokens, reasoning_tokens = (


### PR DESCRIPTION
## What

Removes the field duplication between `TargetResult` and `SampleResult`, and cleans up the fragile tuple that bridged them.

### `SampleResult` inherits from `TargetResult`
- `SampleResult(TargetResult)` — drops the 4 duplicated agent-run fields (`trajectory`, `agent_usage`, `agent_state`, `token_data`).
- Overrides `agent_id` + `model_handle` as optional (a sample can fail before the target produces either); `TargetResult` keeps its required guarantees.
- Populates `model_handle` in the runner's two `SampleResult` constructions.
- Adds a `model_serializer` so `sample_id` and `agent_id` lead each `<model>.jsonl` row (inheritance otherwise orders `TargetResult`'s fields first).

### `_get_or_run_trajectory` returns `TargetResult`
- Replaces the positional 6-tuple with the `TargetResult` object it was unpacking. Live path returns `target.run()` directly; cached path returns the cached `SampleResult` (now a `TargetResult` subclass) with the requested `model_handle` applied.
- `run_sample` reads named attributes instead of position-matching a tuple. Removed two now-unused imports.

## Compatibility
- Serialization uses `model_dump_json(exclude_none=True)`, so an unset `model_handle` stays off the wire — old `<model>.jsonl` files still load.
- Cached path preserves prior behavior: the requested `model_handle` wins over whatever the cache recorded.

## Testing
- Full suite: **262 passed, 2 skipped**.
- `ruff check` clean.
- Verified serialized field order (`sample_id`/`agent_id` first) and round-trip load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)