### PR TITLE
feat(letta-code): Pin CLI version for eval targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,21 @@ The supported target is `letta_code`, which runs the Letta Code CLI against a Le
 - `agent_script`: optional `file.py:function_name` agent factory
 - `flags`: additional Letta Code CLI flags (including tool restrictions, e.g. `--allowed-tools Bash Read`)
 - `permission_mode`: optional Letta Code permission mode
+- `letta_command`: Letta Code executable to invoke; defaults to `letta` on `PATH`
+- `letta_code_version`: optional expected `@letta-ai/letta-code` CLI version; fails fast if `letta_command --version` does not match
+- `disable_autoupdater`: set `DISABLE_AUTOUPDATER=1` for Letta Code subprocesses; automatically enabled when `letta_code_version` is set
 - `timeout` and `max_retries`: target execution controls
+
+For reproducible runs, install the desired Letta Code CLI separately and pin it in the target:
+
+```yaml
+target:
+  kind: letta_code
+  model_handles:
+    - openai/gpt-4.1-mini
+  letta_command: /path/to/letta
+  letta_code_version: 0.27.16
+```
 
 ### Graders and extractors
 

--- a/letta_evals/models/specs.py
+++ b/letta_evals/models/specs.py
@@ -51,6 +51,23 @@ class LettaCodeTargetSpec(BaseModel):
         default=None,
         description="Permission mode for letta code (e.g., 'memory' to scope writes to memory roots).",
     )
+    letta_command: str = Field(
+        default="letta",
+        description="Letta Code executable to invoke. Defaults to the first 'letta' on PATH.",
+    )
+    letta_code_version: Optional[str] = Field(
+        default=None,
+        description=(
+            "Expected @letta-ai/letta-code CLI version. When set, letta-evals runs "
+            "'<letta_command> --version' and fails fast if the version does not match."
+        ),
+    )
+    disable_autoupdater: bool = Field(
+        default=False,
+        description=(
+            "Set DISABLE_AUTOUPDATER=1 for Letta Code subprocesses. This is forced when letta_code_version is set."
+        ),
+    )
 
 
 class ModalSandboxSpec(BaseModel):

--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -179,6 +179,9 @@ class Runner:
             base_dir=self.suite.target.base_dir,
             flags=self.suite.target.flags,
             permission_mode=self.suite.target.permission_mode,
+            letta_command=self.suite.target.letta_command,
+            letta_code_version=self.suite.target.letta_code_version,
+            disable_autoupdater=self.suite.target.disable_autoupdater,
         )
 
     def _init_graders(self) -> None:

--- a/letta_evals/targets/letta_code_target.py
+++ b/letta_evals/targets/letta_code_target.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import shlex
 from pathlib import Path
 from typing import Optional
@@ -22,6 +23,15 @@ from letta_evals.visualization.base import ProgressCallback
 logger = logging.getLogger(__name__)
 
 
+_VERSION_RE = re.compile(r"\d+\.\d+\.\d+(?:[-+][A-Za-z0-9_.-]+)?")
+
+
+def _extract_version(output: str) -> str:
+    """Extract the package version from ``letta --version`` output."""
+    match = _VERSION_RE.search(output)
+    return match.group(0) if match else output.strip()
+
+
 class LettaCodeTarget:
     """Letta code target that invokes the letta CLI command."""
 
@@ -36,6 +46,9 @@ class LettaCodeTarget:
         base_dir: Optional[Path] = None,
         flags: Optional[str] = None,
         permission_mode: Optional[str] = None,
+        letta_command: str = "letta",
+        letta_code_version: Optional[str] = None,
+        disable_autoupdater: bool = False,
     ):
         """Initialize the Letta Code target.
 
@@ -53,10 +66,19 @@ class LettaCodeTarget:
                 rules (e.g., "--memfs --context-window 8000").
             permission_mode: Permission mode for letta code (e.g., "memory" to scope
                 writes to memory roots). When "memory", sets MEMORY_DIR env var.
+            letta_command: Letta Code executable to run. Defaults to the first
+                ``letta`` on PATH.
+            letta_code_version: If set, run ``<letta_command> --version`` before
+                samples and fail if the reported version does not match.
+            disable_autoupdater: If true, set ``DISABLE_AUTOUPDATER=1`` for the
+                Letta Code subprocess. This is also forced when letta_code_version
+                is set so the checked version cannot auto-update during execution.
 
         Agent factories may set ``sample.extra_vars["env"]`` (dict) to inject
-        per-sample env vars into the subprocess; user keys win over target-managed
-        ones. See ``_build_subprocess_env``.
+        per-sample env vars into the subprocess. Sample keys override most
+        target-managed keys; the Letta Code auto-updater guard still wins when
+        ``disable_autoupdater`` or ``letta_code_version`` is set. See
+        ``_build_subprocess_env``.
 
         The CLI runs in the process's current working directory. For isolated
         execution, configure ``suite.sandbox`` to dispatch each sample to a
@@ -76,6 +98,13 @@ class LettaCodeTarget:
         # suite.sandbox (Modal), which runs the in-sandbox CLI from /mnt/suite.
         self.base_dir = base_dir or Path.cwd()
         self.flags = shlex.split(flags) if flags else []
+        self.letta_command = letta_command
+        self.letta_code_version = letta_code_version
+        self.disable_autoupdater = disable_autoupdater
+        self._verified_letta_code_version: Optional[str] = None
+
+        if not self.letta_command:
+            raise ValueError("letta_command must not be empty")
 
     def _build_subprocess_env(self, sample: Sample, agent_id: Optional[str]) -> dict[str, str]:
         """Build subprocess env: os.environ -> target-managed -> sample.extra_vars["env"]."""
@@ -111,7 +140,52 @@ class LettaCodeTarget:
             if applied:
                 logger.info(f"Applied per-sample env overrides for sample {sample.id}: keys={sorted(applied)}")
 
+        if self.disable_autoupdater or self.letta_code_version:
+            env["DISABLE_AUTOUPDATER"] = "1"
+
         return env
+
+    async def _verify_letta_code_version(self, env: dict[str, str], cwd: str) -> Optional[str]:
+        """Verify the configured Letta Code CLI version, if requested."""
+        if not self.letta_code_version:
+            return None
+        if self._verified_letta_code_version == self.letta_code_version:
+            return self._verified_letta_code_version
+
+        process = await asyncio.create_subprocess_exec(
+            self.letta_command,
+            "--version",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=cwd,
+            env=env,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=30)
+        except asyncio.TimeoutError:
+            process.kill()
+            await process.wait()
+            raise RuntimeError(f"Timed out while checking Letta Code version via {self.letta_command!r}")
+
+        stdout_text = stdout.decode(errors="replace").strip()
+        stderr_text = stderr.decode(errors="replace").strip()
+        output = stdout_text or stderr_text
+
+        if process.returncode != 0:
+            detail = output or f"exit code {process.returncode}"
+            raise RuntimeError(f"Could not check Letta Code version via {self.letta_command!r}: {detail}")
+
+        actual_version = _extract_version(output)
+        if actual_version != self.letta_code_version:
+            raise RuntimeError(
+                "Letta Code version mismatch: "
+                f"expected {self.letta_code_version}, got {actual_version or output} "
+                f"from {self.letta_command!r} --version"
+            )
+
+        self._verified_letta_code_version = actual_version
+        logger.info(f"Verified Letta Code CLI version {actual_version} via {self.letta_command!r}")
+        return actual_version
 
     def _resolve_run_cwd(self, sample: Sample, agent_id: Optional[str]) -> str:
         """Resolve the subprocess working directory.
@@ -151,7 +225,7 @@ class LettaCodeTarget:
 
                 # construct the letta-code CLI command (headless streaming JSON output).
                 cmd = [
-                    "letta",
+                    self.letta_command,
                     "--output-format",
                     "stream-json",
                     "--model",
@@ -215,6 +289,8 @@ class LettaCodeTarget:
                 # Resolve the subprocess cwd (honors a factory-injected MEMORY_DIR
                 # in memory permission mode; see _resolve_run_cwd).
                 run_cwd = self._resolve_run_cwd(sample, factory_agent_id)
+
+                await self._verify_letta_code_version(env, run_cwd)
 
                 # run the letta command with prompt piped via stdin
                 #

--- a/tests/test_letta_code_target_env_overrides.py
+++ b/tests/test_letta_code_target_env_overrides.py
@@ -7,7 +7,7 @@ import pytest
 
 from letta_evals.models import Sample
 from letta_evals.targets.errors import TargetError
-from letta_evals.targets.letta_code_target import LettaCodeTarget
+from letta_evals.targets.letta_code_target import LettaCodeTarget, _extract_version
 
 
 def _make_target(tmp_path, **overrides) -> LettaCodeTarget:
@@ -108,6 +108,24 @@ def test_build_env_per_sample_overrides_win_over_os_environ(tmp_path, monkeypatc
     env = target._build_subprocess_env(sample, agent_id=None)
 
     assert env["MY_VAR"] == "from-sample"
+
+
+def test_build_env_sets_disable_autoupdater_when_configured(tmp_path):
+    target = _make_target(tmp_path, disable_autoupdater=True)
+    sample = _make_sample()
+
+    env = target._build_subprocess_env(sample, agent_id=None)
+
+    assert env["DISABLE_AUTOUPDATER"] == "1"
+
+
+def test_build_env_sets_disable_autoupdater_when_version_pinned(tmp_path):
+    target = _make_target(tmp_path, letta_code_version="0.27.16")
+    sample = _make_sample(extra_vars={"env": {"DISABLE_AUTOUPDATER": ""}})
+
+    env = target._build_subprocess_env(sample, agent_id=None)
+
+    assert env["DISABLE_AUTOUPDATER"] == "1"
 
 
 def test_build_env_coerces_non_string_values_to_str(tmp_path):
@@ -233,3 +251,35 @@ def test_run_cwd_without_agent_id_uses_base_dir(tmp_path):
 
     # No agent id -> cannot be in memory-cwd mode, fall back to base dir.
     assert target._resolve_run_cwd(sample, agent_id=None) == str(tmp_path)
+
+
+# --- Letta Code version checks --------------------------------------------
+
+
+def test_extract_version_from_letta_code_output():
+    assert _extract_version("0.27.16 (Letta Code)") == "0.27.16"
+    assert _extract_version("@letta-ai/letta-code 0.27.16\n") == "0.27.16"
+    assert _extract_version("custom-build") == "custom-build"
+
+
+@pytest.mark.asyncio
+async def test_verify_letta_code_version_accepts_matching_cli(tmp_path):
+    script = tmp_path / "letta"
+    script.write_text("#!/bin/sh\necho '0.27.16 (Letta Code)'\n")
+    script.chmod(0o755)
+    target = _make_target(tmp_path, letta_command=str(script), letta_code_version="0.27.16")
+
+    actual = await target._verify_letta_code_version(env={}, cwd=str(tmp_path))
+
+    assert actual == "0.27.16"
+
+
+@pytest.mark.asyncio
+async def test_verify_letta_code_version_rejects_mismatched_cli(tmp_path):
+    script = tmp_path / "letta"
+    script.write_text("#!/bin/sh\necho '0.27.18 (Letta Code)'\n")
+    script.chmod(0o755)
+    target = _make_target(tmp_path, letta_command=str(script), letta_code_version="0.27.16")
+
+    with pytest.raises(RuntimeError, match="expected 0.27.16, got 0.27.18"):
+        await target._verify_letta_code_version(env={}, cwd=str(tmp_path))


### PR DESCRIPTION
## Summary
- Add letta_code target fields for `letta_command`, `letta_code_version`, and `disable_autoupdater`.
- Verify `letta_command --version` before target execution when a version is pinned and fail fast on drift.
- Document reproducible Letta Code target configuration and add tests for version parsing/mismatch behavior.

## Test plan
- `uv run pytest tests/test_letta_code_target_env_overrides.py tests/test_cli_validate.py -q`
- `uv run pytest -q`
- `uv run ruff check .`

👾 Generated with [Letta Code](https://letta.com)