### PR TITLE
feat(letta-code): Add memory workspace target config

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,12 @@ The supported target is `letta_code`, which runs the Letta Code CLI against a Le
 - `model_handles`: one or more model handles to evaluate
 - `agent_script`: optional `file.py:function_name` agent factory
 - `flags`: additional Letta Code CLI flags (including tool restrictions, e.g. `--allowed-tools Bash Read`)
-- `permission_mode`: optional Letta Code permission mode
+- `permission_mode`: optional Letta Code permission mode, such as `unrestricted`, `standard`, or `acceptEdits`
+- `memory_workspace`: configure `MEMORY_DIR` / `LETTA_MEMORY_DIR` and run the Letta Code subprocess from a memory workspace without passing the removed `--permission-mode memory` CLI mode
+- `memory_dir`: optional explicit memory workspace root; relative paths are resolved from the suite file
 - `timeout` and `max_retries`: target execution controls
+
+Do not use `permission_mode: memory`: recent Letta Code releases removed that CLI mode. Use `memory_workspace: true` for memory workspace env/cwd setup, and Modal or another external sandbox if you need strict filesystem confinement.
 
 ### Graders and extractors
 

--- a/letta_evals/models/specs.py
+++ b/letta_evals/models/specs.py
@@ -49,8 +49,31 @@ class LettaCodeTargetSpec(BaseModel):
     )
     permission_mode: Optional[str] = Field(
         default=None,
-        description="Permission mode for letta code (e.g., 'memory' to scope writes to memory roots).",
+        description=("Permission mode passed to letta code (e.g., 'unrestricted', 'standard', or 'acceptEdits')."),
     )
+    memory_workspace: bool = Field(
+        default=False,
+        description=(
+            "Configure MEMORY_DIR/LETTA_MEMORY_DIR and run the Letta Code subprocess from a memory "
+            "workspace. This does not pass '--permission-mode memory' to letta code."
+        ),
+    )
+    memory_dir: Optional[Path] = Field(
+        default=None,
+        description=(
+            "Optional memory workspace root. Relative paths are resolved from the suite file. "
+            "When unset, memory_workspace uses per-sample overrides or the factory-created agent's memory root."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def reject_removed_memory_permission_mode(self):
+        if self.permission_mode == "memory":
+            raise ValueError(
+                "permission_mode: memory was removed from Letta Code. "
+                "Use memory_workspace: true with a current permission_mode such as 'unrestricted'."
+            )
+        return self
 
 
 class ModalSandboxSpec(BaseModel):
@@ -260,6 +283,11 @@ class SuiteSpec(BaseModel):
 
             # resolve target paths
             if "target" in yaml_data:
+                if "memory_dir" in yaml_data["target"] and yaml_data["target"]["memory_dir"]:
+                    memory_dir = Path(yaml_data["target"]["memory_dir"])
+                    if not memory_dir.is_absolute():
+                        yaml_data["target"]["memory_dir"] = str((base_dir / memory_dir).resolve())
+
                 # resolve path-valued flags (--skills, --import) relative to suite file
                 if "flags" in yaml_data["target"] and yaml_data["target"]["flags"]:
                     PATH_FLAGS = {"--skills", "--import"}

--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -179,6 +179,8 @@ class Runner:
             base_dir=self.suite.target.base_dir,
             flags=self.suite.target.flags,
             permission_mode=self.suite.target.permission_mode,
+            memory_workspace=self.suite.target.memory_workspace,
+            memory_dir=self.suite.target.memory_dir,
         )
 
     def _init_graders(self) -> None:

--- a/letta_evals/targets/letta_code_target.py
+++ b/letta_evals/targets/letta_code_target.py
@@ -36,6 +36,8 @@ class LettaCodeTarget:
         base_dir: Optional[Path] = None,
         flags: Optional[str] = None,
         permission_mode: Optional[str] = None,
+        memory_workspace: bool = False,
+        memory_dir: Optional[Path] = None,
     ):
         """Initialize the Letta Code target.
 
@@ -51,8 +53,16 @@ class LettaCodeTarget:
             base_dir: Base directory for resolving relative paths in agent_script
             flags: Additional CLI flags to pass to letta code, parsed with shell quoting
                 rules (e.g., "--memfs --context-window 8000").
-            permission_mode: Permission mode for letta code (e.g., "memory" to scope
-                writes to memory roots). When "memory", sets MEMORY_DIR env var.
+            permission_mode: Permission mode to pass through to Letta Code.
+                Use a current Letta Code CLI mode such as "unrestricted",
+                "standard", or "acceptEdits".
+            memory_workspace: If true, configure MEMORY_DIR/LETTA_MEMORY_DIR
+                and run the subprocess from that memory workspace when one can
+                be resolved. This controls letta-evals workspace behavior only;
+                use sandboxing if strict filesystem confinement is required.
+            memory_dir: Optional explicit memory workspace root. If unset,
+                memory_workspace uses a per-sample override or the factory-created
+                agent's default ~/.letta/agents/<agent_id>/memory root.
 
         Agent factories may set ``sample.extra_vars["env"]`` (dict) to inject
         per-sample env vars into the subprocess; user keys win over target-managed
@@ -65,6 +75,12 @@ class LettaCodeTarget:
         """
         self.client = client
         self.model_handle = model_handle
+        if permission_mode == "memory":
+            raise ValueError(
+                "permission_mode='memory' was removed from Letta Code. "
+                "Use memory_workspace=True with a current permission_mode such as 'unrestricted'."
+            )
+        self.memory_workspace = memory_workspace
         self.permission_mode = permission_mode
         self.timeout = timeout
         self.max_retries = max_retries
@@ -76,6 +92,30 @@ class LettaCodeTarget:
         # suite.sandbox (Modal), which runs the in-sandbox CLI from /mnt/suite.
         self.base_dir = base_dir or Path.cwd()
         self.flags = shlex.split(flags) if flags else []
+        self.memory_dir = memory_dir
+
+    def _resolve_memory_workspace_dir(self, sample: Sample, agent_id: Optional[str]) -> Optional[Path]:
+        """Resolve the memory workspace root for env/cwd configuration."""
+        if not self.memory_workspace:
+            return None
+
+        sample_env = (sample.extra_vars or {}).get("env") or {}
+        if isinstance(sample_env, dict):
+            injected = sample_env.get("MEMORY_DIR") or sample_env.get("LETTA_MEMORY_DIR")
+            if injected:
+                return Path(str(injected)).expanduser()
+
+        sample_memory_dir = (sample.extra_vars or {}).get("memory_dir")
+        if sample_memory_dir:
+            return Path(str(sample_memory_dir)).expanduser()
+
+        if self.memory_dir:
+            return self.memory_dir.expanduser()
+
+        if agent_id:
+            return Path.home() / ".letta" / "agents" / agent_id / "memory"
+
+        return None
 
     def _build_subprocess_env(self, sample: Sample, agent_id: Optional[str]) -> dict[str, str]:
         """Build subprocess env: os.environ -> target-managed -> sample.extra_vars["env"]."""
@@ -85,10 +125,11 @@ class LettaCodeTarget:
             env["LETTA_BASE_URL"] = self.base_url
             logger.info(f"Setting LETTA_BASE_URL={self.base_url} for letta CLI")
 
-        if self.permission_mode == "memory" and agent_id:
-            memory_dir = Path.home() / ".letta" / "agents" / agent_id / "memory"
+        memory_dir = self._resolve_memory_workspace_dir(sample, agent_id)
+        if memory_dir:
             memory_dir.mkdir(parents=True, exist_ok=True)
             env["MEMORY_DIR"] = str(memory_dir)
+            env["LETTA_MEMORY_DIR"] = str(memory_dir)
 
         sample_env = (sample.extra_vars or {}).get("env")
         if sample_env is not None:
@@ -116,18 +157,15 @@ class LettaCodeTarget:
     def _resolve_run_cwd(self, sample: Sample, agent_id: Optional[str]) -> str:
         """Resolve the subprocess working directory.
 
-        In ``permission_mode == "memory"`` we cd into the memory root so relative
-        file paths resolve correctly. An agent factory may point memory operations
-        at a different repo than the agent's own MemFS (e.g. a seeded "fake" repo)
-        by injecting ``MEMORY_DIR`` via ``sample.extra_vars`` — honor that path so
-        the subprocess starts in the repo it will actually read/write. Otherwise
-        fall back to the agent's own memory root, or the configured base dir.
+        When ``memory_workspace`` is true, run from the resolved memory root so
+        relative file paths resolve there. Agent factories may point memory
+        operations at a seeded repo by injecting ``MEMORY_DIR`` or
+        ``memory_dir`` via ``sample.extra_vars``; otherwise an explicit target
+        ``memory_dir`` or the factory-created agent's own memory root is used.
         """
-        if self.permission_mode == "memory" and agent_id:
-            injected_memory_dir = ((sample.extra_vars or {}).get("env") or {}).get("MEMORY_DIR") or (
-                sample.extra_vars or {}
-            ).get("memory_dir")
-            return str(injected_memory_dir or Path.home() / ".letta" / "agents" / agent_id / "memory")
+        memory_dir = self._resolve_memory_workspace_dir(sample, agent_id)
+        if memory_dir:
+            return str(memory_dir)
         return str(self.base_dir)
 
     async def run(
@@ -191,7 +229,8 @@ class LettaCodeTarget:
                 if self.flags:
                     cmd.extend(self.flags)
 
-                # permission mode (e.g., "memory" to scope writes to MEMORY_DIR)
+                # permission mode passed through to Letta Code. Memory workspace
+                # behavior is handled by letta-evals and is not a CLI permission mode.
                 if self.permission_mode:
                     cmd.extend(["--permission-mode", self.permission_mode])
 
@@ -212,8 +251,8 @@ class LettaCodeTarget:
                 agent_id = factory_agent_id
                 stderr_chunks = []
 
-                # Resolve the subprocess cwd (honors a factory-injected MEMORY_DIR
-                # in memory permission mode; see _resolve_run_cwd).
+                # Resolve the subprocess cwd (honors memory_workspace settings;
+                # see _resolve_run_cwd).
                 run_cwd = self._resolve_run_cwd(sample, factory_agent_id)
 
                 # run the letta command with prompt piped via stdin

--- a/tests/test_letta_code_target_env_overrides.py
+++ b/tests/test_letta_code_target_env_overrides.py
@@ -42,7 +42,7 @@ def test_build_env_inherits_os_environ_when_no_overrides(tmp_path, monkeypatch):
 
     assert env["EXISTING_VAR"] == "from-os"
     assert "LETTA_BASE_URL" not in env  # no base_url configured
-    assert "MEMORY_DIR" not in env  # no memory permission mode
+    assert "MEMORY_DIR" not in env  # no memory workspace
 
 
 def test_build_env_sets_base_url_when_configured(tmp_path):
@@ -54,30 +54,50 @@ def test_build_env_sets_base_url_when_configured(tmp_path):
     assert env["LETTA_BASE_URL"] == "https://api.example.com"
 
 
-def test_build_env_sets_memory_dir_in_memory_permission_mode(tmp_path, monkeypatch):
+def test_build_env_sets_memory_dir_in_memory_workspace(tmp_path, monkeypatch):
     # Redirect HOME so the test doesn't pollute the real ~/.letta
     monkeypatch.setenv("HOME", str(tmp_path))
 
-    target = _make_target(tmp_path, permission_mode="memory")
+    target = _make_target(tmp_path, memory_workspace=True)
     sample = _make_sample()
 
     env = target._build_subprocess_env(sample, agent_id="agent-abc")
 
     expected = str(Path(tmp_path) / ".letta" / "agents" / "agent-abc" / "memory")
     assert env["MEMORY_DIR"] == expected
+    assert env["LETTA_MEMORY_DIR"] == expected
     # mkdir(parents=True, exist_ok=True) should have created it
     assert Path(expected).is_dir()
 
 
 def test_build_env_skips_memory_dir_without_agent_id(tmp_path, monkeypatch):
     monkeypatch.delenv("MEMORY_DIR", raising=False)
+    monkeypatch.delenv("LETTA_MEMORY_DIR", raising=False)
 
-    target = _make_target(tmp_path, permission_mode="memory")
+    target = _make_target(tmp_path, memory_workspace=True)
     sample = _make_sample()
 
     env = target._build_subprocess_env(sample, agent_id=None)
 
     assert "MEMORY_DIR" not in env
+    assert "LETTA_MEMORY_DIR" not in env
+
+
+def test_build_env_sets_explicit_memory_dir_without_agent_id(tmp_path):
+    explicit = tmp_path / "seeded-memory"
+    target = _make_target(tmp_path, memory_workspace=True, memory_dir=explicit)
+    sample = _make_sample()
+
+    env = target._build_subprocess_env(sample, agent_id=None)
+
+    assert env["MEMORY_DIR"] == str(explicit)
+    assert env["LETTA_MEMORY_DIR"] == str(explicit)
+    assert explicit.is_dir()
+
+
+def test_target_rejects_removed_memory_permission_mode(tmp_path):
+    with pytest.raises(ValueError, match="permission_mode='memory' was removed"):
+        _make_target(tmp_path, permission_mode="memory")
 
 
 def test_build_env_applies_per_sample_overrides(tmp_path):
@@ -202,9 +222,9 @@ def test_run_cwd_defaults_to_base_dir_without_memory_mode(tmp_path):
     assert target._resolve_run_cwd(sample, agent_id="agent-abc") == str(tmp_path)
 
 
-def test_run_cwd_uses_agent_memory_root_in_memory_mode(tmp_path, monkeypatch):
+def test_run_cwd_uses_agent_memory_root_in_memory_workspace(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
-    target = _make_target(tmp_path, permission_mode="memory")
+    target = _make_target(tmp_path, memory_workspace=True)
     sample = _make_sample()
 
     expected = str(Path(tmp_path) / ".letta" / "agents" / "agent-abc" / "memory")
@@ -212,7 +232,7 @@ def test_run_cwd_uses_agent_memory_root_in_memory_mode(tmp_path, monkeypatch):
 
 
 def test_run_cwd_honors_injected_memory_dir_env(tmp_path):
-    target = _make_target(tmp_path, permission_mode="memory")
+    target = _make_target(tmp_path, memory_workspace=True)
     fake = str(tmp_path / "fake" / "repo")
     sample = _make_sample(extra_vars={"env": {"MEMORY_DIR": fake}})
 
@@ -220,7 +240,7 @@ def test_run_cwd_honors_injected_memory_dir_env(tmp_path):
 
 
 def test_run_cwd_honors_injected_memory_dir_non_env_key(tmp_path):
-    target = _make_target(tmp_path, permission_mode="memory")
+    target = _make_target(tmp_path, memory_workspace=True)
     fake = str(tmp_path / "fake" / "repo")
     sample = _make_sample(extra_vars={"memory_dir": fake})
 
@@ -228,8 +248,23 @@ def test_run_cwd_honors_injected_memory_dir_non_env_key(tmp_path):
 
 
 def test_run_cwd_without_agent_id_uses_base_dir(tmp_path):
-    target = _make_target(tmp_path, permission_mode="memory")
+    target = _make_target(tmp_path, memory_workspace=True)
+    sample = _make_sample()
+
+    # No agent id or explicit workspace -> cannot infer a memory cwd, fall back to base dir.
+    assert target._resolve_run_cwd(sample, agent_id=None) == str(tmp_path)
+
+
+def test_run_cwd_uses_injected_memory_dir_without_agent_id(tmp_path):
+    target = _make_target(tmp_path, memory_workspace=True)
     sample = _make_sample(extra_vars={"env": {"MEMORY_DIR": str(tmp_path / "x")}})
 
-    # No agent id -> cannot be in memory-cwd mode, fall back to base dir.
-    assert target._resolve_run_cwd(sample, agent_id=None) == str(tmp_path)
+    assert target._resolve_run_cwd(sample, agent_id=None) == str(tmp_path / "x")
+
+
+def test_run_cwd_uses_explicit_memory_dir_without_agent_id(tmp_path):
+    explicit = tmp_path / "seeded-memory"
+    target = _make_target(tmp_path, memory_workspace=True, memory_dir=explicit)
+    sample = _make_sample()
+
+    assert target._resolve_run_cwd(sample, agent_id=None) == str(explicit)

--- a/tests/test_modal_sandbox.py
+++ b/tests/test_modal_sandbox.py
@@ -9,6 +9,7 @@ The spec-parsing tests do not touch Modal at all.
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -126,6 +127,33 @@ class TestSuiteSpecWithSandbox:
         assert suite.sandbox.image == "ghcr.io/letta/letta-evals-runtime:test"
         assert suite.sandbox.secrets == ["letta-api-key"]
         assert suite.sandbox.cpu == 4
+
+    def test_target_memory_workspace_fields_parse_and_resolve(self, tmp_path):
+        yaml_data = _minimal_suite_yaml()
+        yaml_data["target"] = {
+            "kind": "letta_code",
+            "model_handles": ["openai/gpt-4.1-mini"],
+            "permission_mode": "unrestricted",
+            "memory_workspace": True,
+            "memory_dir": "seeded-memory",
+        }
+
+        suite = SuiteSpec.from_yaml(yaml_data, base_dir=tmp_path)
+
+        assert suite.target.permission_mode == "unrestricted"
+        assert suite.target.memory_workspace is True
+        assert suite.target.memory_dir == Path(tmp_path / "seeded-memory").resolve()
+
+    def test_target_rejects_removed_memory_permission_mode(self, tmp_path):
+        yaml_data = _minimal_suite_yaml()
+        yaml_data["target"] = {
+            "kind": "letta_code",
+            "model_handles": ["openai/gpt-4.1-mini"],
+            "permission_mode": "memory",
+        }
+
+        with pytest.raises(ValueError, match="permission_mode: memory was removed"):
+            SuiteSpec.from_yaml(yaml_data, base_dir=tmp_path)
 
 
 class TestExecResult:


### PR DESCRIPTION
## Summary
- Add explicit `memory_workspace` and `memory_dir` target fields for Letta Code evals.
- Treat legacy `permission_mode: memory` as a deprecated compatibility alias for `memory_workspace: true` without passing `--permission-mode memory` to Letta Code.
- Set both `MEMORY_DIR` and `LETTA_MEMORY_DIR` for memory workspaces and resolve relative `memory_dir` values from the suite file.
- Document the migration and add tests for env/cwd resolution and YAML parsing.

## Test plan
- `uv run pytest tests/test_letta_code_target_env_overrides.py tests/test_modal_sandbox.py tests/test_cli_validate.py -q`
- `uv run pytest -q`
- `uv run ruff check .`

👾 Generated with [Letta Code](https://letta.com)