### PR TITLE
feat(sandbox): Pin letta-code version in Modal image

### DIFF
--- a/docs/modal-sandbox.md
+++ b/docs/modal-sandbox.md
@@ -18,6 +18,25 @@ via Modal's `Image.from_dockerfile` — it carries `letta-evals` (pip) and
 sandbox after an edit pays the build cost. Override `image` only when you
 need additional system tools the agent invokes.
 
+## Pinning the letta-code version
+
+The bundled image installs `@letta-ai/letta-code@latest` by default. To
+evaluate a specific letta-code release — e.g. for reproducible training
+rollouts — pin it with `letta_code_version`:
+
+```yaml
+sandbox:
+  kind: modal
+  letta_code_version: "0.27.17"
+```
+
+The driver passes it to the Dockerfile as the `LETTA_CODE_VERSION` build
+arg (`npm install -g @letta-ai/letta-code@<version>`). Modal keys the
+cached image on build args, so each pinned version gets its own cached
+build. This applies only to the bundled Dockerfile path — when you set a
+pre-built `image`, `letta_code_version` is ignored (the registry image
+already bakes in its own letta-code) and the driver logs a warning.
+
 The orchestrator (`letta-evals run`) keeps running on your host — same
 sample loop, same `max_concurrent`, same JSONL output, same reward
 composition. The only thing that changes is what happens *per sample*:

--- a/examples/letta-code-simple-edit/suite.yaml
+++ b/examples/letta-code-simple-edit/suite.yaml
@@ -34,3 +34,6 @@ sandbox:
   memory_mb: 4096
   timeout_sec: 1800
   block_network: false
+  # Pin the @letta-ai/letta-code version installed in the sandbox image.
+  # Omit to track the npm `latest` tag.
+  letta_code_version: "0.27.16"

--- a/letta_evals/models/specs.py
+++ b/letta_evals/models/specs.py
@@ -107,6 +107,16 @@ class ModalSandboxSpec(BaseModel):
             "matches at sandbox start to guard against SampleResult schema drift."
         ),
     )
+    letta_code_version: Optional[str] = Field(
+        default=None,
+        description=(
+            "If set, pins the ``@letta-ai/letta-code`` npm version installed in "
+            "the bundled Dockerfile image, passed through as the "
+            "``LETTA_CODE_VERSION`` build arg (e.g. '0.27.17'). Defaults to the "
+            "Dockerfile's ``latest``. Ignored when ``image`` is set, since a "
+            "pre-built registry image already bakes in its own letta-code."
+        ),
+    )
     secrets: List[str] = Field(default_factory=list, description="Names of pre-uploaded Modal Secrets to attach")
     forward_env: List[str] = Field(
         default_factory=list,

--- a/letta_evals/sandbox/Dockerfile
+++ b/letta_evals/sandbox/Dockerfile
@@ -30,6 +30,12 @@ RUN pip install --no-cache-dir --upgrade "letta-evals>=0.19.0" letta-client
 
 # letta-code is the agent harness invoked by the LettaCodeTarget.
 # Install globally so the `letta` CLI is on $PATH inside the sandbox.
-RUN npm install -g @letta-ai/letta-code
+#
+# LETTA_CODE_VERSION pins the installed npm version; it defaults to `latest`.
+# The Modal driver overrides it from `sandbox.letta_code_version` via
+# Image.from_dockerfile(build_args=...). Modal keys its cached image build on
+# the build args, so each pinned version resolves to its own cached image.
+ARG LETTA_CODE_VERSION=latest
+RUN npm install -g "@letta-ai/letta-code@${LETTA_CODE_VERSION}"
 
 WORKDIR /work

--- a/letta_evals/sandbox/modal.py
+++ b/letta_evals/sandbox/modal.py
@@ -72,10 +72,21 @@ class ModalSandbox(AbstractSandbox):
             # Default: build the base image from the Dockerfile bundled with
             # the package. Modal caches the build, so repeated sandboxes
             # don't pay the full build cost — only the first sandbox after
-            # the Dockerfile changes does.
+            # the Dockerfile (or its build args) changes does.
             dockerfile_path = Path(__file__).parent / "Dockerfile"
-            image = modal.Image.from_dockerfile(str(dockerfile_path))
+            build_args: dict[str, str] = {}
+            if self.spec.letta_code_version:
+                # Pins @letta-ai/letta-code in the Dockerfile's npm install.
+                build_args["LETTA_CODE_VERSION"] = self.spec.letta_code_version
+            image = modal.Image.from_dockerfile(str(dockerfile_path), build_args=build_args)
         else:
+            if self.spec.letta_code_version:
+                logger.warning(
+                    "sandbox.letta_code_version=%s is ignored because a pre-built "
+                    "image (%s) is set; the registry image bakes in its own letta-code.",
+                    self.spec.letta_code_version,
+                    self.spec.image,
+                )
             image = modal.Image.from_registry(self.spec.image)
 
         secrets = [modal.Secret.from_name(name) for name in self.spec.secrets]

--- a/tests/test_modal_sandbox.py
+++ b/tests/test_modal_sandbox.py
@@ -54,6 +54,7 @@ class TestModalSandboxSpec:
         assert spec.forward_env == []
         assert spec.volumes == {}
         assert spec.letta_evals_version is None
+        assert spec.letta_code_version is None
 
     def test_image_override(self):
         spec = ModalSandboxSpec(image="ghcr.io/custom/runtime:1.0")
@@ -87,11 +88,16 @@ class TestModalSandboxSpec:
         # Sanity-check the recipe carries both runtimes.
         assert "letta-evals" in contents
         assert "@letta-ai/letta-code" in contents
+        # The letta-code install must be pinnable via the LETTA_CODE_VERSION
+        # build arg the Modal driver passes from sandbox.letta_code_version.
+        assert "ARG LETTA_CODE_VERSION" in contents
+        assert "@letta-ai/letta-code@${LETTA_CODE_VERSION}" in contents
 
     def test_overrides(self):
         spec = ModalSandboxSpec(
             image="img:1",
             letta_evals_version="0.17.0",
+            letta_code_version="0.27.17",
             secrets=["k1", "k2"],
             forward_env=["MY_CUSTOM_KEY"],
             volumes={"/mnt/cache": "cache-vol"},
@@ -110,6 +116,7 @@ class TestModalSandboxSpec:
         assert spec.block_network is True
         assert spec.app_name == "my-app"
         assert spec.letta_evals_version == "0.17.0"
+        assert spec.letta_code_version == "0.27.17"
 
 
 class TestSuiteSpecWithSandbox:
@@ -161,6 +168,78 @@ class TestExecResult:
         r = ExecResult(stdout="ok", stderr="", return_code=0)
         assert r.stdout == "ok"
         assert r.return_code == 0
+
+
+def _install_fake_modal(monkeypatch):
+    """Inject a fake ``modal`` SDK and return it so tests can assert on calls.
+
+    ``ModalSandbox.start`` imports modal lazily and calls App.lookup,
+    Image.from_dockerfile / from_registry, and Sandbox.create. We stub all of
+    them so start() runs end-to-end without touching Modal, letting us inspect
+    how the image was built.
+    """
+    import sys
+    from unittest.mock import AsyncMock, MagicMock
+
+    import letta_evals.sandbox.modal as modal_driver
+
+    fake_modal = MagicMock(name="modal")
+    fake_modal.App.lookup.aio = AsyncMock(return_value=MagicMock(name="app"))
+    fake_image = MagicMock(name="image")
+    fake_modal.Image.from_dockerfile = MagicMock(return_value=fake_image)
+    fake_modal.Image.from_registry = MagicMock(return_value=fake_image)
+    fake_sandbox = MagicMock(name="sandbox")
+    fake_sandbox.object_id = "sb-xyz"
+    fake_modal.Sandbox.create.aio = AsyncMock(return_value=fake_sandbox)
+
+    monkeypatch.setitem(sys.modules, "modal", fake_modal)
+    monkeypatch.setattr(modal_driver, "_check_modal_auth", lambda: None)
+    return fake_modal
+
+
+class TestModalDriverImageBuild:
+    """The driver turns sandbox.letta_code_version into a Dockerfile build arg."""
+
+    @pytest.mark.asyncio
+    async def test_letta_code_version_becomes_build_arg(self, monkeypatch):
+        from letta_evals.sandbox.modal import ModalSandbox
+
+        fake_modal = _install_fake_modal(monkeypatch)
+        spec = ModalSandboxSpec(letta_code_version="0.27.17", timeout_sec=60, cpu=1, memory_mb=512)
+        sandbox = ModalSandbox(spec=spec, session_id="unit-build-args")
+
+        await sandbox.start()
+
+        fake_modal.Image.from_dockerfile.assert_called_once()
+        _, kwargs = fake_modal.Image.from_dockerfile.call_args
+        assert kwargs["build_args"] == {"LETTA_CODE_VERSION": "0.27.17"}
+        fake_modal.Image.from_registry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unset_version_passes_empty_build_args(self, monkeypatch):
+        from letta_evals.sandbox.modal import ModalSandbox
+
+        fake_modal = _install_fake_modal(monkeypatch)
+        spec = ModalSandboxSpec(timeout_sec=60)
+        sandbox = ModalSandbox(spec=spec, session_id="unit-no-version")
+
+        await sandbox.start()
+
+        _, kwargs = fake_modal.Image.from_dockerfile.call_args
+        assert kwargs["build_args"] == {}
+
+    @pytest.mark.asyncio
+    async def test_registry_image_ignores_version(self, monkeypatch):
+        from letta_evals.sandbox.modal import ModalSandbox
+
+        fake_modal = _install_fake_modal(monkeypatch)
+        spec = ModalSandboxSpec(image="ghcr.io/custom/runtime:1.0", letta_code_version="0.27.17", timeout_sec=60)
+        sandbox = ModalSandbox(spec=spec, session_id="unit-registry")
+
+        await sandbox.start()
+
+        fake_modal.Image.from_registry.assert_called_once_with("ghcr.io/custom/runtime:1.0")
+        fake_modal.Image.from_dockerfile.assert_not_called()
 
 
 class TestModalDriverLazyImport:


### PR DESCRIPTION
## What

Adds a `letta_code_version` field to `ModalSandboxSpec` that pins the `@letta-ai/letta-code` npm version installed in the bundled Modal sandbox image:

```yaml
sandbox:
  kind: modal
  letta_code_version: "0.27.16"   # omit to track npm `latest`
```

This makes sandbox rollouts reproducible against a specific letta-code release instead of always installing whatever `latest` resolves to.

## How

- **`specs.py`** — new optional `letta_code_version` (defaults to `None` → Dockerfile's `latest`, so existing suites are unchanged).
- **`Dockerfile`** — `ARG LETTA_CODE_VERSION=latest` consumed by `npm install -g @letta-ai/letta-code@${LETTA_CODE_VERSION}`.
- **`modal.py`** — driver passes it via `Image.from_dockerfile(build_args=...)` on the bundled-image path; when a pre-built registry `image` is set the field is ignored (registry image bakes in its own letta-code) and the driver logs a warning. Modal keys its image cache on build args, so each pinned version gets its own cached build.
- **tests** — spec defaults/overrides, Dockerfile carries the arg, and three driver tests asserting the build arg is passed / empty / ignored-for-registry (faked `modal` SDK, no network).
- **docs + example** — documented in `docs/modal-sandbox.md` and demonstrated in the `letta-code-simple-edit` modal example.

## Verification

- `pytest tests/test_modal_sandbox.py tests/test_runner_sandbox_dispatch.py` → 25 passed, 1 skipped (opt-in live Modal test); `ruff check` + `ruff format` clean.
- **Live Modal run**: built the bundled image with the pin and confirmed inside a real sandbox:
  ```
  rc=0 | letta --version -> '0.27.16 (Letta Code)'
  PASS: sandbox installed pinned letta-code 0.27.16 (not latest 0.27.18)
  ```

## Notes

- The example suite is pinned to `0.27.16` as a demonstration value — happy to bump it to current `latest` if preferred.