### PR TITLE
fix(sandbox): Drop agent state across result boundary

### DIFF
--- a/letta_evals/cli.py
+++ b/letta_evals/cli.py
@@ -399,7 +399,9 @@ async def _run_single_sample(
 
     output_json_path.parent.mkdir(parents=True, exist_ok=True)
     with open(output_json_path, "w") as f:
-        f.write(result.model_dump_json(exclude_none=True))
+        # agent_state is consumed inside the sandbox for grading/reward, but the
+        # host never needs to deserialize the SDK object across this boundary.
+        f.write(result.model_dump_json(exclude_none=True, exclude={"agent_state"}))
 
 
 def display_multi_run_summary(summary):

--- a/letta_evals/sandbox/dispatch.py
+++ b/letta_evals/sandbox/dispatch.py
@@ -206,6 +206,9 @@ async def run_sample_in_sandbox(
             try:
                 with open(local_result_path, "r") as f:
                     result_data = json.load(f)
+                # Be tolerant of older/custom sandbox images that still wrote
+                # agent_state; the host does not compute on it post-grading.
+                result_data.pop("agent_state", None)
                 sample_result = SampleResult.model_validate(result_data)
             except Exception as e:
                 return sandbox_error_result(

--- a/tests/test_cli_single_sample.py
+++ b/tests/test_cli_single_sample.py
@@ -98,6 +98,34 @@ class TestRunSingleSampleHelper:
         revived = SampleResult.model_validate(data)
         assert revived.grades["acc"].rationale == "canned"
 
+    def test_single_sample_output_excludes_agent_state(self, tmp_path):
+        """The sandbox entrypoint consumes agent_state in-process for grading,
+        but must not serialize it across the sandbox→host boundary."""
+        from letta_evals.cli import _run_single_sample
+
+        suite_path = _write_minimal_suite(tmp_path)
+        sample_path = _write_sample(tmp_path)
+        out_path = tmp_path / "out.json"
+
+        result = _canned_result().model_copy(update={"agent_state": {"provider_type": "unknown-preview-provider"}})
+
+        with patch("letta_evals.runner.Runner.run_sample", new_callable=AsyncMock) as run_sample:
+            run_sample.return_value = result
+            anyio.run(
+                _run_single_sample,
+                suite_path,
+                sample_path,
+                out_path,
+                None,
+                None,
+                None,
+                None,
+            )
+
+        data = json.loads(out_path.read_text())
+        assert data["sample_id"] == "s1"
+        assert "agent_state" not in data
+
     def test_drops_sandbox_field_to_prevent_reentry(self, tmp_path):
         """If the suite YAML declares sandbox:, the in-sandbox path must
         strip it before constructing SuiteSpec — otherwise the Runner would

--- a/tests/test_runner_sandbox_dispatch.py
+++ b/tests/test_runner_sandbox_dispatch.py
@@ -7,6 +7,7 @@ teardown) without touching Modal at all.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock
@@ -152,6 +153,46 @@ class TestRunSampleInSandbox:
         # Result round-tripped.
         assert result.sample_id == "s1"
         assert result.grades["acc"].score == 1.0
+
+    def test_host_drops_agent_state_before_result_validation(self, tmp_path, monkeypatch):
+        """Older/custom sandbox images may still include agent_state in
+        result.json. The host should ignore it before validating SampleResult
+        so provider enum skew in AgentState cannot lose an otherwise successful
+        sample."""
+        _write_suite_yaml(tmp_path)
+        runner = _make_runner_with_sandbox(tmp_path)
+
+        class _SandboxWithUnknownAgentState(_StubSandbox):
+            async def download_file(self, remote: str, local: Path) -> None:
+                self.downloaded.append((remote, local))
+                payload = _canned_result("s1").model_dump(mode="json")
+                payload["agent_state"] = {
+                    "id": "agent-sandbox-1",
+                    "llm_config": {"model_endpoint_type": "unknown-preview-provider"},
+                }
+                local.parent.mkdir(parents=True, exist_ok=True)
+                with open(local, "w") as f:
+                    json.dump(payload, f)
+
+        stub = _SandboxWithUnknownAgentState()
+        monkeypatch.setattr("letta_evals.sandbox.dispatch.ModalSandbox", lambda spec, session_id: stub)
+
+        sample = Sample(id="s1", input="hi", ground_truth="hi")
+        result = anyio.run(
+            run_sample_in_sandbox,
+            runner.suite,
+            sample,
+            "openai/gpt-a",
+            0.0,
+        )
+
+        assert result.error is None
+        assert result.sample_id == "s1"
+        assert result.agent_id == "agent-sandbox-1"
+        assert result.agent_state is None
+        assert result.grades["acc"].score == 1.0
+        assert result.reward is not None
+        assert result.reward.score == 1.0
 
     @pytest.mark.parametrize("suite_filename", ["suite.yaml", "suite-mini.yaml"])
     def test_preserves_exact_suite_file_when_multiple_suite_yamls_exist(self, tmp_path, monkeypatch, suite_filename):


### PR DESCRIPTION
## Summary
- exclude `agent_state` from in-sandbox single-sample result serialization
- defensively drop `agent_state` before host-side sandbox result validation for older/custom sandbox images
- add regressions for both the in-sandbox writer and host sandbox dispatcher

Fixes #309.

## Tests
- `uv run --frozen pytest tests/test_cli_single_sample.py tests/test_runner_sandbox_dispatch.py tests/test_runner_token_data.py`
- `uv run --frozen pytest tests/test_modal_sandbox.py tests/test_runner_sandbox_dispatch.py`
- `uv run --frozen ruff check letta_evals/cli.py letta_evals/sandbox/dispatch.py tests/test_cli_single_sample.py tests/test_runner_sandbox_dispatch.py`

👾 Generated with [Letta Code](https://letta.com)