### PR TITLE
feat(sandbox): Support non-self-contained suites via project_root

### DIFF
--- a/letta_evals/models/specs.py
+++ b/letta_evals/models/specs.py
@@ -143,23 +143,6 @@ class ModalSandboxSpec(BaseModel):
             "(self-contained-suite behavior, unchanged)."
         ),
     )
-    include: List[str] = Field(
-        default_factory=list,
-        description=(
-            "Gitignore-style globs; when non-empty, ONLY matching files under the "
-            "uploaded tree are shipped (an allowlist). Use to trim a large "
-            "project_root down to its code closure. Directories are always "
-            "descended so nested matches are reachable."
-        ),
-    )
-    exclude: List[str] = Field(
-        default_factory=list,
-        description=(
-            "Gitignore-style globs excluded from the upload, on top of built-in "
-            "defaults (.git, __pycache__, *.pyc, .venv, node_modules, and similar "
-            "junk) and any .gitignore patterns. Applied after `include`."
-        ),
-    )
     respect_gitignore: bool = Field(
         default=True,
         description=(

--- a/letta_evals/models/specs.py
+++ b/letta_evals/models/specs.py
@@ -131,6 +131,44 @@ class ModalSandboxSpec(BaseModel):
         default_factory=dict,
         description="Mapping of in-sandbox mount path -> Modal Volume name",
     )
+    project_root: Optional[Path] = Field(
+        default=None,
+        description=(
+            "Optional directory (an ancestor of the suite file) uploaded to the "
+            "sandbox and placed on PYTHONPATH, so a suite that lives inside a "
+            "larger package tree can import shared modules "
+            "(e.g. `from myproject.pkg import ...`) and reference files outside "
+            "the suite folder. Relative paths resolve against the suite file's "
+            "directory. When unset, only the suite directory is uploaded "
+            "(self-contained-suite behavior, unchanged)."
+        ),
+    )
+    include: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Gitignore-style globs; when non-empty, ONLY matching files under the "
+            "uploaded tree are shipped (an allowlist). Use to trim a large "
+            "project_root down to its code closure. Directories are always "
+            "descended so nested matches are reachable."
+        ),
+    )
+    exclude: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Gitignore-style globs excluded from the upload, on top of built-in "
+            "defaults (.git, __pycache__, *.pyc, .venv, node_modules, and similar "
+            "junk) and any .gitignore patterns. Applied after `include`."
+        ),
+    )
+    respect_gitignore: bool = Field(
+        default=True,
+        description=(
+            "When True (default), patterns from the uploaded root's .gitignore are "
+            "excluded from the upload, so anything git ignores is never shipped to "
+            "the sandbox. Reads the root-level .gitignore only; nested .gitignore "
+            "files, the global gitignore, and .git/info/exclude are not consulted."
+        ),
+    )
     cpu: int = Field(default=2, description="vCPU count for the sandbox")
     memory_mb: int = Field(default=2048, description="Memory in MiB for the sandbox")
     timeout_sec: int = Field(default=1800, description="Hard sandbox timeout in seconds")
@@ -329,6 +367,14 @@ class SuiteSpec(BaseModel):
                     gspec["base_dir"] = base_dir
                     resolved_graders[key] = gspec
                 yaml_data["graders"] = resolved_graders
+
+            # resolve sandbox.project_root — the ancestor dir uploaded and made
+            # the import root. Relative paths resolve against the suite file dir.
+            if isinstance(yaml_data.get("sandbox"), dict) and yaml_data["sandbox"].get("project_root"):
+                project_root = Path(yaml_data["sandbox"]["project_root"])
+                if not project_root.is_absolute():
+                    project_root = base_dir / project_root
+                yaml_data["sandbox"]["project_root"] = str(project_root.resolve())
 
             yaml_data["base_dir"] = base_dir
 

--- a/letta_evals/models/specs.py
+++ b/letta_evals/models/specs.py
@@ -364,4 +364,19 @@ class SuiteSpec(BaseModel):
         if suite_path is not None:
             yaml_data["suite_path"] = suite_path
 
+        # Fail fast at load (so `validate` catches it once) when project_root
+        # isn't an ancestor of the suite — otherwise every sample's sandbox
+        # dispatch would fail identically. Deferred when the suite path is
+        # unknown; sandbox_mount re-checks defensively.
+        sandbox_cfg = yaml_data.get("sandbox")
+        if isinstance(sandbox_cfg, dict) and sandbox_cfg.get("project_root") and suite_path is not None:
+            project_root = Path(sandbox_cfg["project_root"])
+            try:
+                suite_path.resolve().relative_to(project_root.resolve())
+            except ValueError as e:
+                raise ValueError(
+                    f"Suite file {suite_path} is not inside sandbox.project_root {project_root}; "
+                    "project_root must be an ancestor of the suite."
+                ) from e
+
         return cls(**yaml_data)

--- a/letta_evals/sandbox/base.py
+++ b/letta_evals/sandbox/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 
 @dataclass
@@ -43,7 +43,9 @@ class AbstractSandbox(ABC):
     async def upload_file(self, local: Path, remote: str) -> None: ...
 
     @abstractmethod
-    async def upload_dir(self, local: Path, remote: str) -> None: ...
+    async def upload_dir(
+        self, local: Path, remote: str, path_filter: Optional[Callable[[str], bool]] = None
+    ) -> None: ...
 
     @abstractmethod
     async def download_file(self, remote: str, local: Path) -> None: ...

--- a/letta_evals/sandbox/dispatch.py
+++ b/letta_evals/sandbox/dispatch.py
@@ -126,29 +126,18 @@ def build_upload_filter(
     Built-in junk excludes always apply. When ``spec.respect_gitignore`` is set
     (the default), the patterns from ``root/.gitignore`` are folded in too — the
     file is just more gitignore-syntax lines, which is exactly what the exclude
-    spec consumes. ``exclude`` then adds to that; a non-empty ``include`` turns
-    file selection into an allowlist. Directories are always kept (descended)
-    unless they themselves match an exclude, so nested allowlisted files stay
-    reachable.
+    spec consumes. A directory that matches an exclude is pruned wholesale;
+    everything else is kept.
     """
     exclude_patterns = list(DEFAULT_UPLOAD_EXCLUDES)
     if spec and spec.respect_gitignore and root is not None:
         gitignore = root / ".gitignore"
         if gitignore.is_file():
             exclude_patterns += gitignore.read_text().splitlines()
-    exclude_patterns += list(spec.exclude if spec else [])
     exclude_spec = pathspec.GitIgnoreSpec.from_lines(exclude_patterns)
-    include_lines = list(spec.include) if spec and spec.include else []
-    include_spec = pathspec.GitIgnoreSpec.from_lines(include_lines) if include_lines else None
 
     def keep(relpath: str, is_dir: bool) -> bool:
-        if exclude_spec.match_file(relpath):
-            return False
-        if is_dir:
-            return True
-        if include_spec is not None and not include_spec.match_file(relpath):
-            return False
-        return True
+        return not exclude_spec.match_file(relpath)
 
     return keep
 

--- a/letta_evals/sandbox/dispatch.py
+++ b/letta_evals/sandbox/dispatch.py
@@ -103,7 +103,9 @@ def sandbox_mount(suite: SuiteSpec) -> SandboxMount:
         )
 
     if suite.suite_path is None:
-        raise ValueError("sandbox.project_root is set but the suite file path is unknown — cannot place the suite YAML.")
+        raise ValueError(
+            "sandbox.project_root is set but the suite file path is unknown — cannot place the suite YAML."
+        )
 
     try:
         suite_yaml_remote = _remote_suite_yaml(suite.suite_path, project_root, "/mnt/project")
@@ -121,9 +123,7 @@ def sandbox_mount(suite: SuiteSpec) -> SandboxMount:
     )
 
 
-def build_upload_filter(
-    spec: Optional[ModalSandboxSpec], root: Optional[Path] = None
-) -> Callable[[str], bool]:
+def build_upload_filter(spec: Optional[ModalSandboxSpec], root: Optional[Path] = None) -> Callable[[str], bool]:
     """Return ``keep(relpath)`` deciding what enters the upload tarball.
 
     Built-in junk excludes always apply. When ``spec.respect_gitignore`` is set
@@ -226,9 +226,7 @@ async def run_sample_in_sandbox(
     try:
         mount = sandbox_mount(suite)
     except ValueError as e:
-        return sandbox_error_result(
-            sample_id, t_sample_start, ErrorCategory.UNKNOWN, "SuiteConfigurationError", str(e)
-        )
+        return sandbox_error_result(sample_id, t_sample_start, ErrorCategory.UNKNOWN, "SuiteConfigurationError", str(e))
 
     sandbox = ModalSandbox(suite.sandbox, session_id=session_id)
     try:

--- a/letta_evals/sandbox/dispatch.py
+++ b/letta_evals/sandbox/dispatch.py
@@ -49,21 +49,27 @@ DEFAULT_SANDBOX_FORWARD_ENV = (
 )
 
 
+def _remote_suite_yaml(suite_path: Path, local_root: Path, remote_root: str) -> str:
+    """Map a host suite-file path to its in-sandbox path under ``remote_root``.
+
+    Tolerates a relative or unresolved ``suite_path`` by falling back to
+    resolving both sides. Raises ``ValueError`` if the suite is not under
+    ``local_root``.
+    """
+    try:
+        relative = suite_path.relative_to(local_root)
+    except ValueError:
+        relative = suite_path.resolve().relative_to(local_root.resolve())
+    return f"{remote_root}/{relative.as_posix()}"
+
+
 def suite_yaml_remote_path(suite: SuiteSpec) -> str:
     """Return the in-sandbox path for the suite file the host loaded."""
     if suite.suite_path is None:
         return "/mnt/suite/suite.yaml"
-
-    base = suite.base_dir
-    if base is None:
+    if suite.base_dir is None:
         return f"/mnt/suite/{suite.suite_path.name}"
-
-    try:
-        relative_suite_path = suite.suite_path.relative_to(base)
-    except ValueError:
-        relative_suite_path = suite.suite_path.resolve().relative_to(base.resolve())
-
-    return f"/mnt/suite/{relative_suite_path.as_posix()}"
+    return _remote_suite_yaml(suite.suite_path, suite.base_dir, "/mnt/suite")
 
 
 @dataclass(frozen=True)
@@ -76,8 +82,7 @@ class SandboxMount:
     """
 
     local_root: Path  # host directory tarred and uploaded
-    remote_root: str  # where it is extracted in the sandbox
-    cwd: str  # in-sandbox working directory for the CLI
+    remote_root: str  # where it is extracted in the sandbox; also the CLI's cwd
     pythonpath: Optional[str]  # dir prepended to PYTHONPATH, or None
     suite_yaml_remote: str  # in-sandbox path to the suite YAML
 
@@ -93,7 +98,6 @@ def sandbox_mount(suite: SuiteSpec) -> SandboxMount:
         return SandboxMount(
             local_root=suite.base_dir,
             remote_root="/mnt/suite",
-            cwd="/mnt/suite",
             pythonpath=None,
             suite_yaml_remote=suite_yaml_remote_path(suite),
         )
@@ -102,7 +106,7 @@ def sandbox_mount(suite: SuiteSpec) -> SandboxMount:
         raise ValueError("sandbox.project_root is set but the suite file path is unknown — cannot place the suite YAML.")
 
     try:
-        relative_suite_path = suite.suite_path.resolve().relative_to(project_root.resolve())
+        suite_yaml_remote = _remote_suite_yaml(suite.suite_path, project_root, "/mnt/project")
     except ValueError as e:
         raise ValueError(
             f"Suite file {suite.suite_path} is not inside sandbox.project_root {project_root}; "
@@ -112,21 +116,21 @@ def sandbox_mount(suite: SuiteSpec) -> SandboxMount:
     return SandboxMount(
         local_root=project_root,
         remote_root="/mnt/project",
-        cwd="/mnt/project",
         pythonpath="/mnt/project",
-        suite_yaml_remote=f"/mnt/project/{relative_suite_path.as_posix()}",
+        suite_yaml_remote=suite_yaml_remote,
     )
 
 
 def build_upload_filter(
     spec: Optional[ModalSandboxSpec], root: Optional[Path] = None
-) -> Callable[[str, bool], bool]:
-    """Return ``keep(relpath, is_dir)`` deciding what enters the upload tarball.
+) -> Callable[[str], bool]:
+    """Return ``keep(relpath)`` deciding what enters the upload tarball.
 
     Built-in junk excludes always apply. When ``spec.respect_gitignore`` is set
     (the default), the patterns from ``root/.gitignore`` are folded in too — the
     file is just more gitignore-syntax lines, which is exactly what the exclude
-    spec consumes. A directory that matches an exclude is pruned wholesale;
+    spec consumes. A directory that matches an exclude is pruned wholesale (a
+    property of ``tarfile.add`` skipping recursion when the filter drops it);
     everything else is kept.
     """
     exclude_patterns = list(DEFAULT_UPLOAD_EXCLUDES)
@@ -136,7 +140,7 @@ def build_upload_filter(
             exclude_patterns += gitignore.read_text().splitlines()
     exclude_spec = pathspec.GitIgnoreSpec.from_lines(exclude_patterns)
 
-    def keep(relpath: str, is_dir: bool) -> bool:
+    def keep(relpath: str) -> bool:
         return not exclude_spec.match_file(relpath)
 
     return keep
@@ -173,7 +177,7 @@ def build_sandbox_command(mount: SandboxMount, model_handle: Optional[str]) -> s
         cmd_parts += ["--model-handle", model_handle]
 
     inner_command = " ".join(shlex.quote(p) for p in cmd_parts)
-    prefix = f"cd {shlex.quote(mount.cwd)}"
+    prefix = f"cd {shlex.quote(mount.remote_root)}"
     if mount.pythonpath:
         # Prepend the import root, preserving any PYTHONPATH the image already set.
         prefix += f" && export PYTHONPATH={shlex.quote(mount.pythonpath)}${{PYTHONPATH:+:$PYTHONPATH}}"

--- a/letta_evals/sandbox/dispatch.py
+++ b/letta_evals/sandbox/dispatch.py
@@ -5,14 +5,35 @@ import shlex
 import tempfile
 import time
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional
 
-from letta_evals.models import Error, Sample, SampleResult, SuiteSpec, Timing
+import pathspec
+
+from letta_evals.models import Error, ModalSandboxSpec, Sample, SampleResult, SuiteSpec, Timing
 from letta_evals.sandbox.modal import ModalSandbox
 from letta_evals.types import ErrorCategory
 
 logger = logging.getLogger(__name__)
+
+# Always dropped from the upload regardless of user config — VCS metadata,
+# caches, virtualenvs, and editor cruft that would only bloat the per-sample
+# tarball. Gitignore-style: a bare name matches at any depth.
+DEFAULT_UPLOAD_EXCLUDES = (
+    ".git",
+    "__pycache__",
+    "*.pyc",
+    "*.pyo",
+    ".venv",
+    "venv",
+    "node_modules",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "*.egg-info",
+    ".DS_Store",
+)
 
 # Built-in host env vars forwarded to Modal sandboxes. Only explicit names are
 # forwarded; suite authors can extend this with `sandbox.forward_env`.
@@ -45,6 +66,93 @@ def suite_yaml_remote_path(suite: SuiteSpec) -> str:
     return f"/mnt/suite/{relative_suite_path.as_posix()}"
 
 
+@dataclass(frozen=True)
+class SandboxMount:
+    """Where the suite's code lands in the sandbox and how the CLI is invoked.
+
+    ``project_root`` mode uploads an ancestor package tree so absolute imports
+    resolve; the default (``project_root`` unset) uploads just the suite
+    directory, preserving self-contained-suite behavior byte-for-byte.
+    """
+
+    local_root: Path  # host directory tarred and uploaded
+    remote_root: str  # where it is extracted in the sandbox
+    cwd: str  # in-sandbox working directory for the CLI
+    pythonpath: Optional[str]  # dir prepended to PYTHONPATH, or None
+    suite_yaml_remote: str  # in-sandbox path to the suite YAML
+
+
+def sandbox_mount(suite: SuiteSpec) -> SandboxMount:
+    """Compute the upload/exec layout for a suite's sandbox run.
+
+    Raises SuiteConfigurationError-style ValueErrors with actionable messages
+    when the layout can't be resolved (e.g. suite not under project_root).
+    """
+    project_root = suite.sandbox.project_root if suite.sandbox else None
+    if project_root is None:
+        return SandboxMount(
+            local_root=suite.base_dir,
+            remote_root="/mnt/suite",
+            cwd="/mnt/suite",
+            pythonpath=None,
+            suite_yaml_remote=suite_yaml_remote_path(suite),
+        )
+
+    if suite.suite_path is None:
+        raise ValueError("sandbox.project_root is set but the suite file path is unknown — cannot place the suite YAML.")
+
+    try:
+        relative_suite_path = suite.suite_path.resolve().relative_to(project_root.resolve())
+    except ValueError as e:
+        raise ValueError(
+            f"Suite file {suite.suite_path} is not inside sandbox.project_root {project_root}; "
+            "project_root must be an ancestor of the suite."
+        ) from e
+
+    return SandboxMount(
+        local_root=project_root,
+        remote_root="/mnt/project",
+        cwd="/mnt/project",
+        pythonpath="/mnt/project",
+        suite_yaml_remote=f"/mnt/project/{relative_suite_path.as_posix()}",
+    )
+
+
+def build_upload_filter(
+    spec: Optional[ModalSandboxSpec], root: Optional[Path] = None
+) -> Callable[[str, bool], bool]:
+    """Return ``keep(relpath, is_dir)`` deciding what enters the upload tarball.
+
+    Built-in junk excludes always apply. When ``spec.respect_gitignore`` is set
+    (the default), the patterns from ``root/.gitignore`` are folded in too — the
+    file is just more gitignore-syntax lines, which is exactly what the exclude
+    spec consumes. ``exclude`` then adds to that; a non-empty ``include`` turns
+    file selection into an allowlist. Directories are always kept (descended)
+    unless they themselves match an exclude, so nested allowlisted files stay
+    reachable.
+    """
+    exclude_patterns = list(DEFAULT_UPLOAD_EXCLUDES)
+    if spec and spec.respect_gitignore and root is not None:
+        gitignore = root / ".gitignore"
+        if gitignore.is_file():
+            exclude_patterns += gitignore.read_text().splitlines()
+    exclude_patterns += list(spec.exclude if spec else [])
+    exclude_spec = pathspec.GitIgnoreSpec.from_lines(exclude_patterns)
+    include_lines = list(spec.include) if spec and spec.include else []
+    include_spec = pathspec.GitIgnoreSpec.from_lines(include_lines) if include_lines else None
+
+    def keep(relpath: str, is_dir: bool) -> bool:
+        if exclude_spec.match_file(relpath):
+            return False
+        if is_dir:
+            return True
+        if include_spec is not None and not include_spec.match_file(relpath):
+            return False
+        return True
+
+    return keep
+
+
 def sandbox_error_result(
     sample_id, t_sample_start: float, category: ErrorCategory, exception_type: str, message: str
 ) -> SampleResult:
@@ -62,12 +170,11 @@ def sandbox_error_result(
     )
 
 
-def build_sandbox_command(suite: SuiteSpec, model_handle: Optional[str]) -> str:
-    suite_yaml_remote = suite_yaml_remote_path(suite)
+def build_sandbox_command(mount: SandboxMount, model_handle: Optional[str]) -> str:
     cmd_parts = [
         "letta-evals",
         "run",
-        suite_yaml_remote,
+        mount.suite_yaml_remote,
         "--sample",
         "/mnt/sample.json",
         "--output-json",
@@ -77,7 +184,11 @@ def build_sandbox_command(suite: SuiteSpec, model_handle: Optional[str]) -> str:
         cmd_parts += ["--model-handle", model_handle]
 
     inner_command = " ".join(shlex.quote(p) for p in cmd_parts)
-    return f"cd /mnt/suite && {inner_command}"
+    prefix = f"cd {shlex.quote(mount.cwd)}"
+    if mount.pythonpath:
+        # Prepend the import root, preserving any PYTHONPATH the image already set.
+        prefix += f" && export PYTHONPATH={shlex.quote(mount.pythonpath)}${{PYTHONPATH:+:$PYTHONPATH}}"
+    return f"{prefix} && {inner_command}"
 
 
 def forwarded_sandbox_env(suite: SuiteSpec) -> Dict[str, str]:
@@ -119,6 +230,13 @@ async def run_sample_in_sandbox(
             "SuiteSpec.base_dir is unset — required for sandbox execution.",
         )
 
+    try:
+        mount = sandbox_mount(suite)
+    except ValueError as e:
+        return sandbox_error_result(
+            sample_id, t_sample_start, ErrorCategory.UNKNOWN, "SuiteConfigurationError", str(e)
+        )
+
     sandbox = ModalSandbox(suite.sandbox, session_id=session_id)
     try:
         try:
@@ -147,7 +265,8 @@ async def run_sample_in_sandbox(
                     sample_id, t_sample_start, ErrorCategory.UNKNOWN, "VersionMismatch", message
                 )
 
-        await sandbox.upload_dir(suite.base_dir, "/mnt/suite")
+        upload_filter = build_upload_filter(suite.sandbox, mount.local_root)
+        await sandbox.upload_dir(mount.local_root, mount.remote_root, path_filter=upload_filter)
 
         with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as tmp:
             tmp.write(Sample.model_validate(sample.model_dump()).model_dump_json())
@@ -157,7 +276,7 @@ async def run_sample_in_sandbox(
         finally:
             tmp_path.unlink(missing_ok=True)
 
-        command = build_sandbox_command(suite, model_handle)
+        command = build_sandbox_command(mount, model_handle)
         exec_env = forwarded_sandbox_env(suite)
         if exec_env:
             logger.debug("Forwarding env vars to sandbox %s: %s", sandbox.sandbox_id, sorted(exec_env))

--- a/letta_evals/sandbox/modal.py
+++ b/letta_evals/sandbox/modal.py
@@ -15,7 +15,7 @@ import shlex
 import tarfile
 import tempfile
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
 
 from letta_evals.models import ModalSandboxSpec
 from letta_evals.sandbox.base import AbstractSandbox, ExecResult, SandboxAuthError, SandboxNotInstalledError
@@ -153,22 +153,38 @@ class ModalSandbox(AbstractSandbox):
         # tarball, /mnt after upload_dir's mkdir for sample.json).
         await self._sandbox.filesystem.copy_from_local.aio(str(local), remote)
 
-    async def upload_dir(self, local: Path, remote: str) -> None:
+    async def upload_dir(
+        self,
+        local: Path,
+        remote: str,
+        path_filter: Optional[Callable[[str], bool]] = None,
+    ) -> None:
         """Tar up ``local`` on the host, stream into the sandbox, extract at ``remote``.
 
         Avoids per-file SDK round trips (which add up fast for suites with
         large datasets) by going through a single tar exec call.
+
+        ``path_filter(relpath, is_dir)`` selects what enters the tarball: it
+        receives each member's POSIX path relative to ``local`` and whether it
+        is a directory, and returns True to keep it. Returning False for a
+        directory prunes its whole subtree. None uploads everything.
         """
         if self._sandbox is None:
             raise RuntimeError("Sandbox not started — call start() first")
         if not local.is_dir():
             raise ValueError(f"upload_dir: local path is not a directory: {local}")
 
+        def _tar_filter(tarinfo: tarfile.TarInfo) -> Optional[tarfile.TarInfo]:
+            if path_filter is None or tarinfo.name in (".", ""):
+                return tarinfo
+            relpath = tarinfo.name[2:] if tarinfo.name.startswith("./") else tarinfo.name
+            return tarinfo if path_filter(relpath, tarinfo.isdir()) else None
+
         with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
             tar_path = Path(tmp.name)
         try:
             with tarfile.open(tar_path, "w:gz") as tar:
-                tar.add(local, arcname=".")
+                tar.add(local, arcname=".", filter=_tar_filter)
 
             remote_tar = f"/tmp/{self.session_id}-suite.tar.gz"
             await self.upload_file(tar_path, remote_tar)

--- a/letta_evals/sandbox/modal.py
+++ b/letta_evals/sandbox/modal.py
@@ -164,10 +164,10 @@ class ModalSandbox(AbstractSandbox):
         Avoids per-file SDK round trips (which add up fast for suites with
         large datasets) by going through a single tar exec call.
 
-        ``path_filter(relpath, is_dir)`` selects what enters the tarball: it
-        receives each member's POSIX path relative to ``local`` and whether it
-        is a directory, and returns True to keep it. Returning False for a
-        directory prunes its whole subtree. None uploads everything.
+        ``path_filter(relpath)`` selects what enters the tarball: it receives
+        each member's POSIX path relative to ``local`` and returns True to keep
+        it. Dropping a directory prunes its whole subtree (``tarfile`` skips
+        recursion into a filtered-out dir). None uploads everything.
         """
         if self._sandbox is None:
             raise RuntimeError("Sandbox not started — call start() first")
@@ -178,7 +178,7 @@ class ModalSandbox(AbstractSandbox):
             if path_filter is None or tarinfo.name in (".", ""):
                 return tarinfo
             relpath = tarinfo.name[2:] if tarinfo.name.startswith("./") else tarinfo.name
-            return tarinfo if path_filter(relpath, tarinfo.isdir()) else None
+            return tarinfo if path_filter(relpath) else None
 
         with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as tmp:
             tar_path = Path(tmp.name)

--- a/tests/test_modal_sandbox.py
+++ b/tests/test_modal_sandbox.py
@@ -155,6 +155,17 @@ class TestSuiteSpecWithSandbox:
         suite = SuiteSpec.from_yaml(yaml_data, base_dir=tmp_path / "sub")
         assert suite.sandbox.project_root == tmp_path.resolve()
 
+    def test_project_root_must_be_ancestor_of_suite(self, tmp_path):
+        """A project_root that doesn't contain the suite fails at load, so
+        `validate` catches it once instead of every sample failing later."""
+        suite_dir = tmp_path / "suite"
+        suite_dir.mkdir()
+        (tmp_path / "other").mkdir()
+        yaml_data = _minimal_suite_yaml(project_root="../other")
+
+        with pytest.raises(ValueError, match="must be an ancestor"):
+            SuiteSpec.from_yaml(yaml_data, base_dir=suite_dir, suite_path=suite_dir / "suite.yaml")
+
     def test_target_memory_workspace_fields_parse_and_resolve(self, tmp_path):
         yaml_data = _minimal_suite_yaml()
         yaml_data["target"] = {
@@ -187,26 +198,26 @@ class TestUploadFilter:
     def test_default_excludes_drop_junk_but_keep_code_and_data(self):
         keep = build_upload_filter(ModalSandboxSpec())
         # Kept: source, config, data.
-        assert keep("pkg/mod.py", False)
-        assert keep("pyproject.toml", False)
-        assert keep("data/samples.jsonl", False)
+        assert keep("pkg/mod.py")
+        assert keep("pyproject.toml")
+        assert keep("data/samples.jsonl")
         # Dropped: VCS, caches, virtualenvs, compiled/editor junk (at any depth).
-        assert not keep(".git", True)
-        assert not keep("pkg/__pycache__", True)
-        assert not keep("pkg/mod.pyc", False)
-        assert not keep("node_modules", True)
+        assert not keep(".git")
+        assert not keep("pkg/__pycache__")
+        assert not keep("pkg/mod.pyc")
+        assert not keep("node_modules")
 
     def test_respects_gitignore_at_root(self, tmp_path):
         (tmp_path / ".gitignore").write_text("data/large/\n*.log\n")
         keep = build_upload_filter(ModalSandboxSpec(), root=tmp_path)
-        assert keep("pkg/mod.py", False)
-        assert not keep("data/large/blob.bin", False)
-        assert not keep("run.log", False)
+        assert keep("pkg/mod.py")
+        assert not keep("data/large/blob.bin")
+        assert not keep("run.log")
 
     def test_gitignore_ignored_when_respect_gitignore_false(self, tmp_path):
         (tmp_path / ".gitignore").write_text("*.log\n")
         keep = build_upload_filter(ModalSandboxSpec(respect_gitignore=False), root=tmp_path)
-        assert keep("run.log", False)
+        assert keep("run.log")
 
 
 class TestUploadDirFiltering:

--- a/tests/test_modal_sandbox.py
+++ b/tests/test_modal_sandbox.py
@@ -9,12 +9,16 @@ The spec-parsing tests do not touch Modal at all.
 from __future__ import annotations
 
 import os
+import tarfile
 from pathlib import Path
 
+import anyio
 import pytest
 
 from letta_evals.models import ModalSandboxSpec, SuiteSpec
 from letta_evals.sandbox.base import ExecResult
+from letta_evals.sandbox.dispatch import build_upload_filter
+from letta_evals.sandbox.modal import ModalSandbox
 
 
 def _minimal_suite_yaml(**sandbox_overrides):
@@ -55,6 +59,10 @@ class TestModalSandboxSpec:
         assert spec.volumes == {}
         assert spec.letta_evals_version is None
         assert spec.letta_code_version is None
+        assert spec.project_root is None
+        assert spec.include == []
+        assert spec.exclude == []
+        assert spec.respect_gitignore is True
 
     def test_image_override(self):
         spec = ModalSandboxSpec(image="ghcr.io/custom/runtime:1.0")
@@ -135,6 +143,20 @@ class TestSuiteSpecWithSandbox:
         assert suite.sandbox.secrets == ["letta-api-key"]
         assert suite.sandbox.cpu == 4
 
+    def test_project_root_resolves_relative_to_suite_dir(self, tmp_path):
+        suite_dir = tmp_path / "suites" / "mini"
+        suite_dir.mkdir(parents=True)
+        yaml_data = _minimal_suite_yaml(project_root="../..")
+
+        suite = SuiteSpec.from_yaml(yaml_data, base_dir=suite_dir)
+
+        assert suite.sandbox.project_root == tmp_path.resolve()
+
+    def test_absolute_project_root_is_preserved(self, tmp_path):
+        yaml_data = _minimal_suite_yaml(project_root=str(tmp_path))
+        suite = SuiteSpec.from_yaml(yaml_data, base_dir=tmp_path / "sub")
+        assert suite.sandbox.project_root == tmp_path.resolve()
+
     def test_target_memory_workspace_fields_parse_and_resolve(self, tmp_path):
         yaml_data = _minimal_suite_yaml()
         yaml_data["target"] = {
@@ -161,6 +183,88 @@ class TestSuiteSpecWithSandbox:
 
         with pytest.raises(ValueError, match="permission_mode: memory was removed"):
             SuiteSpec.from_yaml(yaml_data, base_dir=tmp_path)
+
+
+class TestUploadFilter:
+    def test_default_excludes_drop_junk_but_keep_code_and_data(self):
+        keep = build_upload_filter(ModalSandboxSpec())
+        # Kept: source, config, data.
+        assert keep("pkg/mod.py", False)
+        assert keep("pyproject.toml", False)
+        assert keep("data/samples.jsonl", False)
+        # Dropped: VCS, caches, virtualenvs, compiled/editor junk (at any depth).
+        assert not keep(".git", True)
+        assert not keep("pkg/__pycache__", True)
+        assert not keep("pkg/mod.pyc", False)
+        assert not keep("node_modules", True)
+
+    def test_include_is_an_allowlist_that_still_descends_directories(self):
+        keep = build_upload_filter(ModalSandboxSpec(include=["pkg/**", "pyproject.toml"]))
+        # Directories always descend so nested allowlisted files stay reachable.
+        assert keep("pkg", True)
+        assert keep("other", True)
+        # Files must match an include pattern.
+        assert keep("pkg/mod.py", False)
+        assert keep("pyproject.toml", False)
+        assert not keep("other/notes.txt", False)
+
+    def test_user_exclude_wins_over_include(self):
+        keep = build_upload_filter(ModalSandboxSpec(include=["pkg/**"], exclude=["pkg/secret.py"]))
+        assert keep("pkg/mod.py", False)
+        assert not keep("pkg/secret.py", False)
+
+    def test_respects_gitignore_at_root(self, tmp_path):
+        (tmp_path / ".gitignore").write_text("data/large/\n*.log\n")
+        keep = build_upload_filter(ModalSandboxSpec(), root=tmp_path)
+        assert keep("pkg/mod.py", False)
+        assert not keep("data/large/blob.bin", False)
+        assert not keep("run.log", False)
+
+    def test_gitignore_ignored_when_respect_gitignore_false(self, tmp_path):
+        (tmp_path / ".gitignore").write_text("*.log\n")
+        keep = build_upload_filter(ModalSandboxSpec(respect_gitignore=False), root=tmp_path)
+        assert keep("run.log", False)
+
+
+class TestUploadDirFiltering:
+    def test_tarball_excludes_filtered_members(self, tmp_path):
+        """upload_dir wires the filter into tarfile.add: excluded subtrees never
+        enter the streamed archive."""
+        root = tmp_path / "project"
+        (root / "pkg").mkdir(parents=True)
+        (root / "pkg" / "mod.py").write_text("x = 1\n")
+        (root / "pkg" / "__pycache__").mkdir()
+        (root / "pkg" / "__pycache__" / "mod.pyc").write_text("junk")
+        (root / ".git").mkdir()
+        (root / ".git" / "config").write_text("[core]\n")
+        (root / "data").mkdir()
+        (root / "data" / "samples.jsonl").write_text("{}\n")
+
+        captured: dict = {}
+
+        class _TarCapturingSandbox(ModalSandbox):
+            def __init__(self):
+                self._sandbox = object()  # non-None sentinel; skip real Modal init
+                self.session_id = "cap"
+
+            async def upload_file(self, local: Path, remote: str) -> None:
+                with tarfile.open(local, "r:gz") as tar:
+                    captured["names"] = {n for n in tar.getnames() if n not in (".", "")}
+
+            async def exec(self, command, env=None, timeout_sec=None):
+                return ExecResult(stdout="", stderr="", return_code=0)
+
+        sb = _TarCapturingSandbox()
+        keep = build_upload_filter(ModalSandboxSpec())
+        anyio.run(sb.upload_dir, root, "/mnt/project", keep)
+
+        names = captured["names"]
+        assert "./pkg/mod.py" in names
+        assert "./data/samples.jsonl" in names
+        # Excluded subtrees are pruned wholesale — not even the dir entry ships.
+        assert not any(".git" in n for n in names)
+        assert not any("__pycache__" in n for n in names)
+        assert not any(n.endswith(".pyc") for n in names)
 
 
 class TestExecResult:

--- a/tests/test_modal_sandbox.py
+++ b/tests/test_modal_sandbox.py
@@ -60,8 +60,6 @@ class TestModalSandboxSpec:
         assert spec.letta_evals_version is None
         assert spec.letta_code_version is None
         assert spec.project_root is None
-        assert spec.include == []
-        assert spec.exclude == []
         assert spec.respect_gitignore is True
 
     def test_image_override(self):
@@ -197,21 +195,6 @@ class TestUploadFilter:
         assert not keep("pkg/__pycache__", True)
         assert not keep("pkg/mod.pyc", False)
         assert not keep("node_modules", True)
-
-    def test_include_is_an_allowlist_that_still_descends_directories(self):
-        keep = build_upload_filter(ModalSandboxSpec(include=["pkg/**", "pyproject.toml"]))
-        # Directories always descend so nested allowlisted files stay reachable.
-        assert keep("pkg", True)
-        assert keep("other", True)
-        # Files must match an include pattern.
-        assert keep("pkg/mod.py", False)
-        assert keep("pyproject.toml", False)
-        assert not keep("other/notes.txt", False)
-
-    def test_user_exclude_wins_over_include(self):
-        keep = build_upload_filter(ModalSandboxSpec(include=["pkg/**"], exclude=["pkg/secret.py"]))
-        assert keep("pkg/mod.py", False)
-        assert not keep("pkg/secret.py", False)
 
     def test_respects_gitignore_at_root(self, tmp_path):
         (tmp_path / ".gitignore").write_text("data/large/\n*.log\n")

--- a/tests/test_runner_sandbox_dispatch.py
+++ b/tests/test_runner_sandbox_dispatch.py
@@ -71,8 +71,9 @@ class _StubSandbox:
     async def upload_file(self, local: Path, remote: str) -> None:
         self.uploaded_files.append((local, remote))
 
-    async def upload_dir(self, local: Path, remote: str) -> None:
+    async def upload_dir(self, local: Path, remote: str, path_filter=None) -> None:
         self.uploaded_dirs.append((local, remote))
+        self.upload_filter = path_filter
 
     async def download_file(self, remote: str, local: Path) -> None:
         self.downloaded.append((remote, local))
@@ -153,6 +154,59 @@ class TestRunSampleInSandbox:
         # Result round-tripped.
         assert result.sample_id == "s1"
         assert result.grades["acc"].score == 1.0
+
+    def test_project_root_uploads_ancestor_and_sets_pythonpath(self, tmp_path, monkeypatch):
+        """With sandbox.project_root set, the ancestor tree is uploaded to
+        /mnt/project, the CLI runs there with it on PYTHONPATH, and the suite
+        YAML is addressed relative to project_root."""
+        suite_dir = tmp_path / "suites" / "mini"
+        suite_dir.mkdir(parents=True)
+        suite_path = suite_dir / "suite.yaml"
+        suite_path.write_text("name: test-suite\n")
+
+        spec = ModalSandboxSpec(image="img:test", timeout_sec=60, project_root=tmp_path)
+        runner = _make_runner_with_sandbox(tmp_path, sandbox_spec=spec)
+        runner.suite.base_dir = suite_dir
+        runner.suite.suite_path = suite_path
+
+        stub = _StubSandbox()
+        monkeypatch.setattr("letta_evals.sandbox.dispatch.ModalSandbox", lambda spec, session_id: stub)
+
+        sample = Sample(id="s1", input="hi", ground_truth="hi")
+        result = anyio.run(run_sample_in_sandbox, runner.suite, sample, "openai/gpt-a", 0.0)
+
+        # The whole project_root (not just the suite dir) is uploaded to /mnt/project.
+        assert (tmp_path, "/mnt/project") in stub.uploaded_dirs
+        cmd = _sandbox_cli_command(stub)
+        assert "cd /mnt/project" in cmd
+        assert "PYTHONPATH=/mnt/project" in cmd
+        # Suite YAML addressed relative to project_root, not /mnt/suite.
+        assert "/mnt/project/suites/mini/suite.yaml" in cmd
+        assert "/mnt/suite" not in cmd
+        assert result.sample_id == "s1"
+
+    def test_project_root_rejects_suite_outside_root(self, tmp_path, monkeypatch):
+        """A project_root that isn't an ancestor of the suite is a config error,
+        surfaced without ever starting a sandbox."""
+        outside_root = tmp_path / "other"
+        outside_root.mkdir()
+        suite_dir = tmp_path / "suite"
+        suite_dir.mkdir()
+
+        spec = ModalSandboxSpec(image="img:test", timeout_sec=60, project_root=outside_root)
+        runner = _make_runner_with_sandbox(tmp_path, sandbox_spec=spec)
+        runner.suite.base_dir = suite_dir
+        runner.suite.suite_path = suite_dir / "suite.yaml"
+
+        stub = _StubSandbox()
+        monkeypatch.setattr("letta_evals.sandbox.dispatch.ModalSandbox", lambda spec, session_id: stub)
+
+        sample = Sample(id="s1", input="hi", ground_truth="hi")
+        result = anyio.run(run_sample_in_sandbox, runner.suite, sample, "openai/gpt-a", 0.0)
+
+        assert not stub.started, "config error must short-circuit before starting a sandbox"
+        assert result.error is not None
+        assert result.error.exception_type == "SuiteConfigurationError"
 
     def test_host_drops_agent_state_before_result_validation(self, tmp_path, monkeypatch):
         """Older/custom sandbox images may still include agent_state in


### PR DESCRIPTION
## Problem

The Modal sandbox dispatch uploaded only the suite YAML's own directory (`base_dir`) to `/mnt/suite` and ran there. That assumes every suite is a single self-contained directory. A suite that lives **inside a larger package tree** couldn't be sandboxed, even though it runs fine in-process:

- **Files outside `base_dir`** — a suite referencing `../agent_setup.py`, `../extractors.py`, `../graders.py` never got those parent files uploaded.
- **Absolute package imports** — `from <project>.<pkg> import ...` needs the package root on `sys.path`; a flat `/mnt/suite` has no such package, so the agent factory / extractor `ModuleNotFoundError`s before any rollout.

Closes #311.

## Change

A suite can declare a **project root** that is uploaded and made the import root:

- `ModalSandboxSpec.project_root` — an ancestor directory of the suite. When set, dispatch uploads it to `/mnt/project`, sets `cwd=/mnt/project`, prepends `/mnt/project` to `PYTHONPATH`, and addresses the suite YAML **relative to `project_root`**. Relative paths resolve against the suite file's directory. **Unset preserves today's `base_dir`-only behavior exactly.**
- `ModalSandboxSpec.respect_gitignore` (default `true`) — the root `.gitignore` patterns are folded into the upload filter, so anything git ignores is never shipped.

The upload is bounded by a filter that always drops junk (`.git`, `__pycache__`, `*.pyc`, `.venv`, `node_modules`, …) and, by default, whatever the root `.gitignore` ignores. A directory matching an exclude is pruned wholesale.

The upload rule in one sentence: **ship `project_root`, minus the built-in junk list, minus what the root `.gitignore` ignores.**

### Why it's small

The in-sandbox CLI re-loads the suite YAML (`cli.py`) and re-derives `base_dir` from where the file landed, and drops `sandbox:` to prevent re-entry. So this is purely a file-layout + cwd + `PYTHONPATH` change — no path-resolution logic moved.

## Notes

- Data lives inside `project_root` and is uploaded with the code (small datasets), so every sample sees the host's current bytes — no Volume staleness.
- `respect_gitignore` reads the **root-level** `.gitignore` only; nested `.gitignore` files, the global gitignore, and `.git/info/exclude` are not consulted (documented on the field).
- Pairs with #312 (agent_state not serialized across the boundary).

## Tests

Added coverage for: `project_root` upload target / `PYTHONPATH` / yaml-path, the suite-outside-root config error, the junk-default and `.gitignore` filter behavior, a real-tarball prune check, and `from_yaml` path resolution. Full suite green, ruff clean.