### PR TITLE
perf: Lazy import heavy eval dependencies

### DIFF
--- a/letta_evals/datasets/loader.py
+++ b/letta_evals/datasets/loader.py
@@ -1,8 +1,6 @@
 import json
 from pathlib import Path
-from typing import Iterator, List, Optional, Union
-
-import pandas as pd
+from typing import Any, Iterator, List, Optional, Union
 
 from letta_evals.models import Sample, SampleId
 
@@ -23,7 +21,9 @@ def _json_sample_id(data: dict, fallback: int) -> SampleId:
     return fallback
 
 
-def _csv_sample_id(df: pd.DataFrame, row, fallback: int) -> SampleId:
+def _csv_sample_id(df: Any, row: Any, fallback: int) -> SampleId:
+    import pandas as pd
+
     for field_name in ("sample_id", "id"):
         if field_name in df.columns and not pd.isna(row.get(field_name)):
             return _normalize_sample_id(row[field_name])
@@ -119,8 +119,10 @@ def _parse_string_or_list(value: str, field_name: str, row_idx: int) -> Union[st
     return value_str
 
 
-def _parse_json_dict_field(df: pd.DataFrame, row, field_name: str, row_idx) -> Optional[dict]:
+def _parse_json_dict_field(df: Any, row: Any, field_name: str, row_idx) -> Optional[dict]:
     """Parse an optional CSV column that expects a JSON object string."""
+    import pandas as pd
+
     if field_name not in df.columns or pd.isna(row.get(field_name)):
         return None
     try:
@@ -148,6 +150,8 @@ def load_csv(
     - rubric_path (optional): per-sample rubric file path. Resolved relative
       to the dataset file's directory. Mutually exclusive with ``rubric``.
     """
+    import pandas as pd
+
     try:
         df = pd.read_csv(file_path)
     except Exception as e:

--- a/letta_evals/graders/rubric.py
+++ b/letta_evals/graders/rubric.py
@@ -3,10 +3,7 @@ import os
 from pathlib import Path
 from typing import Optional, Tuple
 
-from anthropic import AsyncAnthropic, transform_schema
 from dotenv import load_dotenv
-from google import genai
-from openai import AsyncOpenAI
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import Field as PydanticField
 
@@ -70,6 +67,8 @@ class RubricGrader(Grader):
             if not api_key:
                 raise ValueError("OPENAI_API_KEY not found in environment variables")
 
+            from openai import AsyncOpenAI
+
             client_kwargs = {
                 "api_key": api_key,
                 "max_retries": max_retries,
@@ -86,6 +85,8 @@ class RubricGrader(Grader):
             if not api_key:
                 raise ValueError("ANTHROPIC_API_KEY not found in environment variables")
 
+            from anthropic import AsyncAnthropic
+
             client_kwargs = {
                 "api_key": api_key,
                 "max_retries": max_retries,
@@ -101,6 +102,9 @@ class RubricGrader(Grader):
             api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
             if not api_key:
                 raise ValueError("GEMINI_API_KEY or GOOGLE_API_KEY not found in environment variables")
+
+            from google import genai
+
             self.client = genai.Client(api_key=api_key)
         else:
             raise ValueError(f"Unsupported provider: {provider}")
@@ -158,6 +162,8 @@ class RubricGrader(Grader):
                 usage = response.usage.model_dump() if response.usage else None
 
             elif self.provider == LLMProvider.ANTHROPIC:
+                from anthropic import transform_schema
+
                 kwargs = dict(
                     model=self.model,
                     max_tokens=4096,
@@ -179,6 +185,8 @@ class RubricGrader(Grader):
                     "cache_read_input_tokens": getattr(response.usage, "cache_read_input_tokens", 0),
                 }
             elif self.provider == LLMProvider.GOOGLE:
+                from google import genai
+
                 google_config_kwargs = dict(
                     response_mime_type="application/json",
                     response_schema=_JudgeResponse,

--- a/tests/test_import_laziness.py
+++ b/tests/test_import_laziness.py
@@ -1,0 +1,35 @@
+"""Smoke tests for keeping package imports lightweight."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_package_import_does_not_eagerly_import_provider_sdks_or_pandas():
+    code = """
+import sys
+import letta_evals
+
+unexpected = [
+    module_name
+    for module_name in ("anthropic", "google.genai", "openai", "pandas")
+    if module_name in sys.modules
+]
+if unexpected:
+    raise AssertionError(f"unexpected eager imports: {unexpected}")
+"""
+    env = os.environ.copy()
+    repo_root = Path(__file__).resolve().parents[1]
+    env["PYTHONPATH"] = str(repo_root) + os.pathsep + env.get("PYTHONPATH", "")
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=repo_root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- lazy-import OpenAI, Anthropic, and Google provider SDKs only on the selected rubric-grader path
- lazy-import pandas only for CSV dataset loading
- add a subprocess smoke test that guards against eager package import regressions

## Import-time comparison
Warm local `python -X importtime -c "import letta_evals"`, 10 runs each after one warmup:

| ref | mean | median | eager heavy imports |
|---|---:|---:|---|
| `origin/main` | 1369 ms | 1364 ms | `anthropic`, `google.genai`, `openai`, `pandas` |
| this branch | 388 ms | 389 ms | none of those |

## Tests
- `uv run ruff check letta_evals/datasets/loader.py letta_evals/graders/rubric.py tests/test_import_laziness.py`
- `uv run pytest tests/test_import_laziness.py tests/test_loader.py tests/test_rubric_grader.py -q`

Closes #314

👾 Generated with [Letta Code](https://letta.com)