### PR TITLE
feat(datasets): Support HuggingFace Hub-backed datasets in `dataset:`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,15 @@ Dataset rows may also include fields such as:
 - `agent_args` for programmatic agent factories
 - `rubric` or `rubric_path` for per-sample model-judge rubric overrides
 
+Instead of a local path, `dataset:` may point at a dataset hosted on the [HuggingFace Hub](https://huggingface.co/). The single manifest file is fetched and cached on the host, then loaded exactly like a local file:
+
+```yaml
+# pin a revision (tag / branch / commit SHA) for reproducible runs
+dataset: https://huggingface.co/datasets/letta-ai/swe-chat-tagged/resolve/<revision>/train.jsonl
+```
+
+This needs the optional extra (`pip install 'letta-evals[hf]'`). Private repos work with a standard `HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN` in the environment. Fetching happens host-side, so nothing is downloaded inside the Modal sandbox. An unpinned revision (a bare repo URL, or `.../resolve/main/...`) warns and surfaces the resolved commit so the run stays reproducible from its logs; a bare repo URL is accepted only when the repo holds exactly one `.jsonl`/`.csv` manifest. Relative `rubric_path` values still resolve against the suite directory, not the HF cache.
+
 ### Targets
 
 The supported target is `letta_code`, which runs the Letta Code CLI against a Letta server. Important target fields include:

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Instead of a local path, `dataset:` may point at a dataset hosted on the [Huggin
 dataset: https://huggingface.co/datasets/letta-ai/swe-chat-tagged/resolve/<revision>/train.jsonl
 ```
 
-This needs the optional extra (`pip install 'letta-evals[hf]'`). Private repos work with a standard `HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN` in the environment. Fetching happens host-side, so nothing is downloaded inside the Modal sandbox. An unpinned revision (a bare repo URL, or `.../resolve/main/...`) warns and surfaces the resolved commit so the run stays reproducible from its logs; a bare repo URL is accepted only when the repo holds exactly one `.jsonl`/`.csv` manifest. Relative `rubric_path` values still resolve against the suite directory, not the HF cache.
+Private repos work with a standard `HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN` in the environment. Fetching happens host-side, so nothing is downloaded inside the Modal sandbox. An unpinned revision (a bare repo URL, or `.../resolve/main/...`) warns and surfaces the resolved commit so the run stays reproducible from its logs; the resolved commit SHA is also recorded in `suite.json` under `config.dataset_provenance`. A bare repo URL is accepted only when the repo holds exactly one `.jsonl`/`.csv` manifest. Relative `rubric_path` values still resolve against the suite directory, not the HF cache.
 
 ### Targets
 

--- a/letta_evals/cli.py
+++ b/letta_evals/cli.py
@@ -160,7 +160,14 @@ def run(
         )
         effective_output = output if output is not None else suite.output
 
-        samples = list(load_dataset(suite.dataset, max_samples=suite.max_samples, sample_tags=suite.sample_tags))
+        samples = list(
+            load_dataset(
+                suite.dataset,
+                max_samples=suite.max_samples,
+                sample_tags=suite.sample_tags,
+                base_dir=suite.base_dir,
+            )
+        )
         num_samples = len(samples)
 
         # calculate total evaluations (samples × models)

--- a/letta_evals/datasets/hf.py
+++ b/letta_evals/datasets/hf.py
@@ -1,0 +1,216 @@
+"""HuggingFace Hub-backed dataset resolution.
+
+Resolves an HF dataset reference in a suite's ``dataset:`` field to a local
+file, which the loader then reads exactly as it would a local path. Only the
+single manifest file named in the reference is fetched -- never the whole repo
+-- so large repos stay cheap, and on the Modal sandbox path nothing is fetched
+in-sandbox (the host loads the dataset and ships each sample as JSON via
+``--sample``).
+
+``huggingface_hub`` is imported lazily -- only when an HF ref is actually used
+-- and ships as an optional extra: ``pip install 'letta-evals[hf]'``. Suites
+that only use local paths never pay for it.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+from urllib.parse import unquote, urlparse
+
+_HF_HOST = "huggingface.co"
+_MANIFEST_SUFFIXES = (".jsonl", ".csv")
+
+
+def is_hf_ref(value) -> bool:
+    """Return True if ``value`` is a HuggingFace Hub URL.
+
+    Only ``https://huggingface.co/...`` (and the http variant) count as HF
+    references; everything else -- local path strings and ``Path`` objects --
+    is left untouched so filesystem datasets behave exactly as before.
+    """
+    if not isinstance(value, str):
+        return False
+    v = value.strip().lower()
+    return v.startswith(f"https://{_HF_HOST}/") or v.startswith(f"http://{_HF_HOST}/")
+
+
+@dataclass(frozen=True)
+class HfDatasetRef:
+    """A parsed HuggingFace Hub reference to a single manifest file."""
+
+    repo_id: str
+    repo_type: str  # "dataset" | "model" | "space"
+    revision: Optional[str]  # None => unpinned; resolves to the repo default branch
+    path: Optional[str]  # None => bare repo URL; the manifest is resolved on fetch
+
+
+@dataclass(frozen=True)
+class ResolvedHfDataset:
+    """The outcome of fetching an ``HfDatasetRef`` to local disk."""
+
+    local_path: Path
+    repo_id: str
+    repo_type: str
+    revision: Optional[str]
+    path: str
+    commit_sha: Optional[str]  # the exact commit the run read, when recoverable
+
+
+def parse_hf_ref(value: str) -> HfDatasetRef:
+    """Parse a huggingface.co URL into an :class:`HfDatasetRef`.
+
+    Accepts the repo landing URL and the file (``/resolve/`` or ``/blob/``)
+    URL::
+
+        https://huggingface.co/datasets/<org>/<repo>
+        https://huggingface.co/datasets/<org>/<repo>/resolve/<rev>/<path>
+        https://huggingface.co/datasets/<org>/<repo>/blob/<rev>/<path>
+
+    Model and Space repos are recognized via the leading path segment: no
+    prefix => model, ``spaces/`` => space, ``datasets/`` => dataset.
+    """
+    parsed = urlparse(value.strip())
+    segments = [unquote(s) for s in parsed.path.split("/") if s]
+
+    if segments and segments[0] == "datasets":
+        repo_type = "dataset"
+        segments = segments[1:]
+    elif segments and segments[0] == "spaces":
+        repo_type = "space"
+        segments = segments[1:]
+    else:
+        repo_type = "model"
+
+    if len(segments) < 2:
+        raise ValueError(
+            f"Cannot parse HuggingFace dataset URL {value!r}: expected "
+            "'https://huggingface.co/datasets/<org>/<repo>[/resolve/<rev>/<file>]'."
+        )
+
+    repo_id = f"{segments[0]}/{segments[1]}"
+    rest = segments[2:]
+
+    if not rest:
+        # Bare repo URL: manifest file and revision are resolved on fetch.
+        return HfDatasetRef(repo_id=repo_id, repo_type=repo_type, revision=None, path=None)
+
+    if rest[0] in ("resolve", "blob"):
+        if len(rest) < 3:
+            raise ValueError(
+                f"HuggingFace file URL {value!r} is missing a revision and/or file path; "
+                "expected '.../resolve/<rev>/<file>'."
+            )
+        return HfDatasetRef(
+            repo_id=repo_id,
+            repo_type=repo_type,
+            revision=rest[1],
+            path="/".join(rest[2:]),
+        )
+
+    raise ValueError(
+        f"Unrecognized HuggingFace URL shape {value!r}; expected a repo URL or a "
+        "'.../resolve/<rev>/<file>' file URL."
+    )
+
+
+def _is_unpinned(revision: Optional[str]) -> bool:
+    """Whether ``revision`` is a mutable ref that breaks reproducibility.
+
+    Telling a tag from a branch needs a network round-trip, so we only flag the
+    unambiguous mutable cases: no revision, and the default branch names. A
+    commit SHA or a tag is treated as pinned and does not warn.
+    """
+    return revision is None or revision in ("main", "master")
+
+
+def _commit_sha_from_cache_path(local_path: Path) -> Optional[str]:
+    """Extract the resolved commit SHA from an ``hf_hub_download`` cache path.
+
+    Downloads resolve under ``<cache>/<repo>/snapshots/<commit_sha>/<file>``;
+    the segment right after ``snapshots`` is the exact commit the run read.
+    Returns ``None`` if the layout isn't recognized (best-effort provenance).
+    """
+    parts = local_path.parts
+    try:
+        i = parts.index("snapshots")
+    except ValueError:
+        return None
+    return parts[i + 1] if i + 1 < len(parts) else None
+
+
+def _import_hf():
+    try:
+        import huggingface_hub
+    except ImportError as e:
+        raise ImportError(
+            "HuggingFace-backed datasets require the 'huggingface_hub' package. "
+            "Install it with: pip install 'letta-evals[hf]'."
+        ) from e
+    return huggingface_hub
+
+
+def _resolve_manifest_filename(hub, ref: HfDatasetRef) -> str:
+    """Find the single ``.jsonl``/``.csv`` manifest in a bare-repo reference."""
+    files = hub.list_repo_files(repo_id=ref.repo_id, repo_type=ref.repo_type, revision=ref.revision)
+    candidates = [f for f in files if f.lower().endswith(_MANIFEST_SUFFIXES)]
+    if not candidates:
+        raise ValueError(
+            f"No .jsonl/.csv manifest found in HuggingFace repo {ref.repo_id!r}. "
+            "Point 'dataset:' at the file directly, e.g. "
+            f"https://huggingface.co/datasets/{ref.repo_id}/resolve/<rev>/<file>."
+        )
+    if len(candidates) > 1:
+        raise ValueError(
+            f"HuggingFace repo {ref.repo_id!r} has multiple manifests {sorted(candidates)}; "
+            "point 'dataset:' at one of them, e.g. "
+            f"https://huggingface.co/datasets/{ref.repo_id}/resolve/<rev>/<file>."
+        )
+    return candidates[0]
+
+
+def resolve_hf_dataset(value: str) -> ResolvedHfDataset:
+    """Fetch the manifest named by an HF URL and return its local path + provenance.
+
+    Uses ``huggingface_hub``'s local cache, so repeated runs and repeated
+    samples within a run don't re-download. The token is read from the standard
+    ``HF_TOKEN`` / ``HUGGING_FACE_HUB_TOKEN`` env (``huggingface_hub``'s
+    default), so private repos work with no extra config. Warns when the
+    revision is unpinned (mutable), surfacing the resolved commit SHA so the run
+    stays reproducible from its logs.
+    """
+    ref = parse_hf_ref(value)
+    hub = _import_hf()
+
+    filename = ref.path if ref.path is not None else _resolve_manifest_filename(hub, ref)
+
+    local_path = Path(
+        hub.hf_hub_download(
+            repo_id=ref.repo_id,
+            filename=filename,
+            repo_type=ref.repo_type,
+            revision=ref.revision,
+        )
+    )
+    commit_sha = _commit_sha_from_cache_path(local_path)
+
+    if _is_unpinned(ref.revision):
+        pinned = commit_sha or "<commit-sha>"
+        warnings.warn(
+            f"HuggingFace dataset {ref.repo_id!r} loaded at an unpinned revision "
+            f"({ref.revision or 'default branch'}); this is mutable and silently breaks "
+            "reproducibility. Pin the run to the resolved commit: "
+            f"https://huggingface.co/datasets/{ref.repo_id}/resolve/{pinned}/{filename}",
+            stacklevel=2,
+        )
+
+    return ResolvedHfDataset(
+        local_path=local_path,
+        repo_id=ref.repo_id,
+        repo_type=ref.repo_type,
+        revision=ref.revision,
+        path=filename,
+        commit_sha=commit_sha,
+    )

--- a/letta_evals/datasets/hf.py
+++ b/letta_evals/datasets/hf.py
@@ -99,8 +99,7 @@ def parse_hf_ref(value: str) -> HfDatasetRef:
         return HfDatasetRef(repo_id=repo_id, revision=rest[1], path="/".join(rest[2:]))
 
     raise ValueError(
-        f"Unrecognized HuggingFace URL shape {value!r}; expected a repo URL or a "
-        "'.../resolve/<rev>/<file>' file URL."
+        f"Unrecognized HuggingFace URL shape {value!r}; expected a repo URL or a '.../resolve/<rev>/<file>' file URL."
     )
 
 

--- a/letta_evals/datasets/hf.py
+++ b/letta_evals/datasets/hf.py
@@ -8,8 +8,8 @@ in-sandbox (the host loads the dataset and ships each sample as JSON via
 ``--sample``).
 
 ``huggingface_hub`` is imported lazily -- only when an HF ref is actually used
--- and ships as an optional extra: ``pip install 'letta-evals[hf]'``. Suites
-that only use local paths never pay for it.
+-- so suites that only reference local paths don't pay for the import at
+startup.
 """
 
 from __future__ import annotations
@@ -25,24 +25,23 @@ _MANIFEST_SUFFIXES = (".jsonl", ".csv")
 
 
 def is_hf_ref(value) -> bool:
-    """Return True if ``value`` is a HuggingFace Hub URL.
+    """Return True if ``value`` is a HuggingFace Hub *dataset* URL.
 
-    Only ``https://huggingface.co/...`` (and the http variant) count as HF
-    references; everything else -- local path strings and ``Path`` objects --
-    is left untouched so filesystem datasets behave exactly as before.
+    Only ``https://huggingface.co/datasets/...`` (and the http variant) count;
+    everything else -- local path strings and ``Path`` objects -- is left
+    untouched so filesystem datasets behave exactly as before.
     """
     if not isinstance(value, str):
         return False
     v = value.strip().lower()
-    return v.startswith(f"https://{_HF_HOST}/") or v.startswith(f"http://{_HF_HOST}/")
+    return v.startswith(f"https://{_HF_HOST}/datasets/") or v.startswith(f"http://{_HF_HOST}/datasets/")
 
 
 @dataclass(frozen=True)
 class HfDatasetRef:
-    """A parsed HuggingFace Hub reference to a single manifest file."""
+    """A parsed HuggingFace Hub reference to a single dataset manifest file."""
 
     repo_id: str
-    repo_type: str  # "dataset" | "model" | "space"
     revision: Optional[str]  # None => unpinned; resolves to the repo default branch
     path: Optional[str]  # None => bare repo URL; the manifest is resolved on fetch
 
@@ -53,14 +52,13 @@ class ResolvedHfDataset:
 
     local_path: Path
     repo_id: str
-    repo_type: str
     revision: Optional[str]
     path: str
     commit_sha: Optional[str]  # the exact commit the run read, when recoverable
 
 
 def parse_hf_ref(value: str) -> HfDatasetRef:
-    """Parse a huggingface.co URL into an :class:`HfDatasetRef`.
+    """Parse a huggingface.co dataset URL into an :class:`HfDatasetRef`.
 
     Accepts the repo landing URL and the file (``/resolve/`` or ``/blob/``)
     URL::
@@ -68,21 +66,16 @@ def parse_hf_ref(value: str) -> HfDatasetRef:
         https://huggingface.co/datasets/<org>/<repo>
         https://huggingface.co/datasets/<org>/<repo>/resolve/<rev>/<path>
         https://huggingface.co/datasets/<org>/<repo>/blob/<rev>/<path>
-
-    Model and Space repos are recognized via the leading path segment: no
-    prefix => model, ``spaces/`` => space, ``datasets/`` => dataset.
     """
     parsed = urlparse(value.strip())
     segments = [unquote(s) for s in parsed.path.split("/") if s]
 
-    if segments and segments[0] == "datasets":
-        repo_type = "dataset"
-        segments = segments[1:]
-    elif segments and segments[0] == "spaces":
-        repo_type = "space"
-        segments = segments[1:]
-    else:
-        repo_type = "model"
+    if not segments or segments[0] != "datasets":
+        raise ValueError(
+            f"Cannot parse HuggingFace dataset URL {value!r}: expected "
+            "'https://huggingface.co/datasets/<org>/<repo>[/resolve/<rev>/<file>]'."
+        )
+    segments = segments[1:]
 
     if len(segments) < 2:
         raise ValueError(
@@ -95,7 +88,7 @@ def parse_hf_ref(value: str) -> HfDatasetRef:
 
     if not rest:
         # Bare repo URL: manifest file and revision are resolved on fetch.
-        return HfDatasetRef(repo_id=repo_id, repo_type=repo_type, revision=None, path=None)
+        return HfDatasetRef(repo_id=repo_id, revision=None, path=None)
 
     if rest[0] in ("resolve", "blob"):
         if len(rest) < 3:
@@ -103,27 +96,12 @@ def parse_hf_ref(value: str) -> HfDatasetRef:
                 f"HuggingFace file URL {value!r} is missing a revision and/or file path; "
                 "expected '.../resolve/<rev>/<file>'."
             )
-        return HfDatasetRef(
-            repo_id=repo_id,
-            repo_type=repo_type,
-            revision=rest[1],
-            path="/".join(rest[2:]),
-        )
+        return HfDatasetRef(repo_id=repo_id, revision=rest[1], path="/".join(rest[2:]))
 
     raise ValueError(
         f"Unrecognized HuggingFace URL shape {value!r}; expected a repo URL or a "
         "'.../resolve/<rev>/<file>' file URL."
     )
-
-
-def _is_unpinned(revision: Optional[str]) -> bool:
-    """Whether ``revision`` is a mutable ref that breaks reproducibility.
-
-    Telling a tag from a branch needs a network round-trip, so we only flag the
-    unambiguous mutable cases: no revision, and the default branch names. A
-    commit SHA or a tag is treated as pinned and does not warn.
-    """
-    return revision is None or revision in ("main", "master")
 
 
 def _commit_sha_from_cache_path(local_path: Path) -> Optional[str]:
@@ -141,20 +119,11 @@ def _commit_sha_from_cache_path(local_path: Path) -> Optional[str]:
     return parts[i + 1] if i + 1 < len(parts) else None
 
 
-def _import_hf():
-    try:
-        import huggingface_hub
-    except ImportError as e:
-        raise ImportError(
-            "HuggingFace-backed datasets require the 'huggingface_hub' package. "
-            "Install it with: pip install 'letta-evals[hf]'."
-        ) from e
-    return huggingface_hub
-
-
-def _resolve_manifest_filename(hub, ref: HfDatasetRef) -> str:
+def _resolve_manifest_filename(ref: HfDatasetRef) -> str:
     """Find the single ``.jsonl``/``.csv`` manifest in a bare-repo reference."""
-    files = hub.list_repo_files(repo_id=ref.repo_id, repo_type=ref.repo_type, revision=ref.revision)
+    import huggingface_hub
+
+    files = huggingface_hub.list_repo_files(repo_id=ref.repo_id, repo_type="dataset", revision=ref.revision)
     candidates = [f for f in files if f.lower().endswith(_MANIFEST_SUFFIXES)]
     if not candidates:
         raise ValueError(
@@ -181,22 +150,22 @@ def resolve_hf_dataset(value: str) -> ResolvedHfDataset:
     revision is unpinned (mutable), surfacing the resolved commit SHA so the run
     stays reproducible from its logs.
     """
-    ref = parse_hf_ref(value)
-    hub = _import_hf()
+    import huggingface_hub
 
-    filename = ref.path if ref.path is not None else _resolve_manifest_filename(hub, ref)
+    ref = parse_hf_ref(value)
+    filename = ref.path if ref.path is not None else _resolve_manifest_filename(ref)
 
     local_path = Path(
-        hub.hf_hub_download(
+        huggingface_hub.hf_hub_download(
             repo_id=ref.repo_id,
             filename=filename,
-            repo_type=ref.repo_type,
+            repo_type="dataset",
             revision=ref.revision,
         )
     )
     commit_sha = _commit_sha_from_cache_path(local_path)
 
-    if _is_unpinned(ref.revision):
+    if ref.revision is None or ref.revision in ("main", "master"):
         pinned = commit_sha or "<commit-sha>"
         warnings.warn(
             f"HuggingFace dataset {ref.repo_id!r} loaded at an unpinned revision "
@@ -209,8 +178,28 @@ def resolve_hf_dataset(value: str) -> ResolvedHfDataset:
     return ResolvedHfDataset(
         local_path=local_path,
         repo_id=ref.repo_id,
-        repo_type=ref.repo_type,
         revision=ref.revision,
         path=filename,
         commit_sha=commit_sha,
     )
+
+
+def hf_dataset_provenance(dataset_ref) -> Optional[dict]:
+    """Return a JSON-serializable provenance record for an HF ``dataset:`` value.
+
+    ``None`` for local paths. For an HF URL, resolves it (cached) and reports
+    the repo, the requested revision, and the exact commit SHA the run read --
+    intended to be persisted into ``suite.json`` so a completed run records the
+    precise dataset snapshot it used.
+    """
+    if not is_hf_ref(dataset_ref):
+        return None
+    resolved = resolve_hf_dataset(str(dataset_ref))
+    return {
+        "source": "huggingface",
+        "url": str(dataset_ref),
+        "repo_id": resolved.repo_id,
+        "path": resolved.path,
+        "revision": resolved.revision,
+        "commit_sha": resolved.commit_sha,
+    }

--- a/letta_evals/datasets/loader.py
+++ b/letta_evals/datasets/loader.py
@@ -33,7 +33,7 @@ def _csv_sample_id(df: Any, row: Any, fallback: int) -> SampleId:
 def _resolve_rubric_fields(
     rubric_inline: Optional[str],
     rubric_path: Optional[str],
-    dataset_dir: Path,
+    base_dir: Path,
     row_idx: int,
 ) -> Optional[str]:
     """Resolve per-sample rubric fields into a single rubric string.
@@ -41,13 +41,20 @@ def _resolve_rubric_fields(
     Returns the rubric text (loaded from disk if ``rubric_path`` is set,
     otherwise the inline ``rubric``), or ``None`` if neither is provided.
     Raises ``ValueError`` if both are set.
+
+    Relative ``rubric_path`` values resolve against ``base_dir`` (the suite
+    directory), consistent with every other path field in the suite —
+    ``function``, ``extractor``, ``prompt_path``, ``setup_script``, etc. This
+    is what lets a dataset live somewhere other than the suite dir (e.g. an
+    HF-backed manifest in ``~/.cache/huggingface``) while its rubric files
+    stay resolvable next to the suite.
     """
     if rubric_inline is not None and rubric_path is not None:
         raise ValueError(f"Row {row_idx}: cannot set both 'rubric' and 'rubric_path'. Use one or the other.")
     if rubric_path is not None:
         path = Path(rubric_path)
         if not path.is_absolute():
-            path = (dataset_dir / path).resolve()
+            path = (base_dir / path).resolve()
         if not path.exists():
             raise ValueError(f"Row {row_idx}: rubric_path '{rubric_path}' does not exist (resolved to {path}).")
         with open(path, "r") as f:
@@ -56,10 +63,18 @@ def _resolve_rubric_fields(
 
 
 def load_jsonl(
-    file_path: Path, max_samples: Optional[int] = None, sample_tags: Optional[List[str]] = None
+    file_path: Path,
+    max_samples: Optional[int] = None,
+    sample_tags: Optional[List[str]] = None,
+    base_dir: Optional[Path] = None,
 ) -> Iterator[Sample]:
-    """Load samples from a JSONL file."""
-    dataset_dir = file_path.parent
+    """Load samples from a JSONL file.
+
+    ``base_dir`` is the suite directory, used to resolve relative
+    ``rubric_path`` values. Falls back to the dataset file's own directory
+    when unset (e.g. direct calls); for a colocated dataset the two coincide.
+    """
+    rubric_base = base_dir if base_dir is not None else file_path.parent
     with open(file_path, "r") as f:
         line_index = 0
         yielded_count = 0
@@ -78,7 +93,7 @@ def load_jsonl(
             rubric_text = _resolve_rubric_fields(
                 data.get("rubric"),
                 data.get("rubric_path"),
-                dataset_dir,
+                rubric_base,
                 line_index,
             )
             sample = Sample(
@@ -135,7 +150,10 @@ def _parse_json_dict_field(df: Any, row: Any, field_name: str, row_idx) -> Optio
 
 
 def load_csv(
-    file_path: Path, max_samples: Optional[int] = None, sample_tags: Optional[List[str]] = None
+    file_path: Path,
+    max_samples: Optional[int] = None,
+    sample_tags: Optional[List[str]] = None,
+    base_dir: Optional[Path] = None,
 ) -> Iterator[Sample]:
     """Load samples from a CSV file.
 
@@ -148,7 +166,7 @@ def load_csv(
     - rubric (optional): per-sample rubric text (multi-line strings in CSV
       cells are awkward; prefer ``rubric_path`` for non-trivial rubrics)
     - rubric_path (optional): per-sample rubric file path. Resolved relative
-      to the dataset file's directory. Mutually exclusive with ``rubric``.
+      to ``base_dir`` (the suite directory). Mutually exclusive with ``rubric``.
     """
     import pandas as pd
 
@@ -163,7 +181,7 @@ def load_csv(
     if "input" not in df.columns:
         raise ValueError(f"CSV file {file_path} missing required column 'input'. Found columns: {list(df.columns)}")
 
-    dataset_dir = file_path.parent
+    rubric_base = base_dir if base_dir is not None else file_path.parent
     yielded_count = 0
     for idx, row in df.iterrows():
         if max_samples and yielded_count >= max_samples:
@@ -191,7 +209,7 @@ def load_csv(
         if "rubric_path" in df.columns and not pd.isna(row.get("rubric_path")):
             rubric_path_value = str(row["rubric_path"]).strip()
 
-        rubric_text = _resolve_rubric_fields(rubric_inline, rubric_path_value, dataset_dir, int(idx))
+        rubric_text = _resolve_rubric_fields(rubric_inline, rubric_path_value, rubric_base, int(idx))
 
         # create sample
         try:
@@ -212,7 +230,10 @@ def load_csv(
 
 
 def load_dataset(
-    file_path: Union[str, Path], max_samples: Optional[int] = None, sample_tags: Optional[List[str]] = None
+    file_path: Union[str, Path],
+    max_samples: Optional[int] = None,
+    sample_tags: Optional[List[str]] = None,
+    base_dir: Optional[Path] = None,
 ) -> Iterator[Sample]:
     """Load samples from a dataset file (JSONL or CSV).
 
@@ -224,6 +245,8 @@ def load_dataset(
         file_path: Path to dataset file (.jsonl or .csv)
         max_samples: Maximum number of samples to load
         sample_tags: Filter samples by tags (not currently supported)
+        base_dir: Suite directory, used to resolve relative ``rubric_path``
+            values. Defaults to the dataset file's own directory when unset.
 
     Returns:
         Iterator of Sample objects
@@ -239,8 +262,8 @@ def load_dataset(
     suffix = file_path.suffix.lower()
 
     if suffix == ".jsonl":
-        return load_jsonl(file_path, max_samples=max_samples, sample_tags=sample_tags)
+        return load_jsonl(file_path, max_samples=max_samples, sample_tags=sample_tags, base_dir=base_dir)
     elif suffix == ".csv":
-        return load_csv(file_path, max_samples=max_samples, sample_tags=sample_tags)
+        return load_csv(file_path, max_samples=max_samples, sample_tags=sample_tags, base_dir=base_dir)
     else:
         raise ValueError(f"Unsupported dataset format: {suffix}. Supported formats: .jsonl, .csv")

--- a/letta_evals/datasets/loader.py
+++ b/letta_evals/datasets/loader.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 from typing import Any, Iterator, List, Optional, Union
 
+from letta_evals.datasets.hf import is_hf_ref, resolve_hf_dataset
 from letta_evals.models import Sample, SampleId
 
 
@@ -237,16 +238,20 @@ def load_dataset(
 ) -> Iterator[Sample]:
     """Load samples from a dataset file (JSONL or CSV).
 
-    Automatically detects format based on file extension:
+    ``file_path`` is a local path or a HuggingFace Hub URL. HF URLs are fetched
+    (single manifest file, cached) to a local path first; format is then
+    detected by file extension exactly as for a local file:
     - .jsonl: Load as JSONL
     - .csv: Load as CSV
 
     Args:
-        file_path: Path to dataset file (.jsonl or .csv)
+        file_path: Local path or HuggingFace Hub URL to the dataset (.jsonl/.csv)
         max_samples: Maximum number of samples to load
         sample_tags: Filter samples by tags (not currently supported)
         base_dir: Suite directory, used to resolve relative ``rubric_path``
             values. Defaults to the dataset file's own directory when unset.
+            For HF-backed datasets this stays the suite dir, so rubric files
+            resolve next to the suite rather than in the HF cache.
 
     Returns:
         Iterator of Sample objects
@@ -254,16 +259,18 @@ def load_dataset(
     Raises:
         ValueError: If file format is unsupported or file is invalid
     """
-    file_path = Path(file_path)
+    if is_hf_ref(file_path):
+        local_path = resolve_hf_dataset(str(file_path)).local_path
+    else:
+        local_path = Path(file_path)
+        if not local_path.exists():
+            raise ValueError(f"Dataset file does not exist: {local_path}")
 
-    if not file_path.exists():
-        raise ValueError(f"Dataset file does not exist: {file_path}")
-
-    suffix = file_path.suffix.lower()
+    suffix = local_path.suffix.lower()
 
     if suffix == ".jsonl":
-        return load_jsonl(file_path, max_samples=max_samples, sample_tags=sample_tags, base_dir=base_dir)
+        return load_jsonl(local_path, max_samples=max_samples, sample_tags=sample_tags, base_dir=base_dir)
     elif suffix == ".csv":
-        return load_csv(file_path, max_samples=max_samples, sample_tags=sample_tags, base_dir=base_dir)
+        return load_csv(local_path, max_samples=max_samples, sample_tags=sample_tags, base_dir=base_dir)
     else:
         raise ValueError(f"Unsupported dataset format: {suffix}. Supported formats: .jsonl, .csv")

--- a/letta_evals/datasets/loader.py
+++ b/letta_evals/datasets/loader.py
@@ -41,14 +41,8 @@ def _resolve_rubric_fields(
 
     Returns the rubric text (loaded from disk if ``rubric_path`` is set,
     otherwise the inline ``rubric``), or ``None`` if neither is provided.
-    Raises ``ValueError`` if both are set.
-
     Relative ``rubric_path`` values resolve against ``base_dir`` (the suite
-    directory), consistent with every other path field in the suite —
-    ``function``, ``extractor``, ``prompt_path``, ``setup_script``, etc. This
-    is what lets a dataset live somewhere other than the suite dir (e.g. an
-    HF-backed manifest in ``~/.cache/huggingface``) while its rubric files
-    stay resolvable next to the suite.
+    dir). Raises ``ValueError`` if both are set.
     """
     if rubric_inline is not None and rubric_path is not None:
         raise ValueError(f"Row {row_idx}: cannot set both 'rubric' and 'rubric_path'. Use one or the other.")

--- a/letta_evals/models/specs.py
+++ b/letta_evals/models/specs.py
@@ -10,6 +10,7 @@ from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from letta_evals.datasets.hf import is_hf_ref
 from letta_evals.types import (
     GraderKind,
     LLMProvider,
@@ -258,7 +259,13 @@ class SuiteSpec(BaseModel):
 
     name: str = Field(description="Name of the evaluation suite")
     description: Optional[str] = Field(default=None, description="Description of what this suite evaluates")
-    dataset: Path = Field(description="Path to JSONL dataset file")
+    dataset: str = Field(
+        description=(
+            "Local path or HuggingFace Hub URL to the JSONL/CSV dataset file. "
+            "HF URLs (https://huggingface.co/datasets/<org>/<repo>/resolve/<rev>/<file>) "
+            "are fetched and cached on the host; local paths resolve against the suite dir."
+        )
+    )
     target: LettaCodeTargetSpec = Field(description="Target configuration")
     graders: Optional[Dict[str, GraderSpec]] = Field(default=None, description="Multiple graders keyed by metric name")
     reward: RewardSpec = Field(description="Per-sample reward composition contract")
@@ -304,9 +311,12 @@ class SuiteSpec(BaseModel):
     ) -> "SuiteSpec":
         """Create from parsed YAML data."""
         if base_dir:
-            # resolve dataset path
-            if "dataset" in yaml_data and not Path(yaml_data["dataset"]).is_absolute():
-                yaml_data["dataset"] = str((base_dir / yaml_data["dataset"]).resolve())
+            # resolve dataset path (HF Hub URLs are left as-is; only local
+            # relative paths are anchored to the suite dir)
+            if "dataset" in yaml_data:
+                dataset_ref = yaml_data["dataset"]
+                if not is_hf_ref(dataset_ref) and not Path(dataset_ref).is_absolute():
+                    yaml_data["dataset"] = str((base_dir / dataset_ref).resolve())
 
             # resolve output path
             if "output" in yaml_data and yaml_data["output"] and not Path(yaml_data["output"]).is_absolute():

--- a/letta_evals/models/specs.py
+++ b/letta_evals/models/specs.py
@@ -291,6 +291,12 @@ class SuiteSpec(BaseModel):
         ),
     )
 
+    # Resolved dataset provenance, populated at run time (HF repo / revision /
+    # commit SHA) so a completed run records the exact dataset snapshot it used.
+    # None for local datasets. Serialized into suite.json, unlike the internal
+    # path-resolution fields below.
+    dataset_provenance: Optional[Dict[str, Any]] = Field(default=None)
+
     # internal fields for path resolution / dispatch
     base_dir: Optional[Path] = Field(default=None, exclude=True)
     suite_path: Optional[Path] = Field(default=None, exclude=True)

--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -585,7 +585,12 @@ class Runner:
             await self._run_setup()
 
         samples = list(
-            load_dataset(self.suite.dataset, max_samples=self.suite.max_samples, sample_tags=self.suite.sample_tags)
+            load_dataset(
+                self.suite.dataset,
+                max_samples=self.suite.max_samples,
+                sample_tags=self.suite.sample_tags,
+                base_dir=self.suite.base_dir,
+            )
         )
         self._sample_lookup = {s.id: s for s in samples}
 
@@ -724,7 +729,14 @@ async def run_suite(
         cached_results = await StreamingReader.to_runner_result(cached_results_path)
 
         cached_sample_map = {s.id: s for s in cached_results.samples}
-        samples = list(load_dataset(suite.dataset, max_samples=suite.max_samples, sample_tags=suite.sample_tags))
+        samples = list(
+            load_dataset(
+                suite.dataset,
+                max_samples=suite.max_samples,
+                sample_tags=suite.sample_tags,
+                base_dir=suite.base_dir,
+            )
+        )
 
         for sample in samples:
             if sample.id in cached_sample_map:
@@ -734,7 +746,14 @@ async def run_suite(
                         f"Sample ID {sample.id} input mismatch: dataset has '{sample.input}' but cache has '{cached_sample.input}'"
                     )
 
-    samples = list(load_dataset(suite.dataset, max_samples=suite.max_samples, sample_tags=suite.sample_tags))
+    samples = list(
+        load_dataset(
+            suite.dataset,
+            max_samples=suite.max_samples,
+            sample_tags=suite.sample_tags,
+            base_dir=suite.base_dir,
+        )
+    )
     if suite.target.model_handles:
         num_models = len(suite.target.model_handles)
     else:

--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -11,6 +11,7 @@ import yaml
 from letta_client import AsyncLetta
 from rich.console import Console
 
+from letta_evals.datasets.hf import hf_dataset_provenance
 from letta_evals.datasets.loader import load_dataset
 from letta_evals.execution.grading import detect_errors, grade_sample, validate_rubric_vars
 from letta_evals.execution.trace import fetch_agent_state, fetch_token_data, fetch_trajectory
@@ -715,6 +716,10 @@ async def run_suite(
         yaml_data = yaml.safe_load(f)
 
     suite = SuiteSpec.from_yaml(yaml_data, base_dir=suite_path.parent, suite_path=suite_path)
+
+    # Record which exact dataset snapshot this run reads (HF repo/revision/commit);
+    # None for local datasets. Persisted into suite.json by the streaming writer.
+    suite.dataset_provenance = hf_dataset_provenance(suite.dataset)
 
     actual_num_runs = num_runs if num_runs is not None else (suite.num_runs or 1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ dev = [
 filesystem = [
     "faker>=37.6.0",
 ]
+hf = [
+    "huggingface_hub>=0.20.0",
+]
 skills = [
     "pathspec>=0.12.1",
     "openpyxl>=3.1.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "pandas>=2.3.2",
     "matplotlib>=3.10.6",
     "pathspec>=0.12.1",
+    "huggingface_hub>=0.20.0",
 ]
 
 [project.urls]
@@ -54,9 +55,6 @@ dev = [
 ]
 filesystem = [
     "faker>=37.6.0",
-]
-hf = [
-    "huggingface_hub>=0.20.0",
 ]
 skills = [
     "pathspec>=0.12.1",

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,6 +1,5 @@
 """Unit tests for cleanup behavior."""
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from letta_evals.models import (
@@ -16,7 +15,7 @@ def _make_suite(target_spec, cleanup: bool = False) -> SuiteSpec:
     """Create a minimal SuiteSpec for testing."""
     return SuiteSpec(
         name="test-cleanup",
-        dataset=Path("fake.jsonl"),
+        dataset="fake.jsonl",
         target=target_spec,
         graders={"accuracy": ToolGraderSpec(kind=GraderKind.TOOL, function="exact_match")},
         reward=MetricRewardSpec(kind=RewardKind.METRIC, metric_key="accuracy"),

--- a/tests/test_hf_dataset.py
+++ b/tests/test_hf_dataset.py
@@ -1,0 +1,259 @@
+"""Unit tests for HuggingFace Hub-backed datasets.
+
+Covers URL detection/parsing, provenance extraction, the fetch wrapper (with a
+stubbed ``huggingface_hub``), and the end-to-end ``load_dataset`` path including
+that ``rubric_path`` resolves against the suite dir, not the HF cache dir.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from letta_evals.datasets import hf
+from letta_evals.datasets.hf import (
+    HfDatasetRef,
+    _commit_sha_from_cache_path,
+    _import_hf,
+    _is_unpinned,
+    is_hf_ref,
+    parse_hf_ref,
+    resolve_hf_dataset,
+)
+from letta_evals.datasets.loader import load_dataset
+from letta_evals.models import SuiteSpec
+
+
+class _FakeHub:
+    """Stand-in for the ``huggingface_hub`` module in tests."""
+
+    def __init__(self, download_path, files=None):
+        self.download_path = str(download_path)
+        self.files = list(files) if files is not None else []
+        self.download_calls = []
+
+    def hf_hub_download(self, repo_id, filename, repo_type, revision):
+        self.download_calls.append(
+            {"repo_id": repo_id, "filename": filename, "repo_type": repo_type, "revision": revision}
+        )
+        return self.download_path
+
+    def list_repo_files(self, repo_id, repo_type, revision):
+        return list(self.files)
+
+
+def _cache_file(tmp_path: Path, sha: str, filename: str, rows) -> Path:
+    """Materialize a fake hf cache file at <tmp>/…/snapshots/<sha>/<filename>."""
+    path = tmp_path / "datasets--org--repo" / "snapshots" / sha / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    return path
+
+
+# ── is_hf_ref ──────────────────────────────────────────────────────────────
+
+
+class TestIsHfRef:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "https://huggingface.co/datasets/org/repo",
+            "https://huggingface.co/datasets/org/repo/resolve/main/d.jsonl",
+            "http://huggingface.co/org/model/resolve/v1/d.jsonl",
+            "HTTPS://HuggingFace.co/datasets/org/repo",  # case-insensitive host/scheme
+        ],
+    )
+    def test_true(self, value):
+        assert is_hf_ref(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "data.jsonl",
+            "/abs/path/data.jsonl",
+            "datasets/local.jsonl",
+            "https://example.com/data.jsonl",
+            "https://huggingface.co.evil.com/datasets/org/repo",  # look-alike host
+            Path("data.jsonl"),
+            None,
+        ],
+    )
+    def test_false(self, value):
+        assert is_hf_ref(value) is False
+
+
+# ── parse_hf_ref ───────────────────────────────────────────────────────────
+
+
+class TestParseHfRef:
+    def test_resolve_url(self):
+        ref = parse_hf_ref("https://huggingface.co/datasets/letta-ai/swe-chat-tagged/resolve/main/train.jsonl")
+        assert ref == HfDatasetRef("letta-ai/swe-chat-tagged", "dataset", "main", "train.jsonl")
+
+    def test_blob_url(self):
+        ref = parse_hf_ref("https://huggingface.co/datasets/org/repo/blob/v1.0/data.csv")
+        assert ref == HfDatasetRef("org/repo", "dataset", "v1.0", "data.csv")
+
+    def test_bare_repo_url(self):
+        ref = parse_hf_ref("https://huggingface.co/datasets/letta-ai/swe-chat-tagged")
+        assert ref == HfDatasetRef("letta-ai/swe-chat-tagged", "dataset", None, None)
+
+    def test_model_repo(self):
+        ref = parse_hf_ref("https://huggingface.co/org/model/resolve/abc123/d.jsonl")
+        assert ref == HfDatasetRef("org/model", "model", "abc123", "d.jsonl")
+
+    def test_space_repo(self):
+        ref = parse_hf_ref("https://huggingface.co/spaces/org/space/resolve/main/d.csv")
+        assert ref.repo_type == "space"
+        assert ref.repo_id == "org/space"
+
+    def test_nested_path(self):
+        ref = parse_hf_ref("https://huggingface.co/datasets/org/repo/resolve/main/sub/dir/data.jsonl")
+        assert ref.path == "sub/dir/data.jsonl"
+
+    def test_resolve_missing_file_raises(self):
+        with pytest.raises(ValueError, match="missing a revision and/or file path"):
+            parse_hf_ref("https://huggingface.co/datasets/org/repo/resolve/main")
+
+    def test_single_segment_raises(self):
+        with pytest.raises(ValueError, match="expected"):
+            parse_hf_ref("https://huggingface.co/datasets/onlyorg")
+
+
+# ── provenance helpers ─────────────────────────────────────────────────────
+
+
+class TestProvenanceHelpers:
+    def test_commit_sha_extracted(self):
+        p = Path("/home/u/.cache/huggingface/datasets--org--repo/snapshots/deadbeef/data.jsonl")
+        assert _commit_sha_from_cache_path(p) == "deadbeef"
+
+    def test_commit_sha_none_when_no_snapshots(self):
+        assert _commit_sha_from_cache_path(Path("/tmp/local/data.jsonl")) is None
+
+    @pytest.mark.parametrize("rev,expected", [(None, True), ("main", True), ("master", True)])
+    def test_unpinned(self, rev, expected):
+        assert _is_unpinned(rev) is expected
+
+    @pytest.mark.parametrize("rev", ["abc123def", "v1.0", "release-2024"])
+    def test_pinned(self, rev):
+        assert _is_unpinned(rev) is False
+
+
+# ── _import_hf ─────────────────────────────────────────────────────────────
+
+
+def test_import_hf_missing_raises():
+    if importlib.util.find_spec("huggingface_hub") is not None:
+        pytest.skip("huggingface_hub is installed; cannot exercise the missing-dep path")
+    with pytest.raises(ImportError, match=r"letta-evals\[hf\]"):
+        _import_hf()
+
+
+# ── resolve_hf_dataset ─────────────────────────────────────────────────────
+
+
+class TestResolveHfDataset:
+    def test_file_url_returns_path_and_provenance(self, tmp_path, monkeypatch):
+        cache = _cache_file(tmp_path, "abc123", "train.jsonl", [{"input": "Q?"}])
+        fake = _FakeHub(cache)
+        monkeypatch.setattr(hf, "_import_hf", lambda: fake)
+
+        resolved = resolve_hf_dataset("https://huggingface.co/datasets/org/repo/resolve/abc123/train.jsonl")
+
+        assert resolved.local_path == cache
+        assert resolved.commit_sha == "abc123"
+        assert resolved.repo_id == "org/repo"
+        assert resolved.path == "train.jsonl"
+        assert fake.download_calls == [
+            {"repo_id": "org/repo", "filename": "train.jsonl", "repo_type": "dataset", "revision": "abc123"}
+        ]
+
+    def test_unpinned_revision_warns(self, tmp_path, monkeypatch):
+        cache = _cache_file(tmp_path, "sha9", "d.jsonl", [{"input": "Q?"}])
+        monkeypatch.setattr(hf, "_import_hf", lambda: _FakeHub(cache))
+
+        with pytest.warns(UserWarning, match="unpinned"):
+            resolve_hf_dataset("https://huggingface.co/datasets/org/repo/resolve/main/d.jsonl")
+
+    def test_bare_repo_single_manifest_resolved(self, tmp_path, monkeypatch):
+        cache = _cache_file(tmp_path, "sha9", "the_only.jsonl", [{"input": "Q?"}])
+        fake = _FakeHub(cache, files=["README.md", "the_only.jsonl", "config.yaml"])
+        monkeypatch.setattr(hf, "_import_hf", lambda: fake)
+
+        with pytest.warns(UserWarning):  # bare repo => unpinned
+            resolved = resolve_hf_dataset("https://huggingface.co/datasets/org/repo")
+
+        assert resolved.path == "the_only.jsonl"
+        assert fake.download_calls[0]["filename"] == "the_only.jsonl"
+
+    def test_bare_repo_multiple_manifests_raises(self, tmp_path, monkeypatch):
+        fake = _FakeHub(tmp_path / "x", files=["train.jsonl", "test.jsonl"])
+        monkeypatch.setattr(hf, "_import_hf", lambda: fake)
+
+        with pytest.raises(ValueError, match="multiple manifests"):
+            resolve_hf_dataset("https://huggingface.co/datasets/org/repo")
+
+    def test_bare_repo_no_manifest_raises(self, tmp_path, monkeypatch):
+        fake = _FakeHub(tmp_path / "x", files=["README.md", "weights.bin"])
+        monkeypatch.setattr(hf, "_import_hf", lambda: fake)
+
+        with pytest.raises(ValueError, match="No .jsonl/.csv manifest"):
+            resolve_hf_dataset("https://huggingface.co/datasets/org/repo")
+
+
+# ── load_dataset end-to-end over an HF ref ─────────────────────────────────
+
+
+class TestLoadDatasetHf:
+    def test_loads_samples_from_hf_url(self, tmp_path, monkeypatch):
+        cache = _cache_file(tmp_path, "abc", "d.jsonl", [{"input": "Q1"}, {"input": "Q2"}])
+        monkeypatch.setattr(hf, "_import_hf", lambda: _FakeHub(cache))
+
+        samples = list(load_dataset("https://huggingface.co/datasets/org/repo/resolve/abc/d.jsonl"))
+        assert [s.input for s in samples] == ["Q1", "Q2"]
+
+    def test_rubric_path_resolves_against_suite_dir_not_cache(self, tmp_path, monkeypatch):
+        # Rubric file lives next to the suite; the manifest lives in the HF
+        # cache. Relative rubric_path must resolve against base_dir (the suite),
+        # never the cache dir where the fetched manifest happens to land.
+        suite_dir = tmp_path / "suite"
+        suite_dir.mkdir()
+        (suite_dir / "rubric.txt").write_text("suite-level rubric")
+        cache = _cache_file(tmp_path, "abc", "d.jsonl", [{"input": "Q?", "rubric_path": "rubric.txt"}])
+        monkeypatch.setattr(hf, "_import_hf", lambda: _FakeHub(cache))
+
+        samples = list(
+            load_dataset(
+                "https://huggingface.co/datasets/org/repo/resolve/abc/d.jsonl",
+                base_dir=suite_dir,
+            )
+        )
+        assert samples[0].rubric == "suite-level rubric"
+
+
+# ── SuiteSpec.from_yaml leaves HF URLs untouched ───────────────────────────
+
+
+def _suite_yaml(dataset: str) -> dict:
+    return {
+        "name": "hf-suite",
+        "dataset": dataset,
+        "target": {"kind": "letta_code", "model_handles": ["openai/gpt-4.1-mini"]},
+        "graders": {"g": {"kind": "tool", "function": "exact_match"}},
+        "reward": {"kind": "metric", "metric_key": "g"},
+    }
+
+
+class TestFromYamlDataset:
+    def test_hf_url_not_anchored_to_base_dir(self, tmp_path):
+        url = "https://huggingface.co/datasets/org/repo/resolve/main/d.jsonl"
+        suite = SuiteSpec.from_yaml(_suite_yaml(url), base_dir=tmp_path)
+        assert suite.dataset == url  # unchanged, not joined to base_dir
+
+    def test_local_relative_path_still_anchored(self, tmp_path):
+        suite = SuiteSpec.from_yaml(_suite_yaml("data/d.jsonl"), base_dir=tmp_path)
+        assert suite.dataset == str((tmp_path / "data/d.jsonl").resolve())

--- a/tests/test_hf_dataset.py
+++ b/tests/test_hf_dataset.py
@@ -1,24 +1,23 @@
 """Unit tests for HuggingFace Hub-backed datasets.
 
 Covers URL detection/parsing, provenance extraction, the fetch wrapper (with a
-stubbed ``huggingface_hub``), and the end-to-end ``load_dataset`` path including
-that ``rubric_path`` resolves against the suite dir, not the HF cache dir.
+stubbed ``huggingface_hub``), the end-to-end ``load_dataset`` path including
+that ``rubric_path`` resolves against the suite dir (not the HF cache dir), and
+that resolved provenance serializes into the suite config (suite.json).
 """
 
 from __future__ import annotations
 
-import importlib.util
 import json
 from pathlib import Path
 
+import huggingface_hub
 import pytest
 
-from letta_evals.datasets import hf
 from letta_evals.datasets.hf import (
     HfDatasetRef,
     _commit_sha_from_cache_path,
-    _import_hf,
-    _is_unpinned,
+    hf_dataset_provenance,
     is_hf_ref,
     parse_hf_ref,
     resolve_hf_dataset,
@@ -27,22 +26,23 @@ from letta_evals.datasets.loader import load_dataset
 from letta_evals.models import SuiteSpec
 
 
-class _FakeHub:
-    """Stand-in for the ``huggingface_hub`` module in tests."""
+def _install_fake_hub(monkeypatch, download_path=None, files=None):
+    """Patch huggingface_hub's fetch fns with in-memory stubs; return call log."""
+    calls = {"download": [], "list": []}
 
-    def __init__(self, download_path, files=None):
-        self.download_path = str(download_path)
-        self.files = list(files) if files is not None else []
-        self.download_calls = []
-
-    def hf_hub_download(self, repo_id, filename, repo_type, revision):
-        self.download_calls.append(
+    def _download(repo_id, filename, repo_type, revision):
+        calls["download"].append(
             {"repo_id": repo_id, "filename": filename, "repo_type": repo_type, "revision": revision}
         )
-        return self.download_path
+        return str(download_path)
 
-    def list_repo_files(self, repo_id, repo_type, revision):
-        return list(self.files)
+    def _list(repo_id, repo_type, revision):
+        calls["list"].append({"repo_id": repo_id, "repo_type": repo_type, "revision": revision})
+        return list(files or [])
+
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", _download)
+    monkeypatch.setattr(huggingface_hub, "list_repo_files", _list)
+    return calls
 
 
 def _cache_file(tmp_path: Path, sha: str, filename: str, rows) -> Path:
@@ -62,7 +62,7 @@ class TestIsHfRef:
         [
             "https://huggingface.co/datasets/org/repo",
             "https://huggingface.co/datasets/org/repo/resolve/main/d.jsonl",
-            "http://huggingface.co/org/model/resolve/v1/d.jsonl",
+            "http://huggingface.co/datasets/org/repo/blob/v1/d.csv",
             "HTTPS://HuggingFace.co/datasets/org/repo",  # case-insensitive host/scheme
         ],
     )
@@ -76,6 +76,7 @@ class TestIsHfRef:
             "/abs/path/data.jsonl",
             "datasets/local.jsonl",
             "https://example.com/data.jsonl",
+            "https://huggingface.co/org/model/resolve/v1/d.jsonl",  # model repo, not a dataset
             "https://huggingface.co.evil.com/datasets/org/repo",  # look-alike host
             Path("data.jsonl"),
             None,
@@ -91,28 +92,23 @@ class TestIsHfRef:
 class TestParseHfRef:
     def test_resolve_url(self):
         ref = parse_hf_ref("https://huggingface.co/datasets/letta-ai/swe-chat-tagged/resolve/main/train.jsonl")
-        assert ref == HfDatasetRef("letta-ai/swe-chat-tagged", "dataset", "main", "train.jsonl")
+        assert ref == HfDatasetRef("letta-ai/swe-chat-tagged", "main", "train.jsonl")
 
     def test_blob_url(self):
         ref = parse_hf_ref("https://huggingface.co/datasets/org/repo/blob/v1.0/data.csv")
-        assert ref == HfDatasetRef("org/repo", "dataset", "v1.0", "data.csv")
+        assert ref == HfDatasetRef("org/repo", "v1.0", "data.csv")
 
     def test_bare_repo_url(self):
         ref = parse_hf_ref("https://huggingface.co/datasets/letta-ai/swe-chat-tagged")
-        assert ref == HfDatasetRef("letta-ai/swe-chat-tagged", "dataset", None, None)
-
-    def test_model_repo(self):
-        ref = parse_hf_ref("https://huggingface.co/org/model/resolve/abc123/d.jsonl")
-        assert ref == HfDatasetRef("org/model", "model", "abc123", "d.jsonl")
-
-    def test_space_repo(self):
-        ref = parse_hf_ref("https://huggingface.co/spaces/org/space/resolve/main/d.csv")
-        assert ref.repo_type == "space"
-        assert ref.repo_id == "org/space"
+        assert ref == HfDatasetRef("letta-ai/swe-chat-tagged", None, None)
 
     def test_nested_path(self):
         ref = parse_hf_ref("https://huggingface.co/datasets/org/repo/resolve/main/sub/dir/data.jsonl")
         assert ref.path == "sub/dir/data.jsonl"
+
+    def test_non_dataset_url_raises(self):
+        with pytest.raises(ValueError, match="expected"):
+            parse_hf_ref("https://huggingface.co/org/model/resolve/v1/d.jsonl")
 
     def test_resolve_missing_file_raises(self):
         with pytest.raises(ValueError, match="missing a revision and/or file path"):
@@ -126,31 +122,13 @@ class TestParseHfRef:
 # ── provenance helpers ─────────────────────────────────────────────────────
 
 
-class TestProvenanceHelpers:
-    def test_commit_sha_extracted(self):
+class TestCommitShaFromCachePath:
+    def test_extracted(self):
         p = Path("/home/u/.cache/huggingface/datasets--org--repo/snapshots/deadbeef/data.jsonl")
         assert _commit_sha_from_cache_path(p) == "deadbeef"
 
-    def test_commit_sha_none_when_no_snapshots(self):
+    def test_none_when_no_snapshots(self):
         assert _commit_sha_from_cache_path(Path("/tmp/local/data.jsonl")) is None
-
-    @pytest.mark.parametrize("rev,expected", [(None, True), ("main", True), ("master", True)])
-    def test_unpinned(self, rev, expected):
-        assert _is_unpinned(rev) is expected
-
-    @pytest.mark.parametrize("rev", ["abc123def", "v1.0", "release-2024"])
-    def test_pinned(self, rev):
-        assert _is_unpinned(rev) is False
-
-
-# ── _import_hf ─────────────────────────────────────────────────────────────
-
-
-def test_import_hf_missing_raises():
-    if importlib.util.find_spec("huggingface_hub") is not None:
-        pytest.skip("huggingface_hub is installed; cannot exercise the missing-dep path")
-    with pytest.raises(ImportError, match=r"letta-evals\[hf\]"):
-        _import_hf()
 
 
 # ── resolve_hf_dataset ─────────────────────────────────────────────────────
@@ -159,8 +137,7 @@ def test_import_hf_missing_raises():
 class TestResolveHfDataset:
     def test_file_url_returns_path_and_provenance(self, tmp_path, monkeypatch):
         cache = _cache_file(tmp_path, "abc123", "train.jsonl", [{"input": "Q?"}])
-        fake = _FakeHub(cache)
-        monkeypatch.setattr(hf, "_import_hf", lambda: fake)
+        calls = _install_fake_hub(monkeypatch, download_path=cache)
 
         resolved = resolve_hf_dataset("https://huggingface.co/datasets/org/repo/resolve/abc123/train.jsonl")
 
@@ -168,38 +145,42 @@ class TestResolveHfDataset:
         assert resolved.commit_sha == "abc123"
         assert resolved.repo_id == "org/repo"
         assert resolved.path == "train.jsonl"
-        assert fake.download_calls == [
+        assert calls["download"] == [
             {"repo_id": "org/repo", "filename": "train.jsonl", "repo_type": "dataset", "revision": "abc123"}
         ]
 
     def test_unpinned_revision_warns(self, tmp_path, monkeypatch):
         cache = _cache_file(tmp_path, "sha9", "d.jsonl", [{"input": "Q?"}])
-        monkeypatch.setattr(hf, "_import_hf", lambda: _FakeHub(cache))
+        _install_fake_hub(monkeypatch, download_path=cache)
 
         with pytest.warns(UserWarning, match="unpinned"):
             resolve_hf_dataset("https://huggingface.co/datasets/org/repo/resolve/main/d.jsonl")
 
+    def test_pinned_revision_does_not_warn(self, tmp_path, monkeypatch, recwarn):
+        cache = _cache_file(tmp_path, "abc123", "d.jsonl", [{"input": "Q?"}])
+        _install_fake_hub(monkeypatch, download_path=cache)
+
+        resolve_hf_dataset("https://huggingface.co/datasets/org/repo/resolve/abc123/d.jsonl")
+        assert not [w for w in recwarn.list if "unpinned" in str(w.message)]
+
     def test_bare_repo_single_manifest_resolved(self, tmp_path, monkeypatch):
         cache = _cache_file(tmp_path, "sha9", "the_only.jsonl", [{"input": "Q?"}])
-        fake = _FakeHub(cache, files=["README.md", "the_only.jsonl", "config.yaml"])
-        monkeypatch.setattr(hf, "_import_hf", lambda: fake)
+        calls = _install_fake_hub(monkeypatch, download_path=cache, files=["README.md", "the_only.jsonl", "x.yaml"])
 
         with pytest.warns(UserWarning):  # bare repo => unpinned
             resolved = resolve_hf_dataset("https://huggingface.co/datasets/org/repo")
 
         assert resolved.path == "the_only.jsonl"
-        assert fake.download_calls[0]["filename"] == "the_only.jsonl"
+        assert calls["download"][0]["filename"] == "the_only.jsonl"
 
     def test_bare_repo_multiple_manifests_raises(self, tmp_path, monkeypatch):
-        fake = _FakeHub(tmp_path / "x", files=["train.jsonl", "test.jsonl"])
-        monkeypatch.setattr(hf, "_import_hf", lambda: fake)
+        _install_fake_hub(monkeypatch, download_path=tmp_path / "x", files=["train.jsonl", "test.jsonl"])
 
         with pytest.raises(ValueError, match="multiple manifests"):
             resolve_hf_dataset("https://huggingface.co/datasets/org/repo")
 
     def test_bare_repo_no_manifest_raises(self, tmp_path, monkeypatch):
-        fake = _FakeHub(tmp_path / "x", files=["README.md", "weights.bin"])
-        monkeypatch.setattr(hf, "_import_hf", lambda: fake)
+        _install_fake_hub(monkeypatch, download_path=tmp_path / "x", files=["README.md", "weights.bin"])
 
         with pytest.raises(ValueError, match="No .jsonl/.csv manifest"):
             resolve_hf_dataset("https://huggingface.co/datasets/org/repo")
@@ -211,7 +192,7 @@ class TestResolveHfDataset:
 class TestLoadDatasetHf:
     def test_loads_samples_from_hf_url(self, tmp_path, monkeypatch):
         cache = _cache_file(tmp_path, "abc", "d.jsonl", [{"input": "Q1"}, {"input": "Q2"}])
-        monkeypatch.setattr(hf, "_import_hf", lambda: _FakeHub(cache))
+        _install_fake_hub(monkeypatch, download_path=cache)
 
         samples = list(load_dataset("https://huggingface.co/datasets/org/repo/resolve/abc/d.jsonl"))
         assert [s.input for s in samples] == ["Q1", "Q2"]
@@ -224,7 +205,7 @@ class TestLoadDatasetHf:
         suite_dir.mkdir()
         (suite_dir / "rubric.txt").write_text("suite-level rubric")
         cache = _cache_file(tmp_path, "abc", "d.jsonl", [{"input": "Q?", "rubric_path": "rubric.txt"}])
-        monkeypatch.setattr(hf, "_import_hf", lambda: _FakeHub(cache))
+        _install_fake_hub(monkeypatch, download_path=cache)
 
         samples = list(
             load_dataset(
@@ -235,7 +216,7 @@ class TestLoadDatasetHf:
         assert samples[0].rubric == "suite-level rubric"
 
 
-# ── SuiteSpec.from_yaml leaves HF URLs untouched ───────────────────────────
+# ── provenance record + suite.json serialization ───────────────────────────
 
 
 def _suite_yaml(dataset: str) -> dict:
@@ -246,6 +227,32 @@ def _suite_yaml(dataset: str) -> dict:
         "graders": {"g": {"kind": "tool", "function": "exact_match"}},
         "reward": {"kind": "metric", "metric_key": "g"},
     }
+
+
+class TestProvenance:
+    def test_local_dataset_has_no_provenance(self):
+        assert hf_dataset_provenance("data/local.jsonl") is None
+
+    def test_hf_dataset_provenance_record(self, tmp_path, monkeypatch):
+        cache = _cache_file(tmp_path, "abc123", "train.jsonl", [{"input": "Q?"}])
+        _install_fake_hub(monkeypatch, download_path=cache)
+
+        prov = hf_dataset_provenance("https://huggingface.co/datasets/org/repo/resolve/abc123/train.jsonl")
+        assert prov == {
+            "source": "huggingface",
+            "url": "https://huggingface.co/datasets/org/repo/resolve/abc123/train.jsonl",
+            "repo_id": "org/repo",
+            "path": "train.jsonl",
+            "revision": "abc123",
+            "commit_sha": "abc123",
+        }
+
+    def test_provenance_serializes_into_suite_config(self):
+        # Mirrors StreamingWriter.initialize, which dumps the suite into suite.json.
+        suite = SuiteSpec.from_yaml(_suite_yaml("https://huggingface.co/datasets/org/repo/resolve/abc/d.jsonl"))
+        suite.dataset_provenance = {"source": "huggingface", "commit_sha": "abc"}
+        dumped = json.loads(suite.model_dump_json(exclude={"base_dir"}))
+        assert dumped["dataset_provenance"]["commit_sha"] == "abc"
 
 
 class TestFromYamlDataset:

--- a/tests/test_rubric_grader.py
+++ b/tests/test_rubric_grader.py
@@ -133,6 +133,19 @@ class TestLoaderPerSampleRubric:
         # The loader resolves the file and stores its content in sample.rubric.
         assert samples[0].rubric == "file rubric"
 
+    def test_jsonl_rubric_path_resolves_against_base_dir(self, tmp_path: Path):
+        # Dataset in a subdir; rubric file lives next to the suite (base_dir),
+        # not next to the dataset. Relative rubric_path must resolve against
+        # base_dir — the same anchor every other suite path field uses — so an
+        # off-suite dataset (e.g. an HF cache dir) keeps rubric files findable.
+        (tmp_path / "rubric.txt").write_text("suite-level rubric")
+        datasets_dir = tmp_path / "datasets"
+        datasets_dir.mkdir()
+        data = datasets_dir / "data.jsonl"
+        data.write_text(json.dumps({"input": "Q?", "rubric_path": "rubric.txt"}) + "\n")
+        samples = list(load_jsonl(data, base_dir=tmp_path))
+        assert samples[0].rubric == "suite-level rubric"
+
     def test_jsonl_rubric_path_absolute(self, tmp_path: Path):
         rubric_file = tmp_path / "abs.txt"
         rubric_file.write_text("absolute rubric")


### PR DESCRIPTION
A suite's `dataset:` can now be a HuggingFace Hub URL, not just a local path:

```yaml
dataset: https://huggingface.co/datasets/letta-ai/swe-chat-tagged/resolve/<rev>/train.jsonl
```

The single manifest is fetched and cached on the host via `hf_hub_download`, then loaded exactly like a local `.jsonl`/`.csv`. Local paths are unchanged.

### Notes

- `dataset` is now `str` (was `Path`, which mangled `https://` → `https:/`).
- `huggingface_hub` added as a dependency, imported lazily.
- Private repos work via `HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN`. Fetch is host-only, so the Modal sandbox needs no token or network.
- Unpinned revisions (a bare repo URL, or `.../resolve/main/...`) warn; the resolved commit SHA is recorded in `suite.json` under `config.dataset_provenance` so a run captures the exact snapshot it read. A bare repo URL is accepted only when the repo holds a single `.jsonl`/`.csv`.
- Also re-anchors `rubric_path` to the suite dir (it was the only path field resolved against the dataset dir) — which is what lets an HF-cached dataset keep its rubric files resolvable.

Scope: single-file manifest only; sharded/whole-repo loading is a follow-up (as scoped in the issue).

Closes #316.
