### PR TITLE
fix(targets): Drain letta-code stream without parsing redundant events

### DIFF
--- a/letta_evals/execution/trace.py
+++ b/letta_evals/execution/trace.py
@@ -16,66 +16,32 @@ from letta_evals.utils import list_all_agent_messages
 logger = logging.getLogger(__name__)
 
 
-def parse_stream_line(line: str) -> list[dict]:
-    """Parse one stream-json line into its JSON object events.
+def extract_usage_stats(last_line: str) -> Optional[list[dict]]:
+    """Pull agent usage_statistics from the stream's final line.
 
-    Expected framing is one object per line, but torn stdout writes can glue
-    records together — salvage every complete object and log a diagnostic.
-    Non-object values are ignored; returns [] if nothing parses.
+    stream-json emits the ``result`` event last. Returns ``None`` when the
+    line is empty, unparseable, or not a result event (e.g. a stream cut
+    short by a crash or timeout).
     """
-    if not line:
-        return []
     try:
-        obj = json.loads(line)
-        return [obj] if isinstance(obj, dict) else []
+        event = json.loads(last_line) if last_line else None
     except json.JSONDecodeError as err:
-        events: list[dict] = []
-        decoder = json.JSONDecoder()
-        pos = 0
-        while pos < len(line):
-            if line[pos].isspace():
-                pos += 1
-                continue
-            try:
-                obj, pos = decoder.raw_decode(line, pos)
-            except json.JSONDecodeError:
-                break
-            if isinstance(obj, dict):
-                events.append(obj)
-        logger.warning(
-            "Malformed stream-json line: %s at pos %d (%d chars, %d bytes); salvaged %d event(s); prefix=%r suffix=%r",
-            err.msg,
-            err.pos,
-            len(line),
-            len(line.encode("utf-8", errors="replace")),
-            len(events),
-            line[:120],
-            line[-120:],
-        )
-        return events
-
-
-def extract_usage_stats(events: list) -> Optional[list[dict]]:
-    """Pull agent usage_statistics from the final stream ``result`` event.
-
-    stream-json always emits the result event last. Returns ``None`` when no
-    usage is present — e.g. the stream was cut short by a crash or timeout —
-    so both the success path and the error path report usage the same way.
-    """
-    if events and events[-1].get("type") == "result" and "usage" in events[-1]:
-        usage = events[-1]["usage"]
-        return [
-            {
-                "message_type": "usage_statistics",
-                "prompt_tokens": usage.get("prompt_tokens", 0),
-                "completion_tokens": usage.get("completion_tokens", 0),
-                "total_tokens": usage.get("total_tokens", 0),
-                "cached_input_tokens": usage.get("cached_input_tokens", 0),
-                "cache_write_tokens": usage.get("cache_write_tokens", 0),
-                "reasoning_tokens": usage.get("reasoning_tokens", 0),
-            }
-        ]
-    return None
+        logger.warning(f"Unparseable final stream line ({err.msg} at pos {err.pos}): {last_line[:200]}")
+        return None
+    if not isinstance(event, dict) or event.get("type") != "result" or "usage" not in event:
+        return None
+    usage = event["usage"]
+    return [
+        {
+            "message_type": "usage_statistics",
+            "prompt_tokens": usage.get("prompt_tokens", 0),
+            "completion_tokens": usage.get("completion_tokens", 0),
+            "total_tokens": usage.get("total_tokens", 0),
+            "cached_input_tokens": usage.get("cached_input_tokens", 0),
+            "cache_write_tokens": usage.get("cache_write_tokens", 0),
+            "reasoning_tokens": usage.get("reasoning_tokens", 0),
+        }
+    ]
 
 
 async def fetch_trajectory(client: Any, agent_id: str) -> list:

--- a/letta_evals/execution/trace.py
+++ b/letta_evals/execution/trace.py
@@ -6,6 +6,7 @@ agent state keyed by ``agent_id`` into the trace fields persisted on
 sandboxed runs share the same fetch path.
 """
 
+import json
 import logging
 from typing import Any, Optional
 
@@ -13,6 +14,45 @@ from letta_evals.models import TurnTokenData
 from letta_evals.utils import list_all_agent_messages
 
 logger = logging.getLogger(__name__)
+
+
+def parse_stream_line(line: str) -> list[dict]:
+    """Parse one stream-json line into its JSON object events.
+
+    Expected framing is one object per line, but torn stdout writes can glue
+    records together — salvage every complete object and log a diagnostic.
+    Non-object values are ignored; returns [] if nothing parses.
+    """
+    if not line:
+        return []
+    try:
+        obj = json.loads(line)
+        return [obj] if isinstance(obj, dict) else []
+    except json.JSONDecodeError as err:
+        events: list[dict] = []
+        decoder = json.JSONDecoder()
+        pos = 0
+        while pos < len(line):
+            if line[pos].isspace():
+                pos += 1
+                continue
+            try:
+                obj, pos = decoder.raw_decode(line, pos)
+            except json.JSONDecodeError:
+                break
+            if isinstance(obj, dict):
+                events.append(obj)
+        logger.warning(
+            "Malformed stream-json line: %s at pos %d (%d chars, %d bytes); salvaged %d event(s); prefix=%r suffix=%r",
+            err.msg,
+            err.pos,
+            len(line),
+            len(line.encode("utf-8", errors="replace")),
+            len(events),
+            line[:120],
+            line[-120:],
+        )
+        return events
 
 
 def extract_usage_stats(events: list) -> Optional[list[dict]]:

--- a/letta_evals/targets/letta_code_target.py
+++ b/letta_evals/targets/letta_code_target.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import logging
 import os
 import shlex
@@ -9,55 +8,13 @@ from typing import Optional
 import anyio
 from letta_client import AsyncLetta
 
-from letta_evals.execution.trace import extract_usage_stats
+from letta_evals.execution.trace import extract_usage_stats, parse_stream_line
 from letta_evals.models import Sample, TargetResult
 from letta_evals.targets.errors import TargetError
 from letta_evals.utils import load_object
 from letta_evals.visualization.base import ProgressCallback
 
 logger = logging.getLogger(__name__)
-
-
-def _parse_stream_line(line: str) -> list[dict]:
-    """Parse one stream-json line into its JSON object events.
-
-    letta-code emits one JSON object per line, but stdout writes can tear
-    under load and concatenate two records onto a single line (issue #319).
-    Rather than dropping such lines, salvage every complete object and log
-    a diagnostic that identifies the failure mode (error message, position,
-    lengths, prefix/suffix). Non-object JSON values are ignored. Returns []
-    when nothing parseable is found.
-    """
-    if not line:
-        return []
-    try:
-        obj = json.loads(line)
-        return [obj] if isinstance(obj, dict) else []
-    except json.JSONDecodeError as err:
-        events: list[dict] = []
-        decoder = json.JSONDecoder()
-        pos = 0
-        while pos < len(line):
-            if line[pos].isspace():
-                pos += 1
-                continue
-            try:
-                obj, pos = decoder.raw_decode(line, pos)
-            except json.JSONDecodeError:
-                break
-            if isinstance(obj, dict):
-                events.append(obj)
-        logger.warning(
-            "Malformed stream-json line: %s at pos %d (%d chars, %d bytes); salvaged %d event(s); prefix=%r suffix=%r",
-            err.msg,
-            err.pos,
-            len(line),
-            len(line.encode("utf-8", errors="replace")),
-            len(events),
-            line[:120],
-            line[-120:],
-        )
-        return events
 
 
 class LettaCodeTarget:
@@ -224,10 +181,7 @@ class LettaCodeTarget:
         while attempt <= self.max_retries:
             try:
                 agent_id = None
-                # Last non-blank stdout line, kept raw and only parsed after
-                # the process exits (stream-json emits the result event last).
-                # Initialized up front so the error handler can read whatever
-                # streamed before a failure (e.g. for best-effort usage).
+                # Last non-blank stdout line; parsed after exit for the result event.
                 last_line = ""
 
                 # construct the letta-code CLI command (headless streaming JSON output).
@@ -322,14 +276,10 @@ class LettaCodeTarget:
                 process.stdin.close()
                 await process.stdin.wait_closed()
 
-                # Drain stdout line by line. The stream is only load-bearing
-                # in two places: the init event (agent_id, captured as soon as
-                # it arrives so we have it even if the process later times
-                # out) and the final result event (usage, parsed from
-                # last_line after exit). Everything in between is drained
-                # without parsing — the authoritative trajectory is fetched
-                # from the server by agent_id, and large tool-return lines are
-                # exactly the ones that arrive malformed (issue #319).
+                # Only the init event (agent_id) and the final result event
+                # (usage, parsed from last_line after exit) are consumed from
+                # the stream — the trajectory is fetched server-side. Drain
+                # everything after init without parsing (#319).
                 async def _read_stdout():
                     nonlocal agent_id, last_line
                     init_seen = False
@@ -340,7 +290,7 @@ class LettaCodeTarget:
                         last_line = line
                         if init_seen:
                             continue
-                        for event in _parse_stream_line(line):
+                        for event in parse_stream_line(line):
                             if event.get("type") == "system" and event.get("subtype") == "init":
                                 init_seen = True
                                 if not agent_id:
@@ -384,7 +334,7 @@ class LettaCodeTarget:
                     raise RuntimeError("No agent_id found in letta stream output")
 
                 # Extract usage from the final stream result event (best-effort).
-                usage_stats = extract_usage_stats(_parse_stream_line(last_line))
+                usage_stats = extract_usage_stats(parse_stream_line(last_line))
 
                 return TargetResult(
                     agent_id=agent_id,
@@ -400,12 +350,10 @@ class LettaCodeTarget:
                     timeout_hint = f"Timed out after {self.timeout}s" if isinstance(e, TimeoutError) else ""
                     msg = str(e) or timeout_hint or type(e).__name__
                     err_agent_id = agent_id or factory_agent_id
-                    # Best-effort: surface usage from the stream so far. A
-                    # cut-short stream won't end on a result event, so this
-                    # yields None just as before. Any server-side trace fields
-                    # (partial trajectory/token data) are fetched by Runner
-                    # from the agent_id when available.
-                    partial_usage = extract_usage_stats(_parse_stream_line(last_line))
+                    # Best-effort: surface usage from the stream so far. Any
+                    # server-side trace fields (partial trajectory/token data) are
+                    # fetched by Runner from the agent_id when available.
+                    partial_usage = extract_usage_stats(parse_stream_line(last_line))
                     raise TargetError(
                         msg,
                         agent_id=err_agent_id,

--- a/letta_evals/targets/letta_code_target.py
+++ b/letta_evals/targets/letta_code_target.py
@@ -18,6 +18,48 @@ from letta_evals.visualization.base import ProgressCallback
 logger = logging.getLogger(__name__)
 
 
+def _parse_stream_line(line: str) -> list[dict]:
+    """Parse one stream-json line into its JSON object events.
+
+    letta-code emits one JSON object per line, but stdout writes can tear
+    under load and concatenate two records onto a single line (issue #319).
+    Rather than dropping such lines, salvage every complete object and log
+    a diagnostic that identifies the failure mode (error message, position,
+    lengths, prefix/suffix). Non-object JSON values are ignored. Returns []
+    when nothing parseable is found.
+    """
+    if not line:
+        return []
+    try:
+        obj = json.loads(line)
+        return [obj] if isinstance(obj, dict) else []
+    except json.JSONDecodeError as err:
+        events: list[dict] = []
+        decoder = json.JSONDecoder()
+        pos = 0
+        while pos < len(line):
+            if line[pos].isspace():
+                pos += 1
+                continue
+            try:
+                obj, pos = decoder.raw_decode(line, pos)
+            except json.JSONDecodeError:
+                break
+            if isinstance(obj, dict):
+                events.append(obj)
+        logger.warning(
+            "Malformed stream-json line: %s at pos %d (%d chars, %d bytes); salvaged %d event(s); prefix=%r suffix=%r",
+            err.msg,
+            err.pos,
+            len(line),
+            len(line.encode("utf-8", errors="replace")),
+            len(events),
+            line[:120],
+            line[-120:],
+        )
+        return events
+
+
 class LettaCodeTarget:
     """Letta code target that invokes the letta CLI command."""
 
@@ -182,9 +224,11 @@ class LettaCodeTarget:
         while attempt <= self.max_retries:
             try:
                 agent_id = None
+                # Last non-blank stdout line, kept raw and only parsed after
+                # the process exits (stream-json emits the result event last).
                 # Initialized up front so the error handler can read whatever
                 # streamed before a failure (e.g. for best-effort usage).
-                events = []
+                last_line = ""
 
                 # construct the letta-code CLI command (headless streaming JSON output).
                 cmd = [
@@ -278,19 +322,27 @@ class LettaCodeTarget:
                 process.stdin.close()
                 await process.stdin.wait_closed()
 
-                # Read streaming JSON output line by line, capturing agent_id
-                # from the init event as soon as it arrives. This ensures we
-                # have the agent_id even if the process later times out.
+                # Drain stdout line by line. The stream is only load-bearing
+                # in two places: the init event (agent_id, captured as soon as
+                # it arrives so we have it even if the process later times
+                # out) and the final result event (usage, parsed from
+                # last_line after exit). Everything in between is drained
+                # without parsing — the authoritative trajectory is fetched
+                # from the server by agent_id, and large tool-return lines are
+                # exactly the ones that arrive malformed (issue #319).
                 async def _read_stdout():
-                    nonlocal agent_id
+                    nonlocal agent_id, last_line
+                    init_seen = False
                     async for raw_line in process.stdout:
-                        line = raw_line.decode().strip()
+                        line = raw_line.decode(errors="replace").strip()
                         if not line:
                             continue
-                        try:
-                            event = json.loads(line)
-                            events.append(event)
+                        last_line = line
+                        if init_seen:
+                            continue
+                        for event in _parse_stream_line(line):
                             if event.get("type") == "system" and event.get("subtype") == "init":
+                                init_seen = True
                                 if not agent_id:
                                     agent_id = event.get("agent_id")
                                     logger.info(f"Captured agent_id {agent_id} from stream init event")
@@ -302,8 +354,6 @@ class LettaCodeTarget:
                                     await progress_callback.message_sending(
                                         sample.id, 1, len(inputs), agent_id=agent_id, model_handle=self.model_handle
                                     )
-                        except json.JSONDecodeError:
-                            logger.warning(f"Non-JSON stream output: {line[:200]}")
 
                 async def _read_stderr():
                     async for raw_line in process.stderr:
@@ -322,18 +372,10 @@ class LettaCodeTarget:
                 stderr_text = "".join(stderr_chunks)
 
                 if process.returncode != 0:
-                    # Surface the last stdout event so the real error isn't lost
-                    last_stdout_event = ""
-                    for ev in reversed(events):
-                        try:
-                            last_stdout_event = json.dumps(ev)[:500]
-                        except Exception:
-                            last_stdout_event = str(ev)[:500]
-                        break
-
+                    # Surface the last stdout line so the real error isn't lost
                     parts = [f"Letta command failed with return code {process.returncode}"]
-                    if last_stdout_event:
-                        parts.append(f"Last stdout event: {last_stdout_event}")
+                    if last_line:
+                        parts.append(f"Last stdout line: {last_line[:500]}")
                     if stderr_text:
                         parts.append(f"Stderr: {stderr_text[:500]}")
                     raise RuntimeError(". ".join(parts))
@@ -342,7 +384,7 @@ class LettaCodeTarget:
                     raise RuntimeError("No agent_id found in letta stream output")
 
                 # Extract usage from the final stream result event (best-effort).
-                usage_stats = extract_usage_stats(events)
+                usage_stats = extract_usage_stats(_parse_stream_line(last_line))
 
                 return TargetResult(
                     agent_id=agent_id,
@@ -358,10 +400,12 @@ class LettaCodeTarget:
                     timeout_hint = f"Timed out after {self.timeout}s" if isinstance(e, TimeoutError) else ""
                     msg = str(e) or timeout_hint or type(e).__name__
                     err_agent_id = agent_id or factory_agent_id
-                    # Best-effort: surface usage from the stream so far. Any
-                    # server-side trace fields (partial trajectory/token data) are
-                    # fetched by Runner from the agent_id when available.
-                    partial_usage = extract_usage_stats(events)
+                    # Best-effort: surface usage from the stream so far. A
+                    # cut-short stream won't end on a result event, so this
+                    # yields None just as before. Any server-side trace fields
+                    # (partial trajectory/token data) are fetched by Runner
+                    # from the agent_id when available.
+                    partial_usage = extract_usage_stats(_parse_stream_line(last_line))
                     raise TargetError(
                         msg,
                         agent_id=err_agent_id,

--- a/letta_evals/targets/letta_code_target.py
+++ b/letta_evals/targets/letta_code_target.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 import os
 import shlex
@@ -8,7 +9,7 @@ from typing import Optional
 import anyio
 from letta_client import AsyncLetta
 
-from letta_evals.execution.trace import extract_usage_stats, parse_stream_line
+from letta_evals.execution.trace import extract_usage_stats
 from letta_evals.models import Sample, TargetResult
 from letta_evals.targets.errors import TargetError
 from letta_evals.utils import load_object
@@ -290,20 +291,23 @@ class LettaCodeTarget:
                         last_line = line
                         if init_seen:
                             continue
-                        for event in parse_stream_line(line):
-                            if event.get("type") == "system" and event.get("subtype") == "init":
-                                init_seen = True
-                                if not agent_id:
-                                    agent_id = event.get("agent_id")
-                                    logger.info(f"Captured agent_id {agent_id} from stream init event")
-                                    if progress_callback and agent_id:
-                                        await progress_callback.agent_created(
-                                            sample.id, agent_id=agent_id, model_handle=self.model_handle
-                                        )
+                        try:
+                            event = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        if isinstance(event, dict) and event.get("type") == "system" and event.get("subtype") == "init":
+                            init_seen = True
+                            if not agent_id:
+                                agent_id = event.get("agent_id")
+                                logger.info(f"Captured agent_id {agent_id} from stream init event")
                                 if progress_callback and agent_id:
-                                    await progress_callback.message_sending(
-                                        sample.id, 1, len(inputs), agent_id=agent_id, model_handle=self.model_handle
+                                    await progress_callback.agent_created(
+                                        sample.id, agent_id=agent_id, model_handle=self.model_handle
                                     )
+                            if progress_callback and agent_id:
+                                await progress_callback.message_sending(
+                                    sample.id, 1, len(inputs), agent_id=agent_id, model_handle=self.model_handle
+                                )
 
                 async def _read_stderr():
                     async for raw_line in process.stderr:
@@ -334,7 +338,7 @@ class LettaCodeTarget:
                     raise RuntimeError("No agent_id found in letta stream output")
 
                 # Extract usage from the final stream result event (best-effort).
-                usage_stats = extract_usage_stats(parse_stream_line(last_line))
+                usage_stats = extract_usage_stats(last_line)
 
                 return TargetResult(
                     agent_id=agent_id,
@@ -353,7 +357,7 @@ class LettaCodeTarget:
                     # Best-effort: surface usage from the stream so far. Any
                     # server-side trace fields (partial trajectory/token data) are
                     # fetched by Runner from the agent_id when available.
-                    partial_usage = extract_usage_stats(parse_stream_line(last_line))
+                    partial_usage = extract_usage_stats(last_line)
                     raise TargetError(
                         msg,
                         agent_id=err_agent_id,

--- a/tests/test_letta_code_target_stream.py
+++ b/tests/test_letta_code_target_stream.py
@@ -1,68 +1,64 @@
-"""Tests for LettaCodeTarget stream-json handling (issue #319).
-
-Covers the `_parse_stream_line` salvage helper and the slimmed-down stdout
-reader: the stream is drained but only parsed for the init event (agent_id)
-and the final result event (usage), so malformed mid-stream tool-return
-lines cannot affect a run.
-"""
+"""Stream-json handling: the parse_stream_line salvage helper and the
+drain-only LettaCodeTarget stdout reader (issue #319)."""
 
 import logging
 import os
 
 import pytest
 
+from letta_evals.execution.trace import parse_stream_line
 from letta_evals.models import Sample
 from letta_evals.targets.errors import TargetError
-from letta_evals.targets.letta_code_target import LettaCodeTarget, _parse_stream_line
+from letta_evals.targets.letta_code_target import LettaCodeTarget
 
-# --- _parse_stream_line ------------------------------------------------------
+# --- parse_stream_line -------------------------------------------------------
 
 
 def test_parse_single_object():
-    assert _parse_stream_line('{"type": "result"}') == [{"type": "result"}]
+    assert parse_stream_line('{"type": "result"}') == [{"type": "result"}]
 
 
 def test_parse_empty_line():
-    assert _parse_stream_line("") == []
+    assert parse_stream_line("") == []
 
 
 def test_parse_concatenated_records_salvages_all(caplog):
     # Torn writer output: two records glued onto one line ("Extra data").
     line = '{"a": 1}{"b": 2}'
     with caplog.at_level(logging.WARNING):
-        events = _parse_stream_line(line)
+        events = parse_stream_line(line)
     assert events == [{"a": 1}, {"b": 2}]
     assert "Extra data" in caplog.text
     assert "salvaged 2 event(s)" in caplog.text
 
 
 def test_parse_concatenated_records_with_whitespace_between():
-    assert _parse_stream_line('{"a": 1} \t {"b": 2}') == [{"a": 1}, {"b": 2}]
+    assert parse_stream_line('{"a": 1} \t {"b": 2}') == [{"a": 1}, {"b": 2}]
 
 
 def test_parse_truncated_line_returns_empty(caplog):
     line = '{"type": "message", "content": "abc'
     with caplog.at_level(logging.WARNING):
-        events = _parse_stream_line(line)
+        events = parse_stream_line(line)
     assert events == []
     assert "Unterminated string" in caplog.text
 
 
 def test_parse_object_followed_by_truncated_record():
     # First record intact, second torn off mid-payload: salvage the first.
-    assert _parse_stream_line('{"a": 1}{"b": "tru') == [{"a": 1}]
+    assert parse_stream_line('{"a": 1}{"b": "tru') == [{"a": 1}]
 
 
 def test_parse_control_character_payload(caplog):
     line = '{"content": "a\x01b"}'
     with caplog.at_level(logging.WARNING):
-        assert _parse_stream_line(line) == []
+        assert parse_stream_line(line) == []
     assert "Invalid control character" in caplog.text
 
 
 def test_parse_non_object_json_ignored():
-    assert _parse_stream_line("42") == []
-    assert _parse_stream_line("[1, 2]") == []
+    assert parse_stream_line("42") == []
+    assert parse_stream_line("[1, 2]") == []
 
 
 # --- run() end-to-end against a fake letta CLI -------------------------------

--- a/tests/test_letta_code_target_stream.py
+++ b/tests/test_letta_code_target_stream.py
@@ -1,0 +1,181 @@
+"""Tests for LettaCodeTarget stream-json handling (issue #319).
+
+Covers the `_parse_stream_line` salvage helper and the slimmed-down stdout
+reader: the stream is drained but only parsed for the init event (agent_id)
+and the final result event (usage), so malformed mid-stream tool-return
+lines cannot affect a run.
+"""
+
+import logging
+import os
+
+import pytest
+
+from letta_evals.models import Sample
+from letta_evals.targets.errors import TargetError
+from letta_evals.targets.letta_code_target import LettaCodeTarget, _parse_stream_line
+
+# --- _parse_stream_line ------------------------------------------------------
+
+
+def test_parse_single_object():
+    assert _parse_stream_line('{"type": "result"}') == [{"type": "result"}]
+
+
+def test_parse_empty_line():
+    assert _parse_stream_line("") == []
+
+
+def test_parse_concatenated_records_salvages_all(caplog):
+    # Torn writer output: two records glued onto one line ("Extra data").
+    line = '{"a": 1}{"b": 2}'
+    with caplog.at_level(logging.WARNING):
+        events = _parse_stream_line(line)
+    assert events == [{"a": 1}, {"b": 2}]
+    assert "Extra data" in caplog.text
+    assert "salvaged 2 event(s)" in caplog.text
+
+
+def test_parse_concatenated_records_with_whitespace_between():
+    assert _parse_stream_line('{"a": 1} \t {"b": 2}') == [{"a": 1}, {"b": 2}]
+
+
+def test_parse_truncated_line_returns_empty(caplog):
+    line = '{"type": "message", "content": "abc'
+    with caplog.at_level(logging.WARNING):
+        events = _parse_stream_line(line)
+    assert events == []
+    assert "Unterminated string" in caplog.text
+
+
+def test_parse_object_followed_by_truncated_record():
+    # First record intact, second torn off mid-payload: salvage the first.
+    assert _parse_stream_line('{"a": 1}{"b": "tru') == [{"a": 1}]
+
+
+def test_parse_control_character_payload(caplog):
+    line = '{"content": "a\x01b"}'
+    with caplog.at_level(logging.WARNING):
+        assert _parse_stream_line(line) == []
+    assert "Invalid control character" in caplog.text
+
+
+def test_parse_non_object_json_ignored():
+    assert _parse_stream_line("42") == []
+    assert _parse_stream_line("[1, 2]") == []
+
+
+# --- run() end-to-end against a fake letta CLI -------------------------------
+
+INIT_LINE = b'{"type": "system", "subtype": "init", "agent_id": "agent-stream-test"}'
+RESULT_LINE = b'{"type": "result", "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}}'
+TOOL_RETURN_LINE = b'{"type": "message", "message_type": "tool_return_message", "content": "' + b"x" * 30000 + b'"}'
+
+
+def _install_fake_letta(tmp_path, monkeypatch, stdout_payload: bytes, returncode: int = 0) -> None:
+    """Install a fake `letta` CLI on PATH that consumes stdin, emits a fixed
+    stdout payload byte-for-byte, and exits with the given code."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    payload = bin_dir / "stdout_payload"
+    payload.write_bytes(stdout_payload)
+    script = bin_dir / "letta"
+    script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import pathlib, sys\n"
+        "sys.stdin.read()\n"
+        f"sys.stdout.buffer.write(pathlib.Path({str(payload)!r}).read_bytes())\n"
+        f"sys.exit({returncode})\n"
+    )
+    script.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+
+
+def _make_target(tmp_path) -> LettaCodeTarget:
+    # client is only used by the agent_script factory path, never here.
+    return LettaCodeTarget(client=None, model_handle="test-model", base_dir=tmp_path, timeout=30)
+
+
+@pytest.mark.asyncio
+async def test_run_ignores_malformed_mid_stream_lines(tmp_path, monkeypatch, caplog):
+    # A torn tool_return line (two records on one line) between init and
+    # result is drained without parsing: no warning, no effect on the run.
+    payload = b"\n".join([INIT_LINE, TOOL_RETURN_LINE + TOOL_RETURN_LINE, RESULT_LINE, b""])
+    _install_fake_letta(tmp_path, monkeypatch, payload)
+
+    with caplog.at_level(logging.WARNING):
+        result = await _make_target(tmp_path).run(Sample(id=0, input="hello"))
+
+    assert result.agent_id == "agent-stream-test"
+    assert result.agent_usage == [
+        {
+            "message_type": "usage_statistics",
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "cached_input_tokens": 0,
+            "cache_write_tokens": 0,
+            "reasoning_tokens": 0,
+        }
+    ]
+    assert "Malformed stream-json line" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_run_salvages_result_event_glued_to_tool_return(tmp_path, monkeypatch, caplog):
+    # If the writer glues the final result event onto the preceding
+    # tool_return line, raw_decode salvage still recovers the usage stats.
+    payload = b"\n".join([INIT_LINE, TOOL_RETURN_LINE + RESULT_LINE, b""])
+    _install_fake_letta(tmp_path, monkeypatch, payload)
+
+    with caplog.at_level(logging.WARNING):
+        result = await _make_target(tmp_path).run(Sample(id=0, input="hello"))
+
+    assert result.agent_id == "agent-stream-test"
+    assert result.agent_usage is not None
+    assert result.agent_usage[0]["total_tokens"] == 15
+    assert "salvaged 2 event(s)" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_run_survives_invalid_utf8_in_stream(tmp_path, monkeypatch):
+    payload = b"\n".join([INIT_LINE, b'{"type": "message", "content": "\xff\xfe garbage"}', RESULT_LINE, b""])
+    _install_fake_letta(tmp_path, monkeypatch, payload)
+
+    result = await _make_target(tmp_path).run(Sample(id=0, input="hello"))
+
+    assert result.agent_id == "agent-stream-test"
+    assert result.agent_usage[0]["total_tokens"] == 15
+
+
+@pytest.mark.asyncio
+async def test_run_missing_result_event_yields_no_usage(tmp_path, monkeypatch):
+    # A stream cut short of the result event reports usage as None.
+    payload = b"\n".join([INIT_LINE, TOOL_RETURN_LINE, b""])
+    _install_fake_letta(tmp_path, monkeypatch, payload)
+
+    result = await _make_target(tmp_path).run(Sample(id=0, input="hello"))
+
+    assert result.agent_id == "agent-stream-test"
+    assert result.agent_usage is None
+
+
+@pytest.mark.asyncio
+async def test_run_nonzero_exit_surfaces_last_stdout_line(tmp_path, monkeypatch):
+    payload = b"\n".join([INIT_LINE, b'{"type": "error", "message": "boom"}', b""])
+    _install_fake_letta(tmp_path, monkeypatch, payload, returncode=1)
+
+    with pytest.raises(TargetError) as exc_info:
+        await _make_target(tmp_path).run(Sample(id=0, input="hello"))
+
+    assert "return code 1" in str(exc_info.value)
+    assert "boom" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_run_without_init_event_fails_with_no_agent_id(tmp_path, monkeypatch):
+    payload = b"\n".join([TOOL_RETURN_LINE, RESULT_LINE, b""])
+    _install_fake_letta(tmp_path, monkeypatch, payload)
+
+    with pytest.raises(TargetError, match="No agent_id found"):
+        await _make_target(tmp_path).run(Sample(id=0, input="hello"))

--- a/tests/test_letta_code_target_stream.py
+++ b/tests/test_letta_code_target_stream.py
@@ -1,71 +1,58 @@
-"""Stream-json handling: the parse_stream_line salvage helper and the
-drain-only LettaCodeTarget stdout reader (issue #319)."""
+"""Stream-json handling: the drain-only LettaCodeTarget stdout reader and
+final-line usage extraction (issue #319)."""
 
 import logging
 import os
 
 import pytest
 
-from letta_evals.execution.trace import parse_stream_line
+from letta_evals.execution.trace import extract_usage_stats
 from letta_evals.models import Sample
 from letta_evals.targets.errors import TargetError
 from letta_evals.targets.letta_code_target import LettaCodeTarget
 
-# --- parse_stream_line -------------------------------------------------------
+# --- extract_usage_stats -----------------------------------------------------
+
+RESULT_LINE = '{"type": "result", "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}}'
 
 
-def test_parse_single_object():
-    assert parse_stream_line('{"type": "result"}') == [{"type": "result"}]
+def test_extract_usage_from_result_line():
+    stats = extract_usage_stats(RESULT_LINE)
+    assert stats == [
+        {
+            "message_type": "usage_statistics",
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "cached_input_tokens": 0,
+            "cache_write_tokens": 0,
+            "reasoning_tokens": 0,
+        }
+    ]
 
 
-def test_parse_empty_line():
-    assert parse_stream_line("") == []
+def test_extract_usage_empty_line_is_none():
+    assert extract_usage_stats("") is None
 
 
-def test_parse_concatenated_records_salvages_all(caplog):
-    # Torn writer output: two records glued onto one line ("Extra data").
-    line = '{"a": 1}{"b": 2}'
+def test_extract_usage_non_result_event_is_none():
+    assert extract_usage_stats('{"type": "message", "content": "hi"}') is None
+    assert extract_usage_stats("42") is None
+
+
+def test_extract_usage_malformed_line_warns_and_is_none(caplog):
+    # e.g. a result event glued onto a torn tool-return line
     with caplog.at_level(logging.WARNING):
-        events = parse_stream_line(line)
-    assert events == [{"a": 1}, {"b": 2}]
+        assert extract_usage_stats('{"type": "message"}' + RESULT_LINE) is None
+    assert "Unparseable final stream line" in caplog.text
     assert "Extra data" in caplog.text
-    assert "salvaged 2 event(s)" in caplog.text
-
-
-def test_parse_concatenated_records_with_whitespace_between():
-    assert parse_stream_line('{"a": 1} \t {"b": 2}') == [{"a": 1}, {"b": 2}]
-
-
-def test_parse_truncated_line_returns_empty(caplog):
-    line = '{"type": "message", "content": "abc'
-    with caplog.at_level(logging.WARNING):
-        events = parse_stream_line(line)
-    assert events == []
-    assert "Unterminated string" in caplog.text
-
-
-def test_parse_object_followed_by_truncated_record():
-    # First record intact, second torn off mid-payload: salvage the first.
-    assert parse_stream_line('{"a": 1}{"b": "tru') == [{"a": 1}]
-
-
-def test_parse_control_character_payload(caplog):
-    line = '{"content": "a\x01b"}'
-    with caplog.at_level(logging.WARNING):
-        assert parse_stream_line(line) == []
-    assert "Invalid control character" in caplog.text
-
-
-def test_parse_non_object_json_ignored():
-    assert parse_stream_line("42") == []
-    assert parse_stream_line("[1, 2]") == []
 
 
 # --- run() end-to-end against a fake letta CLI -------------------------------
 
-INIT_LINE = b'{"type": "system", "subtype": "init", "agent_id": "agent-stream-test"}'
-RESULT_LINE = b'{"type": "result", "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}}'
-TOOL_RETURN_LINE = b'{"type": "message", "message_type": "tool_return_message", "content": "' + b"x" * 30000 + b'"}'
+INIT_LINE_B = b'{"type": "system", "subtype": "init", "agent_id": "agent-stream-test"}'
+RESULT_LINE_B = RESULT_LINE.encode()
+TOOL_RETURN_LINE_B = b'{"type": "message", "message_type": "tool_return_message", "content": "' + b"x" * 30000 + b'"}'
 
 
 def _install_fake_letta(tmp_path, monkeypatch, stdout_payload: bytes, returncode: int = 0) -> None:
@@ -93,49 +80,36 @@ def _make_target(tmp_path) -> LettaCodeTarget:
 
 
 @pytest.mark.asyncio
-async def test_run_ignores_malformed_mid_stream_lines(tmp_path, monkeypatch, caplog):
+async def test_run_ignores_malformed_mid_stream_lines(tmp_path, monkeypatch):
     # A torn tool_return line (two records on one line) between init and
-    # result is drained without parsing: no warning, no effect on the run.
-    payload = b"\n".join([INIT_LINE, TOOL_RETURN_LINE + TOOL_RETURN_LINE, RESULT_LINE, b""])
+    # result is drained without parsing: no effect on the run.
+    payload = b"\n".join([INIT_LINE_B, TOOL_RETURN_LINE_B + TOOL_RETURN_LINE_B, RESULT_LINE_B, b""])
     _install_fake_letta(tmp_path, monkeypatch, payload)
 
-    with caplog.at_level(logging.WARNING):
-        result = await _make_target(tmp_path).run(Sample(id=0, input="hello"))
+    result = await _make_target(tmp_path).run(Sample(id=0, input="hello"))
 
     assert result.agent_id == "agent-stream-test"
-    assert result.agent_usage == [
-        {
-            "message_type": "usage_statistics",
-            "prompt_tokens": 10,
-            "completion_tokens": 5,
-            "total_tokens": 15,
-            "cached_input_tokens": 0,
-            "cache_write_tokens": 0,
-            "reasoning_tokens": 0,
-        }
-    ]
-    assert "Malformed stream-json line" not in caplog.text
+    assert result.agent_usage[0]["total_tokens"] == 15
 
 
 @pytest.mark.asyncio
-async def test_run_salvages_result_event_glued_to_tool_return(tmp_path, monkeypatch, caplog):
-    # If the writer glues the final result event onto the preceding
-    # tool_return line, raw_decode salvage still recovers the usage stats.
-    payload = b"\n".join([INIT_LINE, TOOL_RETURN_LINE + RESULT_LINE, b""])
+async def test_run_glued_result_line_warns_and_yields_no_usage(tmp_path, monkeypatch, caplog):
+    # If the writer glues the result event onto the preceding tool_return
+    # line, usage is lost (accepted tradeoff) but the run still succeeds.
+    payload = b"\n".join([INIT_LINE_B, TOOL_RETURN_LINE_B + RESULT_LINE_B, b""])
     _install_fake_letta(tmp_path, monkeypatch, payload)
 
     with caplog.at_level(logging.WARNING):
         result = await _make_target(tmp_path).run(Sample(id=0, input="hello"))
 
     assert result.agent_id == "agent-stream-test"
-    assert result.agent_usage is not None
-    assert result.agent_usage[0]["total_tokens"] == 15
-    assert "salvaged 2 event(s)" in caplog.text
+    assert result.agent_usage is None
+    assert "Unparseable final stream line" in caplog.text
 
 
 @pytest.mark.asyncio
 async def test_run_survives_invalid_utf8_in_stream(tmp_path, monkeypatch):
-    payload = b"\n".join([INIT_LINE, b'{"type": "message", "content": "\xff\xfe garbage"}', RESULT_LINE, b""])
+    payload = b"\n".join([INIT_LINE_B, b'{"type": "message", "content": "\xff\xfe garbage"}', RESULT_LINE_B, b""])
     _install_fake_letta(tmp_path, monkeypatch, payload)
 
     result = await _make_target(tmp_path).run(Sample(id=0, input="hello"))
@@ -147,7 +121,7 @@ async def test_run_survives_invalid_utf8_in_stream(tmp_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_run_missing_result_event_yields_no_usage(tmp_path, monkeypatch):
     # A stream cut short of the result event reports usage as None.
-    payload = b"\n".join([INIT_LINE, TOOL_RETURN_LINE, b""])
+    payload = b"\n".join([INIT_LINE_B, TOOL_RETURN_LINE_B, b""])
     _install_fake_letta(tmp_path, monkeypatch, payload)
 
     result = await _make_target(tmp_path).run(Sample(id=0, input="hello"))
@@ -158,7 +132,7 @@ async def test_run_missing_result_event_yields_no_usage(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_run_nonzero_exit_surfaces_last_stdout_line(tmp_path, monkeypatch):
-    payload = b"\n".join([INIT_LINE, b'{"type": "error", "message": "boom"}', b""])
+    payload = b"\n".join([INIT_LINE_B, b'{"type": "error", "message": "boom"}', b""])
     _install_fake_letta(tmp_path, monkeypatch, payload, returncode=1)
 
     with pytest.raises(TargetError) as exc_info:
@@ -170,7 +144,7 @@ async def test_run_nonzero_exit_surfaces_last_stdout_line(tmp_path, monkeypatch)
 
 @pytest.mark.asyncio
 async def test_run_without_init_event_fails_with_no_agent_id(tmp_path, monkeypatch):
-    payload = b"\n".join([TOOL_RETURN_LINE, RESULT_LINE, b""])
+    payload = b"\n".join([TOOL_RETURN_LINE_B, RESULT_LINE_B, b""])
     _install_fake_letta(tmp_path, monkeypatch, payload)
 
     with pytest.raises(TargetError, match="No agent_id found"):


### PR DESCRIPTION
## Summary

Fixes #319.

`LettaCodeTarget` parsed every stream-json line from letta-code, but only two events are ever consumed: the **init** event (`agent_id`, which keys all server-side trace fetches in `Runner`) and the **final result** event (usage stats). The authoritative trajectory never comes from the stream. Meanwhile, large tool-return lines are exactly the ones that arrive malformed from torn stdout writes, producing hundreds of `Non-JSON stream output` warnings with no diagnostic value.

## Changes

- **Drain instead of parse**: once the init event is seen, stdout lines are drained without `json.loads`; only the raw last non-blank line is kept. Malformed mid-stream tool-return lines can no longer produce warnings or affect a run. This also stops accumulating every event in memory for the rollout's duration.
- **`extract_usage_stats` takes the raw final line**: it parses that one line itself and returns `None` when it's empty, unparseable, or not a result event. When the line fails to parse (e.g. the result event torn onto the preceding tool-return line), it logs the decode error message and position — enough to identify the failure mode, per the issue's diagnostics ask. Usage is reported as `None` in that case; the run itself is unaffected.
- **Reader hardening**: invalid UTF-8 is decoded with `errors="replace"` instead of crashing the read task and burning retries; valid-JSON non-object lines are ignored instead of raising `AttributeError`.
- **Better error surfacing**: on non-zero exit, the error message includes the raw last stdout line rather than the last successfully parsed event — more diagnostic when the final line is the malformed one.

## Behavior preserved

- `agent_id` is still captured the moment init arrives, so timeouts retain partial-trajectory fetching.
- A stream cut short of the result event still reports usage as `None` on both success and error paths.
- Progress callbacks (`agent_created`, `message_sending`) fire exactly as before.

## Tests

New `tests/test_letta_code_target_stream.py`: unit tests for final-line usage extraction (result event, empty/non-result/malformed lines) and end-to-end `run()` tests against a fake `letta` CLI on PATH, covering torn mid-stream lines, a result event glued onto a tool-return line, invalid UTF-8, missing result event, non-zero exit, and missing init. `pytest` (329 passed) and `ruff check`/`format` are clean.