### PR TITLE
fix(cli): Print sanitized results filenames in completion messages

### DIFF
--- a/letta_evals/cli.py
+++ b/letta_evals/cli.py
@@ -12,6 +12,7 @@ from letta_evals import __version__
 from letta_evals.datasets.loader import load_dataset
 from letta_evals.models import SuiteSpec
 from letta_evals.runner import run_suite
+from letta_evals.streaming import _safe_segment
 from letta_evals.visualization.factory import ProgressStyle
 
 app = typer.Typer(help="Letta Evals - Evaluation framework for Letta AI agents")
@@ -246,13 +247,15 @@ def run(
         if effective_output and not quiet:
             console.print(f"[green]Suite config saved to {effective_output}/suite.json[/green]")
             console.print(f"[green]Summary saved to {effective_output}/summary.json[/green]")
+            # Print the sanitized on-disk names, not the raw model handles
+            # (streaming writes openai/gpt-4 results to openai-gpt-4.jsonl).
             if is_multi_run:
-                model_dirs = ", ".join(ms.model for ms in result.summary.models)
+                model_dirs = ", ".join(_safe_segment(ms.model) for ms in result.summary.models)
                 console.print(
                     f"[green]Per-run results saved under {effective_output}/<model>/run_*.jsonl (models: {model_dirs})[/green]"
                 )
             else:
-                files = ", ".join(f"{ms.model}.jsonl" for ms in result.summary.models)
+                files = ", ".join(f"{_safe_segment(ms.model)}.jsonl" for ms in result.summary.models)
                 console.print(f"[green]Per-model results streamed to {effective_output}/{{{files}}}[/green]")
 
         if not quiet:


### PR DESCRIPTION
## Summary

The run-completion messages built display paths from raw model handles, while `StreamingWriter` sanitizes handles via `_safe_segment` when naming files (`streaming.py:89`). So the CLI printed `Per-model results streamed to out/{anthropic/claude-sonnet-4-5-20250929.jsonl}` — a path that doesn't exist — when the actual file is `out/anthropic-claude-sonnet-4-5-20250929.jsonl`. The multi-run message had the same mismatch in its `(models: ...)` list.

Apply `_safe_segment` to both messages so the printed names match disk. Imported at top level — `cli.py` already loads `streaming` transitively through `runner`, so there's nothing to defer.

## Verification

Ran a single-run and a `num_runs: 2` suite and compared the printed message against `ls` of the output directory:

```
Per-model results streamed to .../out-display/{anthropic-claude-sonnet-4-5-20250929.jsonl}
--- files on disk:
anthropic-claude-sonnet-4-5-20250929.jsonl

Per-run results saved under .../out-display2/<model>/run_*.jsonl (models: anthropic-claude-sonnet-4-5-20250929)
--- dirs on disk:
anthropic-claude-sonnet-4-5-20250929
```