### PR TITLE
feat(cli): Override models for full suite runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,11 @@ Yes. Many suites only need YAML plus JSONL/CSV data and built-in graders such as
 
 **Can I test multiple models?**
 
-Yes. Set `target.model_handles` to a list. Letta Evals runs every sample for every model and writes per-model results.
+Yes. Set `target.model_handles` to a list. Letta Evals runs every sample for every model and writes per-model results. To run the complete suite against one model without editing its YAML, pass `--model-handle`, for example:
+
+```bash
+letta-evals run suite.yaml --model-handle baseten/dream-1@letta-research
+```
 
 **Can I run evaluations repeatedly?**
 

--- a/examples/letta-code-simple-edit/README.md
+++ b/examples/letta-code-simple-edit/README.md
@@ -65,6 +65,7 @@ return arr[len(arr)]  # should be arr[-1] or arr[len(arr)-1]
 def calculate_average(numbers):
     return sum(numbers) / len(numbers)  # crashes on empty list
 
+
 calculate_average([])  # needs guard clause
 ```
 **Expected output after fix:** `Average: 30.0` (only the second test case)
@@ -146,7 +147,8 @@ async def python_output_grader(sample: Sample, submission: str) -> GradeResult:
 
     # run the python file asynchronously
     process = await asyncio.create_subprocess_exec(
-        "python3", str(full_path),
+        "python3",
+        str(full_path),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )

--- a/letta_evals/cli.py
+++ b/letta_evals/cli.py
@@ -96,8 +96,9 @@ def run(
         None,
         "--model-handle",
         help=(
-            "Only valid with --sample: scope the single-sample run to this model handle "
-            "(e.g. 'openai/gpt-4.1'). Overrides the suite's model_handles list."
+            "Scope the run to this single model handle (e.g. 'openai/gpt-4.1'). "
+            "Overrides the suite's model_handles list for both full-suite and "
+            "--sample runs."
         ),
     ),
 ):
@@ -152,6 +153,13 @@ def run(
     try:
         with open(suite_path, "r") as f:
             yaml_data = yaml.safe_load(f)
+
+        # Apply --model-handle override before SuiteSpec construction so the
+        # entire suite (display counts, runner, sandbox dispatch) sees a
+        # single-model scope.  Mirrors the mutation in _run_single_sample.
+        if model_handle is not None:
+            yaml_data.setdefault("target", {})["model_handles"] = [model_handle]
+
         suite = SuiteSpec.from_yaml(yaml_data, base_dir=suite_path.parent, suite_path=suite_path)
 
         effective_max_concurrent = (
@@ -234,6 +242,7 @@ def run(
             letta_base_url=base_url,
             letta_project_id=project_id,
             num_runs=num_runs,
+            model_handle=model_handle,
         )
 
     try:

--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -702,8 +702,15 @@ async def run_suite(
     letta_base_url: Optional[str] = None,
     letta_project_id: Optional[str] = None,
     num_runs: Optional[int] = None,
+    model_handle: Optional[str] = None,
 ) -> RunnerResult:
-    """Load and run a suite from YAML file."""
+    """Load and run a suite from YAML file.
+
+    When ``model_handle`` is provided, the suite's ``target.model_handles``
+    list is narrowed to just that single handle *before* ``SuiteSpec``
+    construction, so the runner, sandbox dispatch, and streaming writer all
+    see a single-model scope.
+    """
     if custom_progress_callback is not None:
         style_val = progress_style if isinstance(progress_style, ProgressStyle) else ProgressStyle(progress_style)
         if style_val != ProgressStyle.NONE:
@@ -714,6 +721,12 @@ async def run_suite(
 
     with open(suite_path, "r") as f:
         yaml_data = yaml.safe_load(f)
+
+    # Apply --model-handle override before SuiteSpec construction so the
+    # entire run (runner, sandbox dispatch, streaming writer) sees a
+    # single-model scope.  Mirrors the mutation in _run_single_sample.
+    if model_handle is not None:
+        yaml_data.setdefault("target", {})["model_handles"] = [model_handle]
 
     suite = SuiteSpec.from_yaml(yaml_data, base_dir=suite_path.parent, suite_path=suite_path)
 

--- a/tests/test_cli_model_handle_override.py
+++ b/tests/test_cli_model_handle_override.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import anyio
+
+from letta_evals.runner import run_suite
+
+
+def _write_suite(tmp_path: Path, model_handles: list[str] | None) -> Path:
+    dataset_path = tmp_path / "samples.jsonl"
+    dataset_path.write_text(json.dumps({"id": "sample-1", "input": "hello"}) + "\n")
+
+    model_yaml = ""
+    if model_handles is not None:
+        model_yaml = "  model_handles:\n" + "".join(f"    - {handle}\n" for handle in model_handles)
+
+    suite_path = tmp_path / "suite.yaml"
+    suite_path.write_text(
+        f"name: model-override-test\n"
+        f"dataset: samples.jsonl\n"
+        f"target:\n"
+        f"  kind: letta_code\n"
+        f"{model_yaml}"
+        f"graders:\n"
+        f"  acc:\n"
+        f"    kind: tool\n"
+        f"    function: exact_match\n"
+        f"reward:\n"
+        f"  kind: metric\n"
+        f"  metric_key: acc\n"
+    )
+    return suite_path
+
+
+def test_run_suite_overrides_declared_model_handles(tmp_path, monkeypatch):
+    suite_path = _write_suite(tmp_path, ["openai/model-a", "openai/model-b"])
+    captured = {}
+    sentinel = object()
+
+    async def fake_execute_runs(**kwargs):
+        captured["suite"] = kwargs["suite"]
+        return sentinel
+
+    monkeypatch.setattr("letta_evals.runner._execute_runs", fake_execute_runs)
+
+    async def run():
+        return await run_suite(
+            suite_path,
+            max_concurrent=1,
+            model_handle="baseten/dream-1@letta-research",
+        )
+
+    result = anyio.run(run)
+
+    assert result is sentinel
+    assert captured["suite"].target.model_handles == ["baseten/dream-1@letta-research"]
+
+
+def test_run_suite_override_sets_missing_model_handles(tmp_path, monkeypatch):
+    suite_path = _write_suite(tmp_path, None)
+    captured = {}
+
+    async def fake_execute_runs(**kwargs):
+        captured["suite"] = kwargs["suite"]
+        return object()
+
+    monkeypatch.setattr("letta_evals.runner._execute_runs", fake_execute_runs)
+
+    async def run():
+        await run_suite(
+            suite_path,
+            max_concurrent=1,
+            model_handle="baseten/dream-1@production",
+        )
+
+    anyio.run(run)
+
+    assert captured["suite"].target.model_handles == ["baseten/dream-1@production"]
+
+
+def test_run_suite_without_override_preserves_declared_models(tmp_path, monkeypatch):
+    declared = ["openai/model-a", "openai/model-b"]
+    suite_path = _write_suite(tmp_path, declared)
+    captured = {}
+
+    async def fake_execute_runs(**kwargs):
+        captured["suite"] = kwargs["suite"]
+        return object()
+
+    monkeypatch.setattr("letta_evals.runner._execute_runs", fake_execute_runs)
+
+    async def run():
+        await run_suite(suite_path, max_concurrent=1)
+
+    anyio.run(run)
+
+    assert captured["suite"].target.model_handles == declared


### PR DESCRIPTION
## Summary
- allow `--model-handle` to override `target.model_handles` for complete suite runs
- apply the override before suite construction in both CLI display and runner execution paths
- preserve the existing single-sample and sandbox behavior
- document model-specific full-suite invocation

Example:

```bash
letta-evals run suite.yaml --model-handle baseten/model@letta-research
```

## Test plan
- [x] `ruff format` and `ruff check` on changed Python files and tests
- [x] full test suite: 332 passed, 2 skipped

👾 Generated with [Letta Code](https://letta.com)