### PR TITLE
fix(sandbox): Make Modal runtime pins cache-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,10 @@ sandbox:
 **Breaking:** `image` is optional, but when it is omitted both exact
 application pins are now required; mutable tags, ranges, and non-commit Git
 refs are rejected. The driver builds the system base from the bundled
-Dockerfile, then installs each application in an explicit Modal layer whose definition includes its
-pin. Override `image` with a pre-built registry reference only when the agent
-needs additional system tools or a separately managed runtime.
+Dockerfile, then installs each application in an explicit Modal layer whose
+definition includes its pin. Override `image` with a pre-built registry
+reference only when the agent needs additional system tools or a separately
+managed runtime.
 
 When `sandbox` is set, the runner uploads the entire suite directory tree
 to `/mnt/suite/` inside the sandbox, execs `letta-evals run --sample ...`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,16 +16,19 @@ adding a top-level `sandbox` field to the suite YAML:
 ```yaml
 sandbox:
   kind: modal
+  letta_evals_version: "0.25.0"
+  letta_code_version: "0.30.5"
   secrets: [letta-api-key, openai-key]
   cpu: 2
   memory_mb: 4096
 ```
 
-`image` is optional — when omitted, the driver builds the base image on
-demand from the bundled `letta_evals/sandbox/Dockerfile` (cached after the
-first build), which already carries `letta-evals` (pip) and
-`@letta-ai/letta-code` (npm). Override `image` with a pre-built registry
-reference only when the agent needs additional system tools.
+**Breaking:** `image` is optional, but when it is omitted both exact
+application pins are now required; mutable tags, ranges, and non-commit Git
+refs are rejected. The driver builds the system base from the bundled
+Dockerfile, then installs each application in an explicit Modal layer whose definition includes its
+pin. Override `image` with a pre-built registry reference only when the agent
+needs additional system tools or a separately managed runtime.
 
 When `sandbox` is set, the runner uploads the entire suite directory tree
 to `/mnt/suite/` inside the sandbox, execs `letta-evals run --sample ...`,

--- a/README.md
+++ b/README.md
@@ -240,12 +240,14 @@ Add a suite-level `sandbox` block to run every sample inside a fresh Modal sandb
 ```yaml
 sandbox:
   kind: modal
+  letta_evals_version: "0.25.0"
+  letta_code_version: "0.30.5"
   cpu: 2
   memory_mb: 4096
   timeout_sec: 1800
 ```
 
-The host runner still owns the sample loop, concurrency, JSONL output, and reward aggregation. Each sample is uploaded to a sandbox along with the suite directory; the target, extractors, graders, and reward composer run in the sandbox; and the final `SampleResult` is returned to the host.
+The bundled runtime requires exact `letta_evals_version` and `letta_code_version` pins; mutable tags and version ranges are rejected. The host runner still owns the sample loop, concurrency, JSONL output, and reward aggregation. Each sample is uploaded to a sandbox along with the suite directory; the target, extractors, graders, and reward composer run in the sandbox; and the final `SampleResult` is returned to the host.
 
 See [`docs/modal-sandbox.md`](docs/modal-sandbox.md) for setup details, networking notes, and common failure modes.
 

--- a/docs/modal-sandbox.md
+++ b/docs/modal-sandbox.md
@@ -1,56 +1,46 @@
 # Modal sandboxes
 
-Run every sample inside a fresh Modal sandbox by adding a single field to
-your suite YAML:
+Run every sample inside a fresh Modal sandbox by adding a suite-level block
+with exact application runtime pins:
 
 ```yaml
 sandbox:
   kind: modal
+  letta_evals_version: "0.25.0"
+  letta_code_version: "0.30.5"
   secrets: [letta-api-key, openai-key]
   cpu: 2
   memory_mb: 4096
 ```
 
-`image` is optional. When unset, the driver builds the base image on
-demand from the Dockerfile bundled at `letta_evals/sandbox/Dockerfile`
-via Modal's `Image.from_dockerfile` — it carries `letta-evals` (pip) and
-`@letta-ai/letta-code` (npm), and the build is cached so only the first
-sandbox after an edit pays the build cost. Override `image` only when you
-need additional system tools the agent invokes.
+`image` is optional. When unset, the driver builds the system base in
+`letta_evals/sandbox/Dockerfile`, then installs the requested `letta-evals`
+and `@letta-ai/letta-code` releases in explicit Modal layers. Each exact pin
+is part of its layer's command, so changing a pin rebuilds that layer and its
+downstream layers without rebuilding the stable OS/toolchain base.
 
-## Pinning the letta-code version
-
-The bundled image installs `@letta-ai/letta-code@latest` by default. To
-evaluate a specific letta-code release — e.g. for reproducible training
-rollouts — pin it with `letta_code_version`:
+Both pins are required with the bundled base. Mutable values such as `latest`,
+npm version ranges, and Git branch or tag references are rejected. For an
+unreleased `letta-evals` revision, use a direct reference with the full commit
+SHA:
 
 ```yaml
 sandbox:
   kind: modal
-  letta_code_version: "0.27.17"
+  letta_evals_version: "letta-evals @ git+https://github.com/letta-ai/letta-evals.git@0123456789abcdef0123456789abcdef01234567"
+  letta_code_version: "0.30.5"
 ```
 
-The driver passes it to the Dockerfile as the `LETTA_CODE_VERSION` build
-arg (`npm install -g @letta-ai/letta-code@<version>`). Modal keys the
-cached image on build args, so each pinned version gets its own cached
-build. This applies only to the bundled Dockerfile path — when you set a
-pre-built `image`, `letta_code_version` is ignored (the registry image
-already bakes in its own letta-code) and the driver logs a warning.
+For the bundled runtime, the runner verifies the installed Python version or
+Git commit, the installed npm package version, and Node `>=22.19.0`
+immediately after sandbox startup. It also logs the hydrated Modal image ID
+and detected runtime versions. Custom images log the same probe data, while
+their baked-in Node and Letta Code versions remain image-managed.
 
-Pin `letta-evals` the same way when the host and sandbox must use an exact
-runner version:
-
-```yaml
-sandbox:
-  kind: modal
-  letta_evals_version: "0.24.0"
-```
-
-With the bundled image, the driver passes this value to the Dockerfile as the
-`LETTA_EVALS_VERSION` build arg, so it both selects the installed version and
-invalidates stale cached image layers. The runner also verifies the version
-after startup. With a pre-built `image`, the setting only performs the runtime
-version check.
+Override `image` only when you need additional system tools or a pre-built
+runtime. A custom image may omit both pins because it bakes in its own
+applications. If `letta_evals_version` is set with a custom image, it remains
+a runtime assertion; `letta_code_version` is ignored and logs a warning.
 
 The orchestrator (`letta-evals run`) keeps running on your host — same
 sample loop, same `max_concurrent`, same JSONL output, same reward
@@ -93,23 +83,23 @@ final `SampleResult` JSON back.
      `secrets: [<name>]`. Only allowlisted names are forwarded — never
      your whole environment.
 
-   The bundled base image already carries `letta-evals` and
-   `@letta-ai/letta-code`, so most suites won't need a custom image.
+   The default image layers install the two pinned application runtimes,
+   so most suites won't need a custom image.
 
 ### Building a custom image (optional)
 
 If your agent invokes system tools the base image doesn't ship with
-(compilers, language toolchains, project-specific binaries), build a
-derived image and reference it via `sandbox.image`. The bundled base
-recipe at `letta_evals/sandbox/Dockerfile` is a good starting point —
-copy it and add what you need:
+(compilers, language toolchains, project-specific binaries), build a custom
+runtime and reference it via `sandbox.image`. The bundled Dockerfile is now
+system-only, so a registry image must also install compatible `letta-evals`
+and `@letta-ai/letta-code` application runtimes:
 
 ```dockerfile
+# Copy the Python, Node >=22.19, git, and compiler setup from the bundled base.
 FROM python:3.12-slim
-# ... letta-evals + @letta-ai/letta-code (see letta_evals/sandbox/Dockerfile) ...
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential rustc \
-    && rm -rf /var/lib/apt/lists/*
+# ... system setup plus project-specific tools ...
+RUN python -m pip install --no-cache-dir "letta-evals==0.25.0"
+RUN npm install -g --omit=dev "@letta-ai/letta-code@0.30.5"
 ```
 
 Then push to any registry Modal can reach and set
@@ -155,6 +145,8 @@ target:
   base_url: https://your-letta-server.example.com
 sandbox:
   kind: modal
+  letta_evals_version: "0.25.0"
+  letta_code_version: "0.30.5"
   block_network: false
 ```
 
@@ -177,7 +169,7 @@ creation (`No agent_id found in letta stream output`).
 | `Modal SDK not found` | Reinstall letta-evals (`pip install letta-evals`); the Modal SDK ships with it. |
 | `Modal authentication not found` | Run `modal token new`. |
 | `SandboxExecError` with `letta-evals: not found` | The image doesn't install letta-evals on `PATH`. |
-| `VersionMismatch` | The image's `letta-evals --version` doesn't match the `letta_evals_version` pinned in the YAML. Rebuild the image or unpin. |
+| `VersionMismatch` | An installed application version, Git commit, or Node version does not match the sandbox contract. Correct the pins or rebuild a custom image. |
 | `ResultDeserializationError` | The in-sandbox CLI exited 0 but didn't write `/mnt/result.json`. Check sandbox stderr in the host run log. |
 
 ## Migrating from `target.sandbox` / `target.working_dir`
@@ -197,6 +189,8 @@ target:
   kind: letta_code
 sandbox:
   kind: modal
+  letta_evals_version: "0.25.0"
+  letta_code_version: "0.30.5"
 ```
 
 The image's `WORKDIR` (set in the Dockerfile) replaces the role of

--- a/docs/modal-sandbox.md
+++ b/docs/modal-sandbox.md
@@ -17,7 +17,7 @@ sandbox:
 `letta_evals/sandbox/Dockerfile`, then installs the requested `letta-evals`
 and `@letta-ai/letta-code` releases in explicit Modal layers. Each exact pin
 is part of its layer's command, so changing a pin rebuilds that layer and its
-downstream layers without rebuilding the stable OS/toolchain base.
+downstream layers without rebuilding the shared OS/toolchain base.
 
 Both pins are required with the bundled base. Mutable values such as `latest`,
 npm version ranges, and Git branch or tag references are rejected. For an
@@ -31,11 +31,9 @@ sandbox:
   letta_code_version: "0.30.5"
 ```
 
-For the bundled runtime, the runner verifies the installed Python version or
-Git commit, the installed npm package version, and Node `>=22.19.0`
-immediately after sandbox startup. It also logs the hydrated Modal image ID
-and detected runtime versions. Custom images log the same probe data, while
-their baked-in Node and Letta Code versions remain image-managed.
+The base checks Node `>=22.19.0` during the image build, and the application
+layers smoke-test the Letta Code CLI and `typing_extensions.Sentinel`. The
+runner retains its lightweight startup check for released `letta-evals` pins.
 
 Override `image` only when you need additional system tools or a pre-built
 runtime. A custom image may omit both pins because it bakes in its own
@@ -169,7 +167,7 @@ creation (`No agent_id found in letta stream output`).
 | `Modal SDK not found` | Reinstall letta-evals (`pip install letta-evals`); the Modal SDK ships with it. |
 | `Modal authentication not found` | Run `modal token new`. |
 | `SandboxExecError` with `letta-evals: not found` | The image doesn't install letta-evals on `PATH`. |
-| `VersionMismatch` | An installed application version, Git commit, or Node version does not match the sandbox contract. Correct the pins or rebuild a custom image. |
+| `VersionMismatch` | The image's `letta-evals --version` doesn't match the released version pinned in the YAML. Correct the pin or rebuild a custom image. |
 | `ResultDeserializationError` | The in-sandbox CLI exited 0 but didn't write `/mnt/result.json`. Check sandbox stderr in the host run log. |
 
 ## Migrating from `target.sandbox` / `target.working_dir`

--- a/docs/modal-sandbox.md
+++ b/docs/modal-sandbox.md
@@ -167,7 +167,7 @@ creation (`No agent_id found in letta stream output`).
 | `Modal SDK not found` | Reinstall letta-evals (`pip install letta-evals`); the Modal SDK ships with it. |
 | `Modal authentication not found` | Run `modal token new`. |
 | `SandboxExecError` with `letta-evals: not found` | The image doesn't install letta-evals on `PATH`. |
-| `VersionMismatch` | The image's `letta-evals --version` doesn't match the released version pinned in the YAML. Correct the pin or rebuild a custom image. |
+| `VersionMismatch` | The installed `letta-evals` distribution doesn't exactly match the released version pinned in the YAML. Correct the pin or rebuild a custom image. |
 | `ResultDeserializationError` | The in-sandbox CLI exited 0 but didn't write `/mnt/result.json`. Check sandbox stderr in the host run log. |
 
 ## Migrating from `target.sandbox` / `target.working_dir`

--- a/examples/letta-code-simple-edit/suite.yaml
+++ b/examples/letta-code-simple-edit/suite.yaml
@@ -34,6 +34,6 @@ sandbox:
   memory_mb: 4096
   timeout_sec: 1800
   block_network: false
-  # Pin the @letta-ai/letta-code version installed in the sandbox image.
-  # Omit to track the npm `latest` tag.
+  # The bundled image requires exact application runtime pins.
+  letta_evals_version: "0.25.0"
   letta_code_version: "0.27.16"

--- a/letta_evals/models/specs.py
+++ b/letta_evals/models/specs.py
@@ -4,6 +4,7 @@ Pydantic models for the suite YAML: target (agent), graders (tool / model
 judge), reward composition, and the top-level :class:`SuiteSpec`.
 """
 
+import re
 import shlex
 from pathlib import Path
 from typing import Annotated, Any, Dict, List, Literal, Optional, Union
@@ -77,17 +78,68 @@ class LettaCodeTargetSpec(BaseModel):
         return self
 
 
+_EXACT_PYTHON_VERSION_RE = re.compile(
+    r"^(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))*"
+    r"(?:(?:a|b|rc)\d+)?(?:\.post\d+)?(?:\.dev\d+)?"
+    r"(?:\+[a-z0-9]+(?:\.[a-z0-9]+)*)?$"
+)
+_EXACT_NPM_VERSION_RE = re.compile(
+    r"^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$"
+)
+_FULL_GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+def _direct_git_ref(spec: str) -> Optional[str]:
+    """Return the ref from a pip Git direct reference, if present."""
+    if "git+" not in spec:
+        return None
+    url = spec.split("git+", 1)[1].split("#", 1)[0]
+    if "@" not in url:
+        return ""
+    return url.rsplit("@", 1)[1]
+
+
+def _validate_letta_evals_pin(pin: str) -> None:
+    if not pin:
+        raise ValueError("letta_evals_version may not be empty.")
+    if pin != pin.strip():
+        raise ValueError("letta_evals_version may not contain leading or trailing whitespace.")
+    if pin.lower() == "latest":
+        raise ValueError("letta_evals_version may not use the mutable 'latest' tag.")
+
+    git_ref = _direct_git_ref(pin)
+    if git_ref is not None and not _FULL_GIT_SHA_RE.fullmatch(git_ref):
+        raise ValueError(
+            "letta_evals_version Git references must use a full 40-character commit SHA, not a mutable branch or tag."
+        )
+    if git_ref is None and "://" in pin:
+        raise ValueError("letta_evals_version direct references must be Git URLs pinned to a full commit SHA.")
+    if git_ref is None and not _EXACT_PYTHON_VERSION_RE.fullmatch(pin):
+        raise ValueError("letta_evals_version must be a canonical exact version or immutable Git reference.")
+
+
+def _validate_letta_code_pin(pin: str) -> None:
+    if not pin:
+        raise ValueError("letta_code_version may not be empty.")
+    if pin != pin.strip():
+        raise ValueError("letta_code_version may not contain leading or trailing whitespace.")
+    if pin.lower() == "latest":
+        raise ValueError("letta_code_version may not use the mutable 'latest' tag.")
+    if not _EXACT_NPM_VERSION_RE.fullmatch(pin):
+        raise ValueError("letta_code_version must be an exact npm semantic version such as '0.30.5'.")
+
+
 class ModalSandboxSpec(BaseModel):
     """Modal sandbox execution configuration.
 
     When attached to a :class:`SuiteSpec` via the ``sandbox`` field, every
     sample executes inside a fresh Modal sandbox driven by the host runner.
 
-    When ``image`` is unset (the default), the driver builds the sandbox
-    image from the Dockerfile bundled at ``letta_evals/sandbox/Dockerfile``
-    via Modal's ``Image.from_dockerfile``. The bundled recipe carries the
-    ``letta-evals`` Python package and the ``@letta-ai/letta-code`` npm
-    CLI, so no registry publishing is required for the common case.
+    When ``image`` is unset, the driver builds a system base from the bundled
+    Dockerfile, then installs the required pinned ``letta-evals`` and
+    ``@letta-ai/letta-code`` versions in explicit Modal image layers. A custom
+    pre-built ``image`` may instead bake in its own application runtimes.
     """
 
     kind: Literal["modal"] = "modal"
@@ -104,19 +156,17 @@ class ModalSandboxSpec(BaseModel):
     letta_evals_version: Optional[str] = Field(
         default=None,
         description=(
-            "If set with the bundled image, pins the installed letta-evals package and "
-            "asserts its version at sandbox start. With a pre-built image, only the "
-            "runtime assertion applies."
+            "Exact letta-evals package version or Git reference pinned to a full commit SHA. "
+            "Required with the bundled image and verified at sandbox start. With a "
+            "pre-built image, this only verifies the baked-in runtime."
         ),
     )
     letta_code_version: Optional[str] = Field(
         default=None,
         description=(
-            "If set, pins the ``@letta-ai/letta-code`` npm version installed in "
-            "the bundled Dockerfile image, passed through as the "
-            "``LETTA_CODE_VERSION`` build arg (e.g. '0.27.17'). Defaults to the "
-            "Dockerfile's ``latest``. Ignored when ``image`` is set, since a "
-            "pre-built registry image already bakes in its own letta-code."
+            "Exact @letta-ai/letta-code npm version installed in the bundled image "
+            "(e.g. '0.30.5'). Required with the bundled image. Ignored when image "
+            "is set, since a pre-built registry image bakes in its own letta-code."
         ),
     )
     secrets: List[str] = Field(default_factory=list, description="Names of pre-uploaded Modal Secrets to attach")
@@ -160,6 +210,28 @@ class ModalSandboxSpec(BaseModel):
     idle_timeout_sec: Optional[int] = Field(default=None, description="Idle timeout (seconds) before auto-termination")
     block_network: bool = Field(default=False, description="If True, the sandbox is created without network access")
     app_name: str = Field(default="letta-evals", description="Modal App name to attach sandboxes to")
+
+    @model_validator(mode="after")
+    def require_bundled_image_version_pins(self):
+        if self.image is None:
+            pins = {
+                "letta_evals_version": self.letta_evals_version,
+                "letta_code_version": self.letta_code_version,
+            }
+            missing = [name for name, value in pins.items() if value is None or not value.strip()]
+            if missing:
+                raise ValueError(
+                    "The bundled Modal image requires exact version pins for "
+                    f"{', '.join(missing)}; set both version fields or provide sandbox.image."
+                )
+
+        if self.letta_evals_version is not None:
+            _validate_letta_evals_pin(self.letta_evals_version)
+
+        if self.image is None:
+            assert self.letta_code_version is not None
+            _validate_letta_code_pin(self.letta_code_version)
+        return self
 
 
 SandboxSpec = Annotated[ModalSandboxSpec, Field(discriminator="kind")]

--- a/letta_evals/models/specs.py
+++ b/letta_evals/models/specs.py
@@ -78,56 +78,17 @@ class LettaCodeTargetSpec(BaseModel):
         return self
 
 
-_EXACT_PYTHON_VERSION_RE = re.compile(
-    r"^(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))*"
-    r"(?:(?:a|b|rc)\d+)?(?:\.post\d+)?(?:\.dev\d+)?"
-    r"(?:\+[a-z0-9]+(?:\.[a-z0-9]+)*)?$"
-)
-_EXACT_NPM_VERSION_RE = re.compile(
-    r"^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
-    r"(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$"
-)
-_FULL_GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+_EXACT_RELEASE_RE = re.compile(r"^\d+\.\d+\.\d+[a-zA-Z0-9.+-]*$")
+_FULL_GIT_PIN_RE = re.compile(r"^(?:letta-evals\s*@\s*)?git\+https://[^@\s]+@[0-9a-fA-F]{40}(?:#\S+)?$")
 
 
-def _direct_git_ref(spec: str) -> Optional[str]:
-    """Return the ref from a pip Git direct reference, if present."""
-    if "git+" not in spec:
-        return None
-    url = spec.split("git+", 1)[1].split("#", 1)[0]
-    if "@" not in url:
-        return ""
-    return url.rsplit("@", 1)[1]
+def _is_immutable_version_pin(pin: str) -> bool:
+    """Accept an exact release identifier; package managers validate the suffix."""
+    return pin == pin.strip() and _EXACT_RELEASE_RE.fullmatch(pin) is not None
 
 
-def _validate_letta_evals_pin(pin: str) -> None:
-    if not pin:
-        raise ValueError("letta_evals_version may not be empty.")
-    if pin != pin.strip():
-        raise ValueError("letta_evals_version may not contain leading or trailing whitespace.")
-    if pin.lower() == "latest":
-        raise ValueError("letta_evals_version may not use the mutable 'latest' tag.")
-
-    git_ref = _direct_git_ref(pin)
-    if git_ref is not None and not _FULL_GIT_SHA_RE.fullmatch(git_ref):
-        raise ValueError(
-            "letta_evals_version Git references must use a full 40-character commit SHA, not a mutable branch or tag."
-        )
-    if git_ref is None and "://" in pin:
-        raise ValueError("letta_evals_version direct references must be Git URLs pinned to a full commit SHA.")
-    if git_ref is None and not _EXACT_PYTHON_VERSION_RE.fullmatch(pin):
-        raise ValueError("letta_evals_version must be a canonical exact version or immutable Git reference.")
-
-
-def _validate_letta_code_pin(pin: str) -> None:
-    if not pin:
-        raise ValueError("letta_code_version may not be empty.")
-    if pin != pin.strip():
-        raise ValueError("letta_code_version may not contain leading or trailing whitespace.")
-    if pin.lower() == "latest":
-        raise ValueError("letta_code_version may not use the mutable 'latest' tag.")
-    if not _EXACT_NPM_VERSION_RE.fullmatch(pin):
-        raise ValueError("letta_code_version must be an exact npm semantic version such as '0.30.5'.")
+def _is_immutable_evals_pin(pin: str) -> bool:
+    return _is_immutable_version_pin(pin) or _FULL_GIT_PIN_RE.fullmatch(pin) is not None
 
 
 class ModalSandboxSpec(BaseModel):
@@ -157,8 +118,8 @@ class ModalSandboxSpec(BaseModel):
         default=None,
         description=(
             "Exact letta-evals package version or Git reference pinned to a full commit SHA. "
-            "Required with the bundled image and verified at sandbox start. With a "
-            "pre-built image, this only verifies the baked-in runtime."
+            "Required with the bundled image. Released versions are verified at sandbox "
+            "start; with a pre-built image, this only verifies the baked-in runtime."
         ),
     )
     letta_code_version: Optional[str] = Field(
@@ -213,24 +174,17 @@ class ModalSandboxSpec(BaseModel):
 
     @model_validator(mode="after")
     def require_bundled_image_version_pins(self):
-        if self.image is None:
-            pins = {
-                "letta_evals_version": self.letta_evals_version,
-                "letta_code_version": self.letta_code_version,
-            }
-            missing = [name for name, value in pins.items() if value is None or not value.strip()]
-            if missing:
-                raise ValueError(
-                    "The bundled Modal image requires exact version pins for "
-                    f"{', '.join(missing)}; set both version fields or provide sandbox.image."
-                )
-
-        if self.letta_evals_version is not None:
-            _validate_letta_evals_pin(self.letta_evals_version)
-
-        if self.image is None:
-            assert self.letta_code_version is not None
-            _validate_letta_code_pin(self.letta_code_version)
+        if self.image is not None:
+            return self
+        evals_pin, code_pin = self.letta_evals_version, self.letta_code_version
+        if not evals_pin or not code_pin:
+            raise ValueError("The bundled Modal image requires both application version pins.")
+        if not _is_immutable_evals_pin(evals_pin):
+            raise ValueError(
+                "letta_evals_version must be an exact release or a credential-free HTTPS Git URL pinned to a full SHA."
+            )
+        if not _is_immutable_version_pin(code_pin):
+            raise ValueError("letta_code_version must be an exact npm version such as '0.30.5'.")
         return self
 
 

--- a/letta_evals/models/specs.py
+++ b/letta_evals/models/specs.py
@@ -78,13 +78,12 @@ class LettaCodeTargetSpec(BaseModel):
         return self
 
 
-_EXACT_RELEASE_RE = re.compile(r"^\d+\.\d+\.\d+[a-zA-Z0-9.+-]*$")
+_EXACT_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
 _FULL_GIT_PIN_RE = re.compile(r"^(?:letta-evals\s*@\s*)?git\+https://[^@\s]+@[0-9a-fA-F]{40}(?:#\S+)?$")
 
 
 def _is_immutable_version_pin(pin: str) -> bool:
-    """Accept an exact release identifier; package managers validate the suffix."""
-    return pin == pin.strip() and _EXACT_RELEASE_RE.fullmatch(pin) is not None
+    return _EXACT_VERSION_RE.fullmatch(pin) is not None
 
 
 def _is_immutable_evals_pin(pin: str) -> bool:

--- a/letta_evals/sandbox/Dockerfile
+++ b/letta_evals/sandbox/Dockerfile
@@ -1,55 +1,31 @@
-# Base runtime image for letta-evals Modal sandboxes.
+# System base for letta-evals Modal sandboxes.
 #
-# When a suite sets `sandbox: { kind: modal }` without an `image`, the driver
-# builds this Dockerfile on demand via Modal's Image.from_dockerfile (the build
-# is cached, so only the first sandbox after an edit pays the build cost).
-# Suite authors only need their own image when they need extra system tools the
-# agent invokes (e.g. compilers, language toolchains, project-specific binaries).
+# Application runtimes are deliberately not installed here. The Modal driver
+# adds exact letta-evals and @letta-ai/letta-code versions in explicit image
+# layers, so changing a suite pin changes the layer definition without
+# rebuilding this stable OS/toolchain base.
 
 FROM python:3.12-slim
 
-# git is required by extractors that diff the agent's MemFS git repo
-# (e.g. envs/memory_update/extractors.py reading ~/.letta/agents/<id>/memory).
-# curl is used to install Node.js via NodeSource; ca-certificates so HTTPS
-# certificate verification works for the NodeSource setup script.
-# build-essential supplies make + a C/C++ toolchain so node-gyp can compile
-# @letta-ai/letta-code's native dependency (node-pty) during npm install.
+# git is required by extractors that diff the agent's MemFS git repo.
+# build-essential supplies the toolchain needed by node-gyp dependencies.
+# Letta Code requires Node >=22.19.0; NodeSource's 22.x channel supplies it.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
         curl \
         git \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
+    && node -e "const [major, minor] = process.versions.node.split('.').map(Number); \
+        if (major < 22 || (major === 22 && minor < 19)) process.exit(1)" \
     && rm -rf /var/lib/apt/lists/*
 
-# letta-evals provides the in-sandbox `letta-evals run --sample ...` entrypoint.
-# Pinning LETTA_EVALS_VERSION makes the requested runtime part of Modal's image
-# cache key. A plain version installs `letta-evals==<version>`; a direct package
-# spec such as `letta-evals @ git+https://...` installs that exact ref for smoke
-# tests before a PyPI release exists. When unset, install the latest published
-# release.
-ARG LETTA_EVALS_VERSION=latest
+# Upgrade these before the versioned letta-evals layer. Keep the Sentinel check
+# here and after installing letta-evals so an incompatible resolver result fails
+# during the image build rather than at sample startup.
 RUN python -m pip install --no-cache-dir --upgrade pip "typing_extensions>=4.15.0" \
-    && if [ "$LETTA_EVALS_VERSION" = "latest" ]; then \
-        LETTA_EVALS_PACKAGE="letta-evals"; \
-    elif echo "$LETTA_EVALS_VERSION" | grep -Eq '(^letta-evals[[:space:]]*@|^git\+|://)'; then \
-        LETTA_EVALS_PACKAGE="$LETTA_EVALS_VERSION"; \
-    else \
-        LETTA_EVALS_PACKAGE="letta-evals==$LETTA_EVALS_VERSION"; \
-    fi \
-    && pip install --no-cache-dir --upgrade "$LETTA_EVALS_PACKAGE" \
     && python -c "from typing_extensions import Sentinel"
-
-# letta-code is the agent harness invoked by the LettaCodeTarget.
-# Install globally so the `letta` CLI is on $PATH inside the sandbox.
-#
-# LETTA_CODE_VERSION pins the installed npm version; it defaults to `latest`.
-# The Modal driver overrides it from `sandbox.letta_code_version` via
-# Image.from_dockerfile(build_args=...). Modal keys its cached image build on
-# the build args, so each pinned version resolves to its own cached image.
-ARG LETTA_CODE_VERSION=latest
-RUN npm install -g "@letta-ai/letta-code@${LETTA_CODE_VERSION}"
 
 WORKDIR /work

--- a/letta_evals/sandbox/Dockerfile
+++ b/letta_evals/sandbox/Dockerfile
@@ -3,7 +3,7 @@
 # Application runtimes are deliberately not installed here. The Modal driver
 # adds exact letta-evals and @letta-ai/letta-code versions in explicit image
 # layers, so changing a suite pin changes the layer definition without
-# rebuilding this stable OS/toolchain base.
+# rebuilding the shared OS/toolchain base.
 
 FROM python:3.12-slim
 
@@ -22,10 +22,9 @@ RUN apt-get update \
         if (major < 22 || (major === 22 && minor < 19)) process.exit(1)" \
     && rm -rf /var/lib/apt/lists/*
 
-# Upgrade these before the versioned letta-evals layer. Keep the Sentinel check
-# here and after installing letta-evals so an incompatible resolver result fails
-# during the image build rather than at sample startup.
-RUN python -m pip install --no-cache-dir --upgrade pip "typing_extensions>=4.15.0" \
-    && python -c "from typing_extensions import Sentinel"
+# Install the minimum typing_extensions version before the application layers.
+# The driver checks Sentinel again after installing letta-evals so a dependency
+# downgrade fails during the image build.
+RUN python -m pip install --no-cache-dir --upgrade pip "typing_extensions>=4.15.0"
 
 WORKDIR /work

--- a/letta_evals/sandbox/dispatch.py
+++ b/letta_evals/sandbox/dispatch.py
@@ -49,11 +49,6 @@ DEFAULT_SANDBOX_FORWARD_ENV = (
 )
 
 
-def is_direct_letta_evals_package_spec(spec: str) -> bool:
-    """Return true when ``spec`` is a pip direct reference, not a version."""
-    return spec.startswith("git+") or "://" in spec or spec.startswith("letta-evals @")
-
-
 def _remote_suite_yaml(suite_path: Path, local_root: Path, remote_root: str) -> str:
     """Map a host suite-file path to its in-sandbox path under ``remote_root``.
 
@@ -251,13 +246,13 @@ async def run_sample_in_sandbox(
 
         # Keep the existing lightweight check for released letta-evals pins.
         # Git pins are already immutable inputs to the image layer and do not
-        # necessarily expose their commit through `letta-evals --version`.
-        if suite.sandbox.letta_evals_version and not is_direct_letta_evals_package_spec(
-            suite.sandbox.letta_evals_version
-        ):
-            version_check = await sandbox.exec("letta-evals --version")
+        # necessarily expose their commit through distribution metadata.
+        if suite.sandbox.letta_evals_version and "git+" not in suite.sandbox.letta_evals_version:
+            version_check = await sandbox.exec(
+                "python -c \"from importlib.metadata import version; print(version('letta-evals'))\""
+            )
             expected = suite.sandbox.letta_evals_version
-            if version_check.return_code != 0 or expected not in (version_check.stdout + version_check.stderr):
+            if version_check.return_code != 0 or version_check.stdout.strip() != expected:
                 message = (
                     f"Sandbox image's letta-evals version does not match "
                     f"pinned '{expected}': {version_check.stdout.strip() or version_check.stderr.strip()}"

--- a/letta_evals/sandbox/dispatch.py
+++ b/letta_evals/sandbox/dispatch.py
@@ -49,11 +49,6 @@ DEFAULT_SANDBOX_FORWARD_ENV = (
 )
 
 
-def is_direct_letta_evals_package_spec(spec: str) -> bool:
-    """Return true when ``spec`` is a pip direct reference, not a version."""
-    return spec.startswith("git+") or "://" in spec or spec.startswith("letta-evals @")
-
-
 def _remote_suite_yaml(suite_path: Path, local_root: Path, remote_root: str) -> str:
     """Map a host suite-file path to its in-sandbox path under ``remote_root``.
 
@@ -248,20 +243,6 @@ async def run_sample_in_sandbox(
             )
 
         logger.info("Sandbox %s started for sample %s", sandbox.sandbox_id, sample_id)
-
-        if suite.sandbox.letta_evals_version and not is_direct_letta_evals_package_spec(
-            suite.sandbox.letta_evals_version
-        ):
-            version_check = await sandbox.exec("letta-evals --version")
-            expected = suite.sandbox.letta_evals_version
-            if version_check.return_code != 0 or expected not in (version_check.stdout + version_check.stderr):
-                message = (
-                    f"Sandbox image's letta-evals version does not match "
-                    f"pinned '{expected}': {version_check.stdout.strip() or version_check.stderr.strip()}"
-                )
-                return sandbox_error_result(
-                    sample_id, t_sample_start, ErrorCategory.UNKNOWN, "VersionMismatch", message
-                )
 
         upload_filter = build_upload_filter(suite.sandbox, mount.local_root)
         await sandbox.upload_dir(mount.local_root, mount.remote_root, path_filter=upload_filter)

--- a/letta_evals/sandbox/dispatch.py
+++ b/letta_evals/sandbox/dispatch.py
@@ -49,6 +49,11 @@ DEFAULT_SANDBOX_FORWARD_ENV = (
 )
 
 
+def is_direct_letta_evals_package_spec(spec: str) -> bool:
+    """Return true when ``spec`` is a pip direct reference, not a version."""
+    return spec.startswith("git+") or "://" in spec or spec.startswith("letta-evals @")
+
+
 def _remote_suite_yaml(suite_path: Path, local_root: Path, remote_root: str) -> str:
     """Map a host suite-file path to its in-sandbox path under ``remote_root``.
 
@@ -243,6 +248,23 @@ async def run_sample_in_sandbox(
             )
 
         logger.info("Sandbox %s started for sample %s", sandbox.sandbox_id, sample_id)
+
+        # Keep the existing lightweight check for released letta-evals pins.
+        # Git pins are already immutable inputs to the image layer and do not
+        # necessarily expose their commit through `letta-evals --version`.
+        if suite.sandbox.letta_evals_version and not is_direct_letta_evals_package_spec(
+            suite.sandbox.letta_evals_version
+        ):
+            version_check = await sandbox.exec("letta-evals --version")
+            expected = suite.sandbox.letta_evals_version
+            if version_check.return_code != 0 or expected not in (version_check.stdout + version_check.stderr):
+                message = (
+                    f"Sandbox image's letta-evals version does not match "
+                    f"pinned '{expected}': {version_check.stdout.strip() or version_check.stderr.strip()}"
+                )
+                return sandbox_error_result(
+                    sample_id, t_sample_start, ErrorCategory.UNKNOWN, "VersionMismatch", message
+                )
 
         upload_filter = build_upload_filter(suite.sandbox, mount.local_root)
         await sandbox.upload_dir(mount.local_root, mount.remote_root, path_filter=upload_filter)

--- a/letta_evals/sandbox/modal.py
+++ b/letta_evals/sandbox/modal.py
@@ -9,18 +9,99 @@ when the sandbox driver isn't used.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+import re
 import shlex
 import tarfile
 import tempfile
 from pathlib import Path
 from typing import Callable, Optional
+from urllib.parse import urlsplit, urlunsplit
 
 from letta_evals.models import ModalSandboxSpec
 from letta_evals.sandbox.base import AbstractSandbox, ExecResult, SandboxAuthError, SandboxNotInstalledError
 
 logger = logging.getLogger(__name__)
+
+_RUNTIME_PROBE_COMMAND = r"""python - <<'PY'
+import importlib.metadata
+import json
+import pathlib
+import subprocess
+
+
+def run(*args):
+    result = subprocess.run(args, check=True, capture_output=True, text=True)
+    return (result.stdout or result.stderr).strip()
+
+
+dist = importlib.metadata.distribution("letta-evals")
+direct_url_text = dist.read_text("direct_url.json")
+try:
+    npm_root = pathlib.Path(run("npm", "root", "-g"))
+    code_package = json.loads((npm_root / "@letta-ai" / "letta-code" / "package.json").read_text())
+    code_version = code_package["version"]
+except (OSError, KeyError, json.JSONDecodeError, subprocess.CalledProcessError):
+    code_version = None
+
+print(json.dumps({
+    "letta_evals_version": dist.version,
+    "letta_evals_direct_url": json.loads(direct_url_text) if direct_url_text else None,
+    "letta_code_version": code_version,
+    "letta_version_output": run("letta", "--version"),
+    "node_version": run("node", "--version"),
+}, sort_keys=True))
+PY"""
+
+
+class VersionMismatch(RuntimeError):
+    """Raised when a sandbox runtime does not match its requested pin."""
+
+
+class RuntimeProbeError(RuntimeError):
+    """Raised when the sandbox runtime cannot report its installed versions."""
+
+
+def _is_direct_letta_evals_package_spec(spec: str) -> bool:
+    return spec.startswith("git+") or "://" in spec or spec.startswith("letta-evals @")
+
+
+def _letta_evals_package_spec(pin: str) -> str:
+    """Normalize a version or direct reference into a pip package spec."""
+    return pin if _is_direct_letta_evals_package_spec(pin) else f"letta-evals=={pin}"
+
+
+def _requested_git_commit(spec: str) -> Optional[str]:
+    if "git+" not in spec:
+        return None
+    url = spec.split("git+", 1)[1].split("#", 1)[0]
+    ref = url.rsplit("@", 1)[-1]
+    return ref if re.fullmatch(r"[0-9a-fA-F]{40}", ref) else None
+
+
+def _node_version_tuple(version: str) -> tuple[int, int, int]:
+    match = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)", version.strip())
+    if match is None:
+        raise RuntimeProbeError(f"Could not parse Node version: {version!r}")
+    return tuple(int(part) for part in match.groups())
+
+
+def _direct_url_log_summary(direct_url: object) -> object:
+    """Keep useful source provenance in logs without URL credentials or queries."""
+    if not isinstance(direct_url, dict):
+        return direct_url
+    raw_url = direct_url.get("url")
+    if not isinstance(raw_url, str):
+        return direct_url
+    parsed = urlsplit(raw_url)
+    hostname = parsed.hostname or ""
+    netloc = f"{hostname}:{parsed.port}" if parsed.port else hostname
+    safe_url = urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
+    vcs_info = direct_url.get("vcs_info")
+    commit = vcs_info.get("commit_id") if isinstance(vcs_info, dict) else None
+    return {"url": safe_url, "commit_id": commit}
 
 
 def _import_modal():
@@ -56,6 +137,7 @@ class ModalSandbox(AbstractSandbox):
         self.session_id = session_id
         self._sandbox = None
         self._app = None
+        self._image_id = None
 
     @property
     def sandbox_id(self) -> Optional[str]:
@@ -63,26 +145,35 @@ class ModalSandbox(AbstractSandbox):
             return None
         return getattr(self._sandbox, "object_id", None)
 
+    @property
+    def image_id(self) -> Optional[str]:
+        return self._image_id
+
     async def start(self) -> None:
         modal = _import_modal()
         _check_modal_auth()
 
         app = await modal.App.lookup.aio(name=self.spec.app_name, create_if_missing=True)
         if self.spec.image is None:
-            # Default: build the base image from the Dockerfile bundled with
-            # the package. Modal caches the build, so repeated sandboxes
-            # don't pay the full build cost — only the first sandbox after
-            # the Dockerfile (or its build args) changes does.
+            # The Dockerfile is a stable OS/toolchain base. Application pins
+            # live in literal Modal layer commands so each exact pin becomes
+            # part of the layer definition and cannot reuse another version's
+            # cached installation.
             dockerfile_path = Path(__file__).parent / "Dockerfile"
-            build_args: dict[str, str] = {}
-            if self.spec.letta_evals_version:
-                # Pins the in-sandbox runner and invalidates stale cached layers.
-                build_args["LETTA_EVALS_VERSION"] = self.spec.letta_evals_version
-            if self.spec.letta_code_version:
-                # Pins @letta-ai/letta-code in the Dockerfile's npm install.
-                build_args["LETTA_CODE_VERSION"] = self.spec.letta_code_version
-            image = modal.Image.from_dockerfile(str(dockerfile_path), build_args=build_args).pip_install(
-                "typing_extensions>=4.15.0"
+            evals_pin = self.spec.letta_evals_version
+            code_pin = self.spec.letta_code_version
+            assert evals_pin is not None and code_pin is not None  # enforced by ModalSandboxSpec
+
+            evals_package = _letta_evals_package_spec(evals_pin)
+            image = modal.Image.from_dockerfile(str(dockerfile_path)).run_commands(
+                f"python -m pip install --no-cache-dir --upgrade {shlex.quote(evals_package)}",
+                'python -c "from typing_extensions import Sentinel"',
+            )
+            code_package = f"@letta-ai/letta-code@{code_pin}"
+            image = image.run_commands(
+                f"npm install -g --omit=dev {shlex.quote(code_package)}",
+                "node --version",
+                "letta --version",
             )
         else:
             if self.spec.letta_code_version:
@@ -115,12 +206,72 @@ class ModalSandbox(AbstractSandbox):
 
         self._app = app
         self._sandbox = await modal.Sandbox.create.aio(**create_kwargs)
+        self._image_id = getattr(image, "object_id", None)
         logger.info(
             "Started Modal sandbox %s (session=%s, image=%s)",
             self.sandbox_id,
             self.session_id,
-            self.spec.image,
+            self.image_id,
         )
+        try:
+            await self._verify_runtime()
+        except Exception:
+            try:
+                await self.stop()
+            except Exception as cleanup_error:
+                logger.warning("Failed to terminate sandbox after runtime verification error: %s", cleanup_error)
+            raise
+
+    async def _verify_runtime(self) -> None:
+        probe = await self.exec(_RUNTIME_PROBE_COMMAND)
+        if probe.return_code != 0:
+            output = (probe.stderr or probe.stdout or "runtime probe returned non-zero").strip()
+            raise RuntimeProbeError(f"Modal sandbox runtime probe failed: {output}")
+        try:
+            runtime = json.loads(probe.stdout)
+        except (json.JSONDecodeError, TypeError) as e:
+            raise RuntimeProbeError(f"Modal sandbox runtime probe returned invalid JSON: {probe.stdout!r}") from e
+
+        logger.info(
+            "Modal image %s runtime: letta-evals=%s direct_url=%s letta-code=%s letta=%r node=%s",
+            self.image_id,
+            runtime.get("letta_evals_version"),
+            _direct_url_log_summary(runtime.get("letta_evals_direct_url")),
+            runtime.get("letta_code_version"),
+            runtime.get("letta_version_output"),
+            runtime.get("node_version"),
+        )
+
+        evals_pin = self.spec.letta_evals_version
+        if evals_pin:
+            expected_commit = _requested_git_commit(evals_pin)
+            if expected_commit:
+                direct_url = runtime.get("letta_evals_direct_url") or {}
+                actual_commit = (direct_url.get("vcs_info") or {}).get("commit_id")
+                if not actual_commit or actual_commit.lower() != expected_commit.lower():
+                    raise VersionMismatch(
+                        f"Sandbox letta-evals commit {actual_commit!r} does not match pinned {expected_commit!r}."
+                    )
+            elif not _is_direct_letta_evals_package_spec(evals_pin):
+                actual_version = runtime.get("letta_evals_version")
+                if actual_version != evals_pin:
+                    raise VersionMismatch(
+                        f"Sandbox letta-evals version {actual_version!r} does not match pinned {evals_pin!r}."
+                    )
+
+        if self.spec.image is None:
+            actual_code_version = runtime.get("letta_code_version")
+            if actual_code_version != self.spec.letta_code_version:
+                raise VersionMismatch(
+                    f"Sandbox letta-code version {actual_code_version!r} does not match "
+                    f"pinned {self.spec.letta_code_version!r}."
+                )
+
+        node_version = runtime.get("node_version")
+        if self.spec.image is None and (
+            not isinstance(node_version, str) or _node_version_tuple(node_version) < (22, 19, 0)
+        ):
+            raise VersionMismatch(f"Sandbox Node version {node_version!r} does not satisfy >=22.19.0.")
 
     async def exec(
         self,

--- a/letta_evals/sandbox/modal.py
+++ b/letta_evals/sandbox/modal.py
@@ -23,13 +23,9 @@ from letta_evals.sandbox.base import AbstractSandbox, ExecResult, SandboxAuthErr
 logger = logging.getLogger(__name__)
 
 
-def _is_direct_letta_evals_package_spec(spec: str) -> bool:
-    return spec.startswith("git+") or "://" in spec or spec.startswith("letta-evals @")
-
-
 def _letta_evals_package_spec(pin: str) -> str:
     """Normalize a version or direct reference into a pip package spec."""
-    return pin if _is_direct_letta_evals_package_spec(pin) else f"letta-evals=={pin}"
+    return pin if "git+" in pin else f"letta-evals=={pin}"
 
 
 def _import_modal():
@@ -64,7 +60,6 @@ class ModalSandbox(AbstractSandbox):
         self.spec = spec
         self.session_id = session_id
         self._sandbox = None
-        self._app = None
         self._image_id = None
 
     @property
@@ -134,7 +129,6 @@ class ModalSandbox(AbstractSandbox):
         if self.spec.idle_timeout_sec is not None:
             create_kwargs["idle_timeout"] = self.spec.idle_timeout_sec
 
-        self._app = app
         self._sandbox = await modal.Sandbox.create.aio(**create_kwargs)
         self._image_id = getattr(image, "object_id", None)
         logger.info(

--- a/letta_evals/sandbox/modal.py
+++ b/letta_evals/sandbox/modal.py
@@ -9,59 +9,18 @@ when the sandbox driver isn't used.
 
 from __future__ import annotations
 
-import json
 import logging
 import os
-import re
 import shlex
 import tarfile
 import tempfile
 from pathlib import Path
 from typing import Callable, Optional
-from urllib.parse import urlsplit, urlunsplit
 
 from letta_evals.models import ModalSandboxSpec
 from letta_evals.sandbox.base import AbstractSandbox, ExecResult, SandboxAuthError, SandboxNotInstalledError
 
 logger = logging.getLogger(__name__)
-
-_RUNTIME_PROBE_COMMAND = r"""python - <<'PY'
-import importlib.metadata
-import json
-import pathlib
-import subprocess
-
-
-def run(*args):
-    result = subprocess.run(args, check=True, capture_output=True, text=True)
-    return (result.stdout or result.stderr).strip()
-
-
-dist = importlib.metadata.distribution("letta-evals")
-direct_url_text = dist.read_text("direct_url.json")
-try:
-    npm_root = pathlib.Path(run("npm", "root", "-g"))
-    code_package = json.loads((npm_root / "@letta-ai" / "letta-code" / "package.json").read_text())
-    code_version = code_package["version"]
-except (OSError, KeyError, json.JSONDecodeError, subprocess.CalledProcessError):
-    code_version = None
-
-print(json.dumps({
-    "letta_evals_version": dist.version,
-    "letta_evals_direct_url": json.loads(direct_url_text) if direct_url_text else None,
-    "letta_code_version": code_version,
-    "letta_version_output": run("letta", "--version"),
-    "node_version": run("node", "--version"),
-}, sort_keys=True))
-PY"""
-
-
-class VersionMismatch(RuntimeError):
-    """Raised when a sandbox runtime does not match its requested pin."""
-
-
-class RuntimeProbeError(RuntimeError):
-    """Raised when the sandbox runtime cannot report its installed versions."""
 
 
 def _is_direct_letta_evals_package_spec(spec: str) -> bool:
@@ -71,37 +30,6 @@ def _is_direct_letta_evals_package_spec(spec: str) -> bool:
 def _letta_evals_package_spec(pin: str) -> str:
     """Normalize a version or direct reference into a pip package spec."""
     return pin if _is_direct_letta_evals_package_spec(pin) else f"letta-evals=={pin}"
-
-
-def _requested_git_commit(spec: str) -> Optional[str]:
-    if "git+" not in spec:
-        return None
-    url = spec.split("git+", 1)[1].split("#", 1)[0]
-    ref = url.rsplit("@", 1)[-1]
-    return ref if re.fullmatch(r"[0-9a-fA-F]{40}", ref) else None
-
-
-def _node_version_tuple(version: str) -> tuple[int, int, int]:
-    match = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)", version.strip())
-    if match is None:
-        raise RuntimeProbeError(f"Could not parse Node version: {version!r}")
-    return tuple(int(part) for part in match.groups())
-
-
-def _direct_url_log_summary(direct_url: object) -> object:
-    """Keep useful source provenance in logs without URL credentials or queries."""
-    if not isinstance(direct_url, dict):
-        return direct_url
-    raw_url = direct_url.get("url")
-    if not isinstance(raw_url, str):
-        return direct_url
-    parsed = urlsplit(raw_url)
-    hostname = parsed.hostname or ""
-    netloc = f"{hostname}:{parsed.port}" if parsed.port else hostname
-    safe_url = urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
-    vcs_info = direct_url.get("vcs_info")
-    commit = vcs_info.get("commit_id") if isinstance(vcs_info, dict) else None
-    return {"url": safe_url, "commit_id": commit}
 
 
 def _import_modal():
@@ -155,7 +83,7 @@ class ModalSandbox(AbstractSandbox):
 
         app = await modal.App.lookup.aio(name=self.spec.app_name, create_if_missing=True)
         if self.spec.image is None:
-            # The Dockerfile is a stable OS/toolchain base. Application pins
+            # The Dockerfile is a shared OS/toolchain base. Application pins
             # live in literal Modal layer commands so each exact pin becomes
             # part of the layer definition and cannot reuse another version's
             # cached installation.
@@ -164,16 +92,18 @@ class ModalSandbox(AbstractSandbox):
             code_pin = self.spec.letta_code_version
             assert evals_pin is not None and code_pin is not None  # enforced by ModalSandboxSpec
 
-            evals_package = _letta_evals_package_spec(evals_pin)
+            # Letta Code is the larger and less frequently changed layer. Put
+            # it first so changing an evals release or Git SHA only rebuilds
+            # the cheaper Python layer.
+            code_package = f"@letta-ai/letta-code@{code_pin}"
             image = modal.Image.from_dockerfile(str(dockerfile_path)).run_commands(
+                f"npm install -g --omit=dev {shlex.quote(code_package)}",
+                "letta --version",
+            )
+            evals_package = _letta_evals_package_spec(evals_pin)
+            image = image.run_commands(
                 f"python -m pip install --no-cache-dir --upgrade {shlex.quote(evals_package)}",
                 'python -c "from typing_extensions import Sentinel"',
-            )
-            code_package = f"@letta-ai/letta-code@{code_pin}"
-            image = image.run_commands(
-                f"npm install -g --omit=dev {shlex.quote(code_package)}",
-                "node --version",
-                "letta --version",
             )
         else:
             if self.spec.letta_code_version:
@@ -213,65 +143,6 @@ class ModalSandbox(AbstractSandbox):
             self.session_id,
             self.image_id,
         )
-        try:
-            await self._verify_runtime()
-        except Exception:
-            try:
-                await self.stop()
-            except Exception as cleanup_error:
-                logger.warning("Failed to terminate sandbox after runtime verification error: %s", cleanup_error)
-            raise
-
-    async def _verify_runtime(self) -> None:
-        probe = await self.exec(_RUNTIME_PROBE_COMMAND)
-        if probe.return_code != 0:
-            output = (probe.stderr or probe.stdout or "runtime probe returned non-zero").strip()
-            raise RuntimeProbeError(f"Modal sandbox runtime probe failed: {output}")
-        try:
-            runtime = json.loads(probe.stdout)
-        except (json.JSONDecodeError, TypeError) as e:
-            raise RuntimeProbeError(f"Modal sandbox runtime probe returned invalid JSON: {probe.stdout!r}") from e
-
-        logger.info(
-            "Modal image %s runtime: letta-evals=%s direct_url=%s letta-code=%s letta=%r node=%s",
-            self.image_id,
-            runtime.get("letta_evals_version"),
-            _direct_url_log_summary(runtime.get("letta_evals_direct_url")),
-            runtime.get("letta_code_version"),
-            runtime.get("letta_version_output"),
-            runtime.get("node_version"),
-        )
-
-        evals_pin = self.spec.letta_evals_version
-        if evals_pin:
-            expected_commit = _requested_git_commit(evals_pin)
-            if expected_commit:
-                direct_url = runtime.get("letta_evals_direct_url") or {}
-                actual_commit = (direct_url.get("vcs_info") or {}).get("commit_id")
-                if not actual_commit or actual_commit.lower() != expected_commit.lower():
-                    raise VersionMismatch(
-                        f"Sandbox letta-evals commit {actual_commit!r} does not match pinned {expected_commit!r}."
-                    )
-            elif not _is_direct_letta_evals_package_spec(evals_pin):
-                actual_version = runtime.get("letta_evals_version")
-                if actual_version != evals_pin:
-                    raise VersionMismatch(
-                        f"Sandbox letta-evals version {actual_version!r} does not match pinned {evals_pin!r}."
-                    )
-
-        if self.spec.image is None:
-            actual_code_version = runtime.get("letta_code_version")
-            if actual_code_version != self.spec.letta_code_version:
-                raise VersionMismatch(
-                    f"Sandbox letta-code version {actual_code_version!r} does not match "
-                    f"pinned {self.spec.letta_code_version!r}."
-                )
-
-        node_version = runtime.get("node_version")
-        if self.spec.image is None and (
-            not isinstance(node_version, str) or _node_version_tuple(node_version) < (22, 19, 0)
-        ):
-            raise VersionMismatch(f"Sandbox Node version {node_version!r} does not satisfy >=22.19.0.")
 
     async def exec(
         self,

--- a/tests/test_modal_sandbox.py
+++ b/tests/test_modal_sandbox.py
@@ -2,8 +2,8 @@
 
 The live driver test is skipped unless Modal credentials are configured
 (MODAL_TOKEN_ID / MODAL_TOKEN_SECRET or ~/.modal.toml). It builds the
-bundled Dockerfile (the default image) — no per-test image config required.
-The spec-parsing tests do not touch Modal at all.
+bundled system base and exact application layers. The spec-parsing tests do
+not touch Modal at all.
 """
 
 from __future__ import annotations
@@ -43,12 +43,12 @@ def _minimal_suite_yaml(**sandbox_overrides):
 
 
 class TestModalSandboxSpec:
-    def test_defaults(self):
-        """Image defaults to None (build from bundled Dockerfile); other
-        defaults let a minimal `sandbox: { kind: modal }` block work."""
-        spec = ModalSandboxSpec()
+    def test_registry_image_keeps_runtime_pins_optional(self):
+        spec = ModalSandboxSpec(image="ghcr.io/custom/runtime:1.0")
         assert spec.kind == "modal"
-        assert spec.image is None
+        assert spec.image == "ghcr.io/custom/runtime:1.0"
+        assert spec.letta_evals_version is None
+        assert spec.letta_code_version is None
         assert spec.cpu == 2
         assert spec.memory_mb == 2048
         assert spec.timeout_sec == 1800
@@ -57,29 +57,75 @@ class TestModalSandboxSpec:
         assert spec.secrets == []
         assert spec.forward_env == []
         assert spec.volumes == {}
-        assert spec.letta_evals_version is None
-        assert spec.letta_code_version is None
         assert spec.project_root is None
         assert spec.respect_gitignore is True
 
-    def test_image_override(self):
-        spec = ModalSandboxSpec(image="ghcr.io/custom/runtime:1.0")
-        assert spec.image == "ghcr.io/custom/runtime:1.0"
+    @pytest.mark.parametrize(
+        ("kwargs", "missing"),
+        [
+            ({}, "letta_evals_version, letta_code_version"),
+            ({"letta_evals_version": "0.25.0"}, "letta_code_version"),
+            ({"letta_code_version": "0.30.5"}, "letta_evals_version"),
+            ({"letta_evals_version": "", "letta_code_version": "0.30.5"}, "letta_evals_version"),
+            ({"letta_evals_version": "0.25.0", "letta_code_version": ""}, "letta_code_version"),
+        ],
+    )
+    def test_bundled_image_requires_both_pins(self, kwargs, missing):
+        with pytest.raises(ValueError, match=missing):
+            ModalSandboxSpec(**kwargs)
 
-    def test_yaml_without_image_leaves_image_unset(self):
-        """A suite YAML can declare `sandbox: { kind: modal }` with no image
-        — the driver builds from the bundled Dockerfile."""
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"letta_evals_version": "latest", "letta_code_version": "0.30.5"},
+            {"letta_evals_version": "0.25.0", "letta_code_version": "latest"},
+            {"letta_evals_version": "0.25.0", "letta_code_version": "^0.30.5"},
+            {
+                "letta_evals_version": "https://example.com/letta-evals-current.whl",
+                "letta_code_version": "0.30.5",
+            },
+            {
+                "letta_evals_version": "letta-evals @ git+https://github.com/letta-ai/letta-evals.git@main",
+                "letta_code_version": "0.30.5",
+            },
+        ],
+    )
+    def test_bundled_image_rejects_mutable_or_ranged_pins(self, kwargs):
+        with pytest.raises(ValueError):
+            ModalSandboxSpec(**kwargs)
+
+    def test_custom_image_rejects_unverifiable_eval_pin(self):
+        with pytest.raises(ValueError, match="full 40-character commit SHA"):
+            ModalSandboxSpec(
+                image="img:test",
+                letta_evals_version="git+https://github.com/letta-ai/letta-evals.git@main",
+            )
+
+    def test_rejects_noncanonical_python_version(self):
+        with pytest.raises(ValueError, match="canonical exact version"):
+            ModalSandboxSpec(
+                letta_evals_version="1.0-rc1",
+                letta_code_version="0.30.5",
+            )
+
+    def test_yaml_without_image_accepts_exact_pins(self):
+        commit = "a" * 40
         yaml_data = {
             "name": "u",
             "dataset": "s.jsonl",
             "target": {"kind": "letta_code", "model_handles": ["openai/gpt-4.1-mini"]},
             "graders": {"g": {"kind": "tool", "function": "exact_match"}},
             "reward": {"kind": "metric", "metric_key": "g"},
-            "sandbox": {"kind": "modal"},
+            "sandbox": {
+                "kind": "modal",
+                "letta_evals_version": (f"letta-evals @ git+https://github.com/letta-ai/letta-evals.git@{commit}"),
+                "letta_code_version": "0.30.5",
+            },
         }
         suite = SuiteSpec.from_yaml(yaml_data)
         assert suite.sandbox is not None
         assert suite.sandbox.image is None
+        assert suite.sandbox.letta_code_version == "0.30.5"
 
     def test_bundled_dockerfile_exists(self):
         """The Dockerfile must ship with the package so Image.from_dockerfile
@@ -91,20 +137,14 @@ class TestModalSandboxSpec:
         dockerfile = Path(sandbox_pkg.__file__).parent / "Dockerfile"
         assert dockerfile.is_file(), f"Bundled Dockerfile missing: {dockerfile}"
         contents = dockerfile.read_text()
-        # Sanity-check the recipe carries both runtimes.
-        assert "letta-evals" in contents
-        assert "@letta-ai/letta-code" in contents
-        # The letta-evals install must be pinnable so the requested version
-        # invalidates stale Modal image layers.
-        assert "ARG LETTA_EVALS_VERSION" in contents
+        # The bundled Dockerfile is intentionally application-independent.
+        assert "ARG LETTA_EVALS_VERSION" not in contents
+        assert "ARG LETTA_CODE_VERSION" not in contents
+        assert "npm install -g" not in contents
         assert '"typing_extensions>=4.15.0"' in contents
         assert "from typing_extensions import Sentinel" in contents
-        assert "letta-evals @" in contents
-        assert 'LETTA_EVALS_PACKAGE="letta-evals==$LETTA_EVALS_VERSION"' in contents
-        # The letta-code install must be pinnable via the LETTA_CODE_VERSION
-        # build arg the Modal driver passes from sandbox.letta_code_version.
-        assert "ARG LETTA_CODE_VERSION" in contents
-        assert "@letta-ai/letta-code@${LETTA_CODE_VERSION}" in contents
+        assert "setup_22.x" in contents
+        assert "major === 22 && minor < 19" in contents
 
     def test_overrides(self):
         spec = ModalSandboxSpec(
@@ -203,7 +243,7 @@ class TestSuiteSpecWithSandbox:
 
 class TestUploadFilter:
     def test_default_excludes_drop_junk_but_keep_code_and_data(self):
-        keep = build_upload_filter(ModalSandboxSpec())
+        keep = build_upload_filter(ModalSandboxSpec(image="img:test"))
         # Kept: source, config, data.
         assert keep("pkg/mod.py")
         assert keep("pyproject.toml")
@@ -216,14 +256,14 @@ class TestUploadFilter:
 
     def test_respects_gitignore_at_root(self, tmp_path):
         (tmp_path / ".gitignore").write_text("data/large/\n*.log\n")
-        keep = build_upload_filter(ModalSandboxSpec(), root=tmp_path)
+        keep = build_upload_filter(ModalSandboxSpec(image="img:test"), root=tmp_path)
         assert keep("pkg/mod.py")
         assert not keep("data/large/blob.bin")
         assert not keep("run.log")
 
     def test_gitignore_ignored_when_respect_gitignore_false(self, tmp_path):
         (tmp_path / ".gitignore").write_text("*.log\n")
-        keep = build_upload_filter(ModalSandboxSpec(respect_gitignore=False), root=tmp_path)
+        keep = build_upload_filter(ModalSandboxSpec(image="img:test", respect_gitignore=False), root=tmp_path)
         assert keep("run.log")
 
 
@@ -256,7 +296,7 @@ class TestUploadDirFiltering:
                 return ExecResult(stdout="", stderr="", return_code=0)
 
         sb = _TarCapturingSandbox()
-        keep = build_upload_filter(ModalSandboxSpec())
+        keep = build_upload_filter(ModalSandboxSpec(image="img:test"))
         anyio.run(sb.upload_dir, root, "/mnt/project", keep)
 
         names = captured["names"]
@@ -275,24 +315,29 @@ class TestExecResult:
         assert r.return_code == 0
 
 
-def test_direct_letta_evals_package_specs_skip_version_check():
-    from letta_evals.sandbox.dispatch import is_direct_letta_evals_package_spec
+def test_letta_evals_package_spec_normalization():
+    from letta_evals.sandbox.modal import _letta_evals_package_spec
 
-    assert is_direct_letta_evals_package_spec(
-        "letta-evals @ git+https://github.com/letta-ai/letta-evals.git@branch"
+    commit = "a" * 40
+    direct = f"letta-evals @ git+https://github.com/letta-ai/letta-evals.git@{commit}"
+    assert _letta_evals_package_spec("0.25.0") == "letta-evals==0.25.0"
+    assert _letta_evals_package_spec(direct) == direct
+
+
+def test_direct_url_log_summary_redacts_credentials_and_query():
+    from letta_evals.sandbox.modal import _direct_url_log_summary
+
+    summary = _direct_url_log_summary(
+        {
+            "url": "https://user:secret@example.com/org/repo.git?token=secret",
+            "vcs_info": {"commit_id": "a" * 40, "vcs": "git"},
+        }
     )
-    assert is_direct_letta_evals_package_spec("git+https://github.com/letta-ai/letta-evals.git@branch")
-    assert not is_direct_letta_evals_package_spec("0.25.0")
+    assert summary == {"url": "https://example.com/org/repo.git", "commit_id": "a" * 40}
 
 
 def _install_fake_modal(monkeypatch):
-    """Inject a fake ``modal`` SDK and return it so tests can assert on calls.
-
-    ``ModalSandbox.start`` imports modal lazily and calls App.lookup,
-    Image.from_dockerfile / from_registry, and Sandbox.create. We stub all of
-    them so start() runs end-to-end without touching Modal, letting us inspect
-    how the image was built.
-    """
+    """Inject a fake ``modal`` SDK and return it so tests can assert on calls."""
     import sys
     from unittest.mock import AsyncMock, MagicMock
 
@@ -301,72 +346,271 @@ def _install_fake_modal(monkeypatch):
     fake_modal = MagicMock(name="modal")
     fake_modal.App.lookup.aio = AsyncMock(return_value=MagicMock(name="app"))
     fake_image = MagicMock(name="image")
-    fake_image.pip_install.return_value = fake_image
+    fake_image.object_id = "im-xyz"
+    fake_image.run_commands.return_value = fake_image
     fake_modal.Image.from_dockerfile = MagicMock(return_value=fake_image)
     fake_modal.Image.from_registry = MagicMock(return_value=fake_image)
     fake_sandbox = MagicMock(name="sandbox")
     fake_sandbox.object_id = "sb-xyz"
+    fake_sandbox.terminate.aio = AsyncMock()
     fake_modal.Sandbox.create.aio = AsyncMock(return_value=fake_sandbox)
+    runtime_verifier = AsyncMock()
 
     monkeypatch.setitem(sys.modules, "modal", fake_modal)
     monkeypatch.setattr(modal_driver, "_check_modal_auth", lambda: None)
+    monkeypatch.setattr(modal_driver.ModalSandbox, "_verify_runtime", runtime_verifier)
+    fake_modal._runtime_verifier = runtime_verifier
     return fake_modal
 
 
 class TestModalDriverImageBuild:
-    """The driver pins runtime versions in the bundled Dockerfile image."""
+    """The driver puts exact runtime pins in literal Modal layer definitions."""
 
     @pytest.mark.asyncio
-    async def test_letta_code_version_becomes_build_arg(self, monkeypatch):
+    async def test_exact_versions_become_explicit_image_layers(self, monkeypatch):
         from letta_evals.sandbox.modal import ModalSandbox
 
         fake_modal = _install_fake_modal(monkeypatch)
         spec = ModalSandboxSpec(
             letta_evals_version="0.24.0",
-            letta_code_version="0.27.17",
+            letta_code_version="0.30.5",
             timeout_sec=60,
             cpu=1,
             memory_mb=512,
         )
-        sandbox = ModalSandbox(spec=spec, session_id="unit-build-args")
+        sandbox = ModalSandbox(spec=spec, session_id="unit-versioned-layers")
 
         await sandbox.start()
 
         fake_modal.Image.from_dockerfile.assert_called_once()
         _, kwargs = fake_modal.Image.from_dockerfile.call_args
-        assert kwargs["build_args"] == {
-            "LETTA_EVALS_VERSION": "0.24.0",
-            "LETTA_CODE_VERSION": "0.27.17",
-        }
-        fake_modal.Image.from_dockerfile.return_value.pip_install.assert_called_once_with("typing_extensions>=4.15.0")
+        assert kwargs == {}
+        layer_calls = fake_modal.Image.from_dockerfile.return_value.run_commands.call_args_list
+        assert "letta-evals==0.24.0" in layer_calls[0].args[0]
+        assert "from typing_extensions import Sentinel" in layer_calls[0].args[1]
+        assert "@letta-ai/letta-code@0.30.5" in layer_calls[1].args[0]
+        assert layer_calls[1].args[1:] == ("node --version", "letta --version")
+        assert sandbox.image_id == "im-xyz"
         fake_modal.Image.from_registry.assert_not_called()
+        fake_modal._runtime_verifier.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_unset_version_passes_empty_build_args(self, monkeypatch):
+    async def test_changing_pins_changes_literal_layer_definitions(self, monkeypatch):
         from letta_evals.sandbox.modal import ModalSandbox
 
         fake_modal = _install_fake_modal(monkeypatch)
-        spec = ModalSandboxSpec(timeout_sec=60)
-        sandbox = ModalSandbox(spec=spec, session_id="unit-no-version")
+        image = fake_modal.Image.from_dockerfile.return_value
 
-        await sandbox.start()
+        pins = [
+            ("0.24.0", "0.30.5"),
+            ("0.25.0", "0.30.5"),  # only letta-evals changes
+            ("0.24.0", "0.30.7"),  # only letta-code changes
+        ]
+        for evals_version, code_version in pins:
+            spec = ModalSandboxSpec(
+                letta_evals_version=evals_version,
+                letta_code_version=code_version,
+                timeout_sec=60,
+            )
+            await ModalSandbox(spec=spec, session_id=f"unit-{evals_version}-{code_version}").start()
 
-        _, kwargs = fake_modal.Image.from_dockerfile.call_args
-        assert kwargs["build_args"] == {}
-        fake_modal.Image.from_dockerfile.return_value.pip_install.assert_called_once_with("typing_extensions>=4.15.0")
+        commands = [call.args[0] for call in image.run_commands.call_args_list]
+        assert commands == [
+            "python -m pip install --no-cache-dir --upgrade letta-evals==0.24.0",
+            "npm install -g --omit=dev @letta-ai/letta-code@0.30.5",
+            "python -m pip install --no-cache-dir --upgrade letta-evals==0.25.0",
+            "npm install -g --omit=dev @letta-ai/letta-code@0.30.5",
+            "python -m pip install --no-cache-dir --upgrade letta-evals==0.24.0",
+            "npm install -g --omit=dev @letta-ai/letta-code@0.30.7",
+        ]
 
     @pytest.mark.asyncio
-    async def test_registry_image_ignores_version(self, monkeypatch):
+    async def test_direct_git_pin_is_shell_quoted_in_layer(self, monkeypatch):
         from letta_evals.sandbox.modal import ModalSandbox
 
         fake_modal = _install_fake_modal(monkeypatch)
-        spec = ModalSandboxSpec(image="ghcr.io/custom/runtime:1.0", letta_code_version="0.27.17", timeout_sec=60)
+        commit = "a" * 40
+        direct = f"letta-evals @ git+https://github.com/letta-ai/letta-evals.git@{commit}"
+        spec = ModalSandboxSpec(
+            letta_evals_version=direct,
+            letta_code_version="0.30.5",
+            timeout_sec=60,
+        )
+
+        await ModalSandbox(spec=spec, session_id="unit-direct-ref").start()
+
+        evals_command = fake_modal.Image.from_dockerfile.return_value.run_commands.call_args_list[0].args[0]
+        assert evals_command.endswith(f"'{direct}'")
+
+    @pytest.mark.asyncio
+    async def test_registry_image_skips_versioned_layers(self, monkeypatch):
+        from letta_evals.sandbox.modal import ModalSandbox
+
+        fake_modal = _install_fake_modal(monkeypatch)
+        spec = ModalSandboxSpec(image="ghcr.io/custom/runtime:1.0", letta_code_version="0.30.5", timeout_sec=60)
         sandbox = ModalSandbox(spec=spec, session_id="unit-registry")
 
         await sandbox.start()
 
         fake_modal.Image.from_registry.assert_called_once_with("ghcr.io/custom/runtime:1.0")
         fake_modal.Image.from_dockerfile.assert_not_called()
+        fake_modal.Image.from_registry.return_value.run_commands.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_runtime_verification_failure_terminates_created_sandbox(self, monkeypatch):
+        from letta_evals.sandbox.modal import ModalSandbox, VersionMismatch
+
+        fake_modal = _install_fake_modal(monkeypatch)
+        fake_modal._runtime_verifier.side_effect = VersionMismatch("stale runtime")
+        spec = ModalSandboxSpec(letta_evals_version="0.25.0", letta_code_version="0.30.5")
+        sandbox = ModalSandbox(spec=spec, session_id="unit-verification-failure")
+
+        with pytest.raises(VersionMismatch, match="stale runtime"):
+            await sandbox.start()
+
+        created = fake_modal.Sandbox.create.aio.return_value
+        created.terminate.aio.assert_awaited_once()
+        assert sandbox.sandbox_id is None
+
+
+class TestModalRuntimeVerification:
+    @staticmethod
+    def _probe_result(
+        *,
+        evals_version="0.25.0",
+        code_version="0.30.5",
+        node_version="v22.19.0",
+        commit=None,
+    ):
+        import json
+
+        direct_url = None
+        if commit:
+            direct_url = {
+                "url": "https://github.com/letta-ai/letta-evals.git",
+                "vcs_info": {"commit_id": commit, "vcs": "git"},
+            }
+        return ExecResult(
+            stdout=json.dumps(
+                {
+                    "letta_evals_version": evals_version,
+                    "letta_evals_direct_url": direct_url,
+                    "letta_code_version": code_version,
+                    "letta_version_output": code_version,
+                    "node_version": node_version,
+                }
+            ),
+            stderr="",
+            return_code=0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_accepts_exact_versions(self, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        sandbox = ModalSandbox(
+            ModalSandboxSpec(letta_evals_version="0.25.0", letta_code_version="0.30.5"),
+            session_id="verify-exact",
+        )
+        sandbox._sandbox = object()
+        monkeypatch.setattr(sandbox, "exec", AsyncMock(return_value=self._probe_result()))
+
+        await sandbox._verify_runtime()
+
+    @pytest.mark.asyncio
+    async def test_custom_image_allows_older_node_and_non_global_code_install(self, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        sandbox = ModalSandbox(
+            ModalSandboxSpec(image="img:test", letta_evals_version="0.25.0"),
+            session_id="verify-custom",
+        )
+        sandbox._sandbox = object()
+        probe = self._probe_result(code_version=None, node_version="v20.18.0")
+        monkeypatch.setattr(sandbox, "exec", AsyncMock(return_value=probe))
+
+        await sandbox._verify_runtime()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "probe_result",
+        [
+            ExecResult(stdout="", stderr="probe failed", return_code=1),
+            ExecResult(stdout="not-json", stderr="", return_code=0),
+        ],
+    )
+    async def test_rejects_failed_or_invalid_runtime_probe(self, monkeypatch, probe_result):
+        from unittest.mock import AsyncMock
+
+        from letta_evals.sandbox.modal import RuntimeProbeError
+
+        sandbox = ModalSandbox(
+            ModalSandboxSpec(letta_evals_version="0.25.0", letta_code_version="0.30.5"),
+            session_id="verify-probe-failure",
+        )
+        sandbox._sandbox = object()
+        monkeypatch.setattr(sandbox, "exec", AsyncMock(return_value=probe_result))
+
+        with pytest.raises(RuntimeProbeError):
+            await sandbox._verify_runtime()
+
+    @pytest.mark.asyncio
+    async def test_accepts_exact_git_commit(self, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        commit = "a" * 40
+        direct = f"letta-evals @ git+https://github.com/letta-ai/letta-evals.git@{commit}"
+        sandbox = ModalSandbox(
+            ModalSandboxSpec(letta_evals_version=direct, letta_code_version="0.30.5"),
+            session_id="verify-commit",
+        )
+        sandbox._sandbox = object()
+        monkeypatch.setattr(sandbox, "exec", AsyncMock(return_value=self._probe_result(commit=commit)))
+
+        await sandbox._verify_runtime()
+
+    @pytest.mark.asyncio
+    async def test_rejects_git_commit_mismatch(self, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        from letta_evals.sandbox.modal import VersionMismatch
+
+        expected_commit = "a" * 40
+        actual_commit = "b" * 40
+        direct = f"letta-evals @ git+https://github.com/letta-ai/letta-evals.git@{expected_commit}"
+        sandbox = ModalSandbox(
+            ModalSandboxSpec(letta_evals_version=direct, letta_code_version="0.30.5"),
+            session_id="verify-commit-mismatch",
+        )
+        sandbox._sandbox = object()
+        monkeypatch.setattr(sandbox, "exec", AsyncMock(return_value=self._probe_result(commit=actual_commit)))
+
+        with pytest.raises(VersionMismatch):
+            await sandbox._verify_runtime()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "probe_result",
+        [
+            _probe_result(evals_version="0.24.0"),
+            _probe_result(code_version="0.30.7"),
+            _probe_result(node_version="v22.18.0"),
+        ],
+    )
+    async def test_rejects_runtime_mismatches(self, monkeypatch, probe_result):
+        from unittest.mock import AsyncMock
+
+        from letta_evals.sandbox.modal import VersionMismatch
+
+        sandbox = ModalSandbox(
+            ModalSandboxSpec(letta_evals_version="0.25.0", letta_code_version="0.30.5"),
+            session_id="verify-mismatch",
+        )
+        sandbox._sandbox = object()
+        monkeypatch.setattr(sandbox, "exec", AsyncMock(return_value=probe_result))
+
+        with pytest.raises(VersionMismatch):
+            await sandbox._verify_runtime()
 
 
 class TestModalDriverLazyImport:
@@ -409,13 +653,46 @@ class TestModalDriverLive:
     async def test_echo_round_trip(self):
         from letta_evals.sandbox.modal import ModalSandbox
 
-        # No image override: defaults to building the bundled Dockerfile.
-        spec = ModalSandboxSpec(timeout_sec=120, cpu=1, memory_mb=512)
+        # No image override: build the stable base plus exact runtime layers.
+        spec = ModalSandboxSpec(
+            letta_evals_version="0.25.0",
+            letta_code_version="0.30.5",
+            timeout_sec=120,
+            cpu=1,
+            memory_mb=512,
+        )
         sandbox = ModalSandbox(spec=spec, session_id="unit-echo")
         await sandbox.start()
         try:
+            assert sandbox.image_id and sandbox.image_id.startswith("im-")
             res = await sandbox.exec("echo hello")
             assert res.return_code == 0
             assert "hello" in res.stdout
+            help_result = await sandbox.exec("letta --help")
+            assert help_result.return_code == 0
+            assert "--stateless" in help_result.stdout
         finally:
             await sandbox.stop()
+
+    @pytest.mark.asyncio
+    async def test_changing_code_pin_changes_image(self):
+        from letta_evals.sandbox.modal import ModalSandbox
+
+        image_ids = []
+        for code_version in ("0.30.5", "0.30.7"):
+            spec = ModalSandboxSpec(
+                letta_evals_version="0.25.0",
+                letta_code_version=code_version,
+                timeout_sec=180,
+                cpu=1,
+                memory_mb=512,
+            )
+            sandbox = ModalSandbox(spec=spec, session_id=f"unit-pin-{code_version}")
+            await sandbox.start()
+            try:
+                assert sandbox.image_id is not None
+                image_ids.append(sandbox.image_id)
+            finally:
+                await sandbox.stop()
+
+        assert image_ids[0] != image_ids[1]

--- a/tests/test_modal_sandbox.py
+++ b/tests/test_modal_sandbox.py
@@ -60,19 +60,9 @@ class TestModalSandboxSpec:
         assert spec.project_root is None
         assert spec.respect_gitignore is True
 
-    @pytest.mark.parametrize(
-        ("kwargs", "missing"),
-        [
-            ({}, "letta_evals_version, letta_code_version"),
-            ({"letta_evals_version": "0.25.0"}, "letta_code_version"),
-            ({"letta_code_version": "0.30.5"}, "letta_evals_version"),
-            ({"letta_evals_version": "", "letta_code_version": "0.30.5"}, "letta_evals_version"),
-            ({"letta_evals_version": "0.25.0", "letta_code_version": ""}, "letta_code_version"),
-        ],
-    )
-    def test_bundled_image_requires_both_pins(self, kwargs, missing):
-        with pytest.raises(ValueError, match=missing):
-            ModalSandboxSpec(**kwargs)
+    def test_bundled_image_requires_both_pins(self):
+        with pytest.raises(ValueError, match="requires both"):
+            ModalSandboxSpec(letta_evals_version="0.25.0")
 
     @pytest.mark.parametrize(
         "kwargs",
@@ -81,11 +71,11 @@ class TestModalSandboxSpec:
             {"letta_evals_version": "0.25.0", "letta_code_version": "latest"},
             {"letta_evals_version": "0.25.0", "letta_code_version": "^0.30.5"},
             {
-                "letta_evals_version": "https://example.com/letta-evals-current.whl",
+                "letta_evals_version": "letta-evals @ git+https://github.com/letta-ai/letta-evals.git@main",
                 "letta_code_version": "0.30.5",
             },
             {
-                "letta_evals_version": "letta-evals @ git+https://github.com/letta-ai/letta-evals.git@main",
+                "letta_evals_version": f"git+https://user:secret@example.com/repo.git@{'a' * 40}",
                 "letta_code_version": "0.30.5",
             },
         ],
@@ -94,38 +84,13 @@ class TestModalSandboxSpec:
         with pytest.raises(ValueError):
             ModalSandboxSpec(**kwargs)
 
-    def test_custom_image_rejects_unverifiable_eval_pin(self):
-        with pytest.raises(ValueError, match="full 40-character commit SHA"):
-            ModalSandboxSpec(
-                image="img:test",
-                letta_evals_version="git+https://github.com/letta-ai/letta-evals.git@main",
-            )
-
-    def test_rejects_noncanonical_python_version(self):
-        with pytest.raises(ValueError, match="canonical exact version"):
-            ModalSandboxSpec(
-                letta_evals_version="1.0-rc1",
-                letta_code_version="0.30.5",
-            )
-
-    def test_yaml_without_image_accepts_exact_pins(self):
+    def test_bundled_image_accepts_exact_pins(self):
         commit = "a" * 40
-        yaml_data = {
-            "name": "u",
-            "dataset": "s.jsonl",
-            "target": {"kind": "letta_code", "model_handles": ["openai/gpt-4.1-mini"]},
-            "graders": {"g": {"kind": "tool", "function": "exact_match"}},
-            "reward": {"kind": "metric", "metric_key": "g"},
-            "sandbox": {
-                "kind": "modal",
-                "letta_evals_version": (f"letta-evals @ git+https://github.com/letta-ai/letta-evals.git@{commit}"),
-                "letta_code_version": "0.30.5",
-            },
-        }
-        suite = SuiteSpec.from_yaml(yaml_data)
-        assert suite.sandbox is not None
-        assert suite.sandbox.image is None
-        assert suite.sandbox.letta_code_version == "0.30.5"
+        spec = ModalSandboxSpec(
+            letta_evals_version=f"letta-evals @ git+https://github.com/letta-ai/letta-evals.git@{commit}",
+            letta_code_version="0.30.5",
+        )
+        assert spec.image is None
 
     def test_bundled_dockerfile_exists(self):
         """The Dockerfile must ship with the package so Image.from_dockerfile
@@ -142,7 +107,6 @@ class TestModalSandboxSpec:
         assert "ARG LETTA_CODE_VERSION" not in contents
         assert "npm install -g" not in contents
         assert '"typing_extensions>=4.15.0"' in contents
-        assert "from typing_extensions import Sentinel" in contents
         assert "setup_22.x" in contents
         assert "major === 22 && minor < 19" in contents
 
@@ -324,18 +288,6 @@ def test_letta_evals_package_spec_normalization():
     assert _letta_evals_package_spec(direct) == direct
 
 
-def test_direct_url_log_summary_redacts_credentials_and_query():
-    from letta_evals.sandbox.modal import _direct_url_log_summary
-
-    summary = _direct_url_log_summary(
-        {
-            "url": "https://user:secret@example.com/org/repo.git?token=secret",
-            "vcs_info": {"commit_id": "a" * 40, "vcs": "git"},
-        }
-    )
-    assert summary == {"url": "https://example.com/org/repo.git", "commit_id": "a" * 40}
-
-
 def _install_fake_modal(monkeypatch):
     """Inject a fake ``modal`` SDK and return it so tests can assert on calls."""
     import sys
@@ -352,14 +304,10 @@ def _install_fake_modal(monkeypatch):
     fake_modal.Image.from_registry = MagicMock(return_value=fake_image)
     fake_sandbox = MagicMock(name="sandbox")
     fake_sandbox.object_id = "sb-xyz"
-    fake_sandbox.terminate.aio = AsyncMock()
     fake_modal.Sandbox.create.aio = AsyncMock(return_value=fake_sandbox)
-    runtime_verifier = AsyncMock()
 
     monkeypatch.setitem(sys.modules, "modal", fake_modal)
     monkeypatch.setattr(modal_driver, "_check_modal_auth", lambda: None)
-    monkeypatch.setattr(modal_driver.ModalSandbox, "_verify_runtime", runtime_verifier)
-    fake_modal._runtime_verifier = runtime_verifier
     return fake_modal
 
 
@@ -386,43 +334,12 @@ class TestModalDriverImageBuild:
         _, kwargs = fake_modal.Image.from_dockerfile.call_args
         assert kwargs == {}
         layer_calls = fake_modal.Image.from_dockerfile.return_value.run_commands.call_args_list
-        assert "letta-evals==0.24.0" in layer_calls[0].args[0]
-        assert "from typing_extensions import Sentinel" in layer_calls[0].args[1]
-        assert "@letta-ai/letta-code@0.30.5" in layer_calls[1].args[0]
-        assert layer_calls[1].args[1:] == ("node --version", "letta --version")
+        assert "@letta-ai/letta-code@0.30.5" in layer_calls[0].args[0]
+        assert layer_calls[0].args[1:] == ("letta --version",)
+        assert "letta-evals==0.24.0" in layer_calls[1].args[0]
+        assert "from typing_extensions import Sentinel" in layer_calls[1].args[1]
         assert sandbox.image_id == "im-xyz"
         fake_modal.Image.from_registry.assert_not_called()
-        fake_modal._runtime_verifier.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_changing_pins_changes_literal_layer_definitions(self, monkeypatch):
-        from letta_evals.sandbox.modal import ModalSandbox
-
-        fake_modal = _install_fake_modal(monkeypatch)
-        image = fake_modal.Image.from_dockerfile.return_value
-
-        pins = [
-            ("0.24.0", "0.30.5"),
-            ("0.25.0", "0.30.5"),  # only letta-evals changes
-            ("0.24.0", "0.30.7"),  # only letta-code changes
-        ]
-        for evals_version, code_version in pins:
-            spec = ModalSandboxSpec(
-                letta_evals_version=evals_version,
-                letta_code_version=code_version,
-                timeout_sec=60,
-            )
-            await ModalSandbox(spec=spec, session_id=f"unit-{evals_version}-{code_version}").start()
-
-        commands = [call.args[0] for call in image.run_commands.call_args_list]
-        assert commands == [
-            "python -m pip install --no-cache-dir --upgrade letta-evals==0.24.0",
-            "npm install -g --omit=dev @letta-ai/letta-code@0.30.5",
-            "python -m pip install --no-cache-dir --upgrade letta-evals==0.25.0",
-            "npm install -g --omit=dev @letta-ai/letta-code@0.30.5",
-            "python -m pip install --no-cache-dir --upgrade letta-evals==0.24.0",
-            "npm install -g --omit=dev @letta-ai/letta-code@0.30.7",
-        ]
 
     @pytest.mark.asyncio
     async def test_direct_git_pin_is_shell_quoted_in_layer(self, monkeypatch):
@@ -439,7 +356,7 @@ class TestModalDriverImageBuild:
 
         await ModalSandbox(spec=spec, session_id="unit-direct-ref").start()
 
-        evals_command = fake_modal.Image.from_dockerfile.return_value.run_commands.call_args_list[0].args[0]
+        evals_command = fake_modal.Image.from_dockerfile.return_value.run_commands.call_args_list[1].args[0]
         assert evals_command.endswith(f"'{direct}'")
 
     @pytest.mark.asyncio
@@ -455,162 +372,6 @@ class TestModalDriverImageBuild:
         fake_modal.Image.from_registry.assert_called_once_with("ghcr.io/custom/runtime:1.0")
         fake_modal.Image.from_dockerfile.assert_not_called()
         fake_modal.Image.from_registry.return_value.run_commands.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_runtime_verification_failure_terminates_created_sandbox(self, monkeypatch):
-        from letta_evals.sandbox.modal import ModalSandbox, VersionMismatch
-
-        fake_modal = _install_fake_modal(monkeypatch)
-        fake_modal._runtime_verifier.side_effect = VersionMismatch("stale runtime")
-        spec = ModalSandboxSpec(letta_evals_version="0.25.0", letta_code_version="0.30.5")
-        sandbox = ModalSandbox(spec=spec, session_id="unit-verification-failure")
-
-        with pytest.raises(VersionMismatch, match="stale runtime"):
-            await sandbox.start()
-
-        created = fake_modal.Sandbox.create.aio.return_value
-        created.terminate.aio.assert_awaited_once()
-        assert sandbox.sandbox_id is None
-
-
-class TestModalRuntimeVerification:
-    @staticmethod
-    def _probe_result(
-        *,
-        evals_version="0.25.0",
-        code_version="0.30.5",
-        node_version="v22.19.0",
-        commit=None,
-    ):
-        import json
-
-        direct_url = None
-        if commit:
-            direct_url = {
-                "url": "https://github.com/letta-ai/letta-evals.git",
-                "vcs_info": {"commit_id": commit, "vcs": "git"},
-            }
-        return ExecResult(
-            stdout=json.dumps(
-                {
-                    "letta_evals_version": evals_version,
-                    "letta_evals_direct_url": direct_url,
-                    "letta_code_version": code_version,
-                    "letta_version_output": code_version,
-                    "node_version": node_version,
-                }
-            ),
-            stderr="",
-            return_code=0,
-        )
-
-    @pytest.mark.asyncio
-    async def test_accepts_exact_versions(self, monkeypatch):
-        from unittest.mock import AsyncMock
-
-        sandbox = ModalSandbox(
-            ModalSandboxSpec(letta_evals_version="0.25.0", letta_code_version="0.30.5"),
-            session_id="verify-exact",
-        )
-        sandbox._sandbox = object()
-        monkeypatch.setattr(sandbox, "exec", AsyncMock(return_value=self._probe_result()))
-
-        await sandbox._verify_runtime()
-
-    @pytest.mark.asyncio
-    async def test_custom_image_allows_older_node_and_non_global_code_install(self, monkeypatch):
-        from unittest.mock import AsyncMock
-
-        sandbox = ModalSandbox(
-            ModalSandboxSpec(image="img:test", letta_evals_version="0.25.0"),
-            session_id="verify-custom",
-        )
-        sandbox._sandbox = object()
-        probe = self._probe_result(code_version=None, node_version="v20.18.0")
-        monkeypatch.setattr(sandbox, "exec", AsyncMock(return_value=probe))
-
-        await sandbox._verify_runtime()
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "probe_result",
-        [
-            ExecResult(stdout="", stderr="probe failed", return_code=1),
-            ExecResult(stdout="not-json", stderr="", return_code=0),
-        ],
-    )
-    async def test_rejects_failed_or_invalid_runtime_probe(self, monkeypatch, probe_result):
-        from unittest.mock import AsyncMock
-
-        from letta_evals.sandbox.modal import RuntimeProbeError
-
-        sandbox = ModalSandbox(
-            ModalSandboxSpec(letta_evals_version="0.25.0", letta_code_version="0.30.5"),
-            session_id="verify-probe-failure",
-        )
-        sandbox._sandbox = object()
-        monkeypatch.setattr(sandbox, "exec", AsyncMock(return_value=probe_result))
-
-        with pytest.raises(RuntimeProbeError):
-            await sandbox._verify_runtime()
-
-    @pytest.mark.asyncio
-    async def test_accepts_exact_git_commit(self, monkeypatch):
-        from unittest.mock import AsyncMock
-
-        commit = "a" * 40
-        direct = f"letta-evals @ git+https://github.com/letta-ai/letta-evals.git@{commit}"
-        sandbox = ModalSandbox(
-            ModalSandboxSpec(letta_evals_version=direct, letta_code_version="0.30.5"),
-            session_id="verify-commit",
-        )
-        sandbox._sandbox = object()
-        monkeypatch.setattr(sandbox, "exec", AsyncMock(return_value=self._probe_result(commit=commit)))
-
-        await sandbox._verify_runtime()
-
-    @pytest.mark.asyncio
-    async def test_rejects_git_commit_mismatch(self, monkeypatch):
-        from unittest.mock import AsyncMock
-
-        from letta_evals.sandbox.modal import VersionMismatch
-
-        expected_commit = "a" * 40
-        actual_commit = "b" * 40
-        direct = f"letta-evals @ git+https://github.com/letta-ai/letta-evals.git@{expected_commit}"
-        sandbox = ModalSandbox(
-            ModalSandboxSpec(letta_evals_version=direct, letta_code_version="0.30.5"),
-            session_id="verify-commit-mismatch",
-        )
-        sandbox._sandbox = object()
-        monkeypatch.setattr(sandbox, "exec", AsyncMock(return_value=self._probe_result(commit=actual_commit)))
-
-        with pytest.raises(VersionMismatch):
-            await sandbox._verify_runtime()
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "probe_result",
-        [
-            _probe_result(evals_version="0.24.0"),
-            _probe_result(code_version="0.30.7"),
-            _probe_result(node_version="v22.18.0"),
-        ],
-    )
-    async def test_rejects_runtime_mismatches(self, monkeypatch, probe_result):
-        from unittest.mock import AsyncMock
-
-        from letta_evals.sandbox.modal import VersionMismatch
-
-        sandbox = ModalSandbox(
-            ModalSandboxSpec(letta_evals_version="0.25.0", letta_code_version="0.30.5"),
-            session_id="verify-mismatch",
-        )
-        sandbox._sandbox = object()
-        monkeypatch.setattr(sandbox, "exec", AsyncMock(return_value=probe_result))
-
-        with pytest.raises(VersionMismatch):
-            await sandbox._verify_runtime()
 
 
 class TestModalDriverLazyImport:
@@ -653,7 +414,7 @@ class TestModalDriverLive:
     async def test_echo_round_trip(self):
         from letta_evals.sandbox.modal import ModalSandbox
 
-        # No image override: build the stable base plus exact runtime layers.
+        # No image override: build the shared base plus exact runtime layers.
         spec = ModalSandboxSpec(
             letta_evals_version="0.25.0",
             letta_code_version="0.30.5",

--- a/tests/test_modal_sandbox.py
+++ b/tests/test_modal_sandbox.py
@@ -70,6 +70,8 @@ class TestModalSandboxSpec:
             {"letta_evals_version": "latest", "letta_code_version": "0.30.5"},
             {"letta_evals_version": "0.25.0", "letta_code_version": "latest"},
             {"letta_evals_version": "0.25.0", "letta_code_version": "^0.30.5"},
+            {"letta_evals_version": "1.2.3-rc1", "letta_code_version": "0.30.5"},
+            {"letta_evals_version": "0.25.0", "letta_code_version": "1.2.3-beta.1"},
             {
                 "letta_evals_version": "letta-evals @ git+https://github.com/letta-ai/letta-evals.git@main",
                 "letta_code_version": "0.30.5",
@@ -411,32 +413,7 @@ class TestModalDriverLive:
     """
 
     @pytest.mark.asyncio
-    async def test_echo_round_trip(self):
-        from letta_evals.sandbox.modal import ModalSandbox
-
-        # No image override: build the shared base plus exact runtime layers.
-        spec = ModalSandboxSpec(
-            letta_evals_version="0.25.0",
-            letta_code_version="0.30.5",
-            timeout_sec=120,
-            cpu=1,
-            memory_mb=512,
-        )
-        sandbox = ModalSandbox(spec=spec, session_id="unit-echo")
-        await sandbox.start()
-        try:
-            assert sandbox.image_id and sandbox.image_id.startswith("im-")
-            res = await sandbox.exec("echo hello")
-            assert res.return_code == 0
-            assert "hello" in res.stdout
-            help_result = await sandbox.exec("letta --help")
-            assert help_result.return_code == 0
-            assert "--stateless" in help_result.stdout
-        finally:
-            await sandbox.stop()
-
-    @pytest.mark.asyncio
-    async def test_changing_code_pin_changes_image(self):
+    async def test_pinned_images_have_requested_versions(self):
         from letta_evals.sandbox.modal import ModalSandbox
 
         image_ids = []
@@ -453,6 +430,16 @@ class TestModalDriverLive:
             try:
                 assert sandbox.image_id is not None
                 image_ids.append(sandbox.image_id)
+                version_result = await sandbox.exec("npm list -g @letta-ai/letta-code --depth=0")
+                assert version_result.return_code == 0
+                assert f"@letta-ai/letta-code@{code_version}" in version_result.stdout
+                if code_version == "0.30.5":
+                    echo_result = await sandbox.exec("echo hello")
+                    assert echo_result.return_code == 0
+                    assert "hello" in echo_result.stdout
+                    help_result = await sandbox.exec("letta --help")
+                    assert help_result.return_code == 0
+                    assert "--stateless" in help_result.stdout
             finally:
                 await sandbox.stop()
 

--- a/tests/test_runner_sandbox_dispatch.py
+++ b/tests/test_runner_sandbox_dispatch.py
@@ -1,7 +1,7 @@
 """Tests for the sandbox dispatch path.
 
 These tests mock out ``ModalSandbox`` so we exercise the orchestration code
-(suite-dir upload, command construction, result round-trip,
+(version check, suite-dir upload, command construction, result round-trip,
 teardown) without touching Modal at all.
 """
 
@@ -44,13 +44,14 @@ def _canned_result(sample_id) -> SampleResult:
 class _StubSandbox:
     """Stand-in for ModalSandbox that records calls."""
 
-    def __init__(self, exec_return_code: int = 0):
+    def __init__(self, version_output: str = "letta-evals 0.17.0", exec_return_code: int = 0):
         self.started = False
         self.stopped = False
         self.uploaded_files: list[tuple[Path, str]] = []
         self.uploaded_dirs: list[tuple[Path, str]] = []
         self.execs: list[tuple[str, Optional[dict], Optional[int]]] = []
         self.downloaded: list[tuple[str, Path]] = []
+        self._version_output = version_output
         self._exec_return_code = exec_return_code
         self.sandbox_id = "sb-test-1"
         self._result_to_write: Optional[SampleResult] = None
@@ -63,6 +64,8 @@ class _StubSandbox:
 
     async def exec(self, command, env=None, timeout_sec=None) -> ExecResult:
         self.execs.append((command, env, timeout_sec))
+        if "--version" in command:
+            return ExecResult(stdout=self._version_output, stderr="", return_code=0)
         return ExecResult(stdout="", stderr="", return_code=self._exec_return_code)
 
     async def upload_file(self, local: Path, remote: str) -> None:
@@ -365,6 +368,34 @@ sandbox:
         assert result.error is not None
         assert result.error.exception_type == "SandboxTimeout"
         assert result.error.category.value == "target"
+
+    def test_version_mismatch_short_circuits(self, tmp_path, monkeypatch):
+        _write_suite_yaml(tmp_path)
+        runner = _make_runner_with_sandbox(
+            tmp_path,
+            sandbox_spec=ModalSandboxSpec(
+                image="img:test",
+                letta_evals_version="0.99.0",
+                timeout_sec=60,
+            ),
+        )
+        stub = _StubSandbox(version_output="letta-evals 0.17.0")
+        monkeypatch.setattr("letta_evals.sandbox.dispatch.ModalSandbox", lambda spec, session_id: stub)
+
+        sample = Sample(id="s1", input="hi", ground_truth="hi")
+        result = anyio.run(
+            run_sample_in_sandbox,
+            runner.suite,
+            sample,
+            "openai/gpt-a",
+            0.0,
+        )
+
+        assert result.error is not None
+        assert result.error.exception_type == "VersionMismatch"
+        # No CLI exec should have happened after the failed version check.
+        cli_commands = [c[0] for c in stub.execs if "--sample" in c[0]]
+        assert not cli_commands
 
     def test_start_failure_returns_target_error(self, tmp_path, monkeypatch):
         _write_suite_yaml(tmp_path)

--- a/tests/test_runner_sandbox_dispatch.py
+++ b/tests/test_runner_sandbox_dispatch.py
@@ -1,7 +1,7 @@
 """Tests for the sandbox dispatch path.
 
 These tests mock out ``ModalSandbox`` so we exercise the orchestration code
-(version check, suite-dir upload, command construction, result round-trip,
+(suite-dir upload, command construction, result round-trip,
 teardown) without touching Modal at all.
 """
 
@@ -44,14 +44,13 @@ def _canned_result(sample_id) -> SampleResult:
 class _StubSandbox:
     """Stand-in for ModalSandbox that records calls."""
 
-    def __init__(self, version_output: str = "letta-evals 0.17.0", exec_return_code: int = 0):
+    def __init__(self, exec_return_code: int = 0):
         self.started = False
         self.stopped = False
         self.uploaded_files: list[tuple[Path, str]] = []
         self.uploaded_dirs: list[tuple[Path, str]] = []
         self.execs: list[tuple[str, Optional[dict], Optional[int]]] = []
         self.downloaded: list[tuple[str, Path]] = []
-        self._version_output = version_output
         self._exec_return_code = exec_return_code
         self.sandbox_id = "sb-test-1"
         self._result_to_write: Optional[SampleResult] = None
@@ -64,8 +63,6 @@ class _StubSandbox:
 
     async def exec(self, command, env=None, timeout_sec=None) -> ExecResult:
         self.execs.append((command, env, timeout_sec))
-        if "--version" in command:
-            return ExecResult(stdout=self._version_output, stderr="", return_code=0)
         return ExecResult(stdout="", stderr="", return_code=self._exec_return_code)
 
     async def upload_file(self, local: Path, remote: str) -> None:
@@ -368,34 +365,6 @@ sandbox:
         assert result.error is not None
         assert result.error.exception_type == "SandboxTimeout"
         assert result.error.category.value == "target"
-
-    def test_version_mismatch_short_circuits(self, tmp_path, monkeypatch):
-        _write_suite_yaml(tmp_path)
-        runner = _make_runner_with_sandbox(
-            tmp_path,
-            sandbox_spec=ModalSandboxSpec(
-                image="img:test",
-                letta_evals_version="0.99.0",
-                timeout_sec=60,
-            ),
-        )
-        stub = _StubSandbox(version_output="letta-evals 0.17.0")
-        monkeypatch.setattr("letta_evals.sandbox.dispatch.ModalSandbox", lambda spec, session_id: stub)
-
-        sample = Sample(id="s1", input="hi", ground_truth="hi")
-        result = anyio.run(
-            run_sample_in_sandbox,
-            runner.suite,
-            sample,
-            "openai/gpt-a",
-            0.0,
-        )
-
-        assert result.error is not None
-        assert result.error.exception_type == "VersionMismatch"
-        # No CLI exec should have happened after the failed version check.
-        cli_commands = [c[0] for c in stub.execs if "--sample" in c[0]]
-        assert not cli_commands
 
     def test_start_failure_returns_target_error(self, tmp_path, monkeypatch):
         _write_suite_yaml(tmp_path)

--- a/tests/test_runner_sandbox_dispatch.py
+++ b/tests/test_runner_sandbox_dispatch.py
@@ -44,7 +44,7 @@ def _canned_result(sample_id) -> SampleResult:
 class _StubSandbox:
     """Stand-in for ModalSandbox that records calls."""
 
-    def __init__(self, version_output: str = "letta-evals 0.17.0", exec_return_code: int = 0):
+    def __init__(self, version_output: str = "0.17.0", exec_return_code: int = 0):
         self.started = False
         self.stopped = False
         self.uploaded_files: list[tuple[Path, str]] = []
@@ -64,7 +64,7 @@ class _StubSandbox:
 
     async def exec(self, command, env=None, timeout_sec=None) -> ExecResult:
         self.execs.append((command, env, timeout_sec))
-        if "--version" in command:
+        if "importlib.metadata" in command:
             return ExecResult(stdout=self._version_output, stderr="", return_code=0)
         return ExecResult(stdout="", stderr="", return_code=self._exec_return_code)
 
@@ -375,11 +375,12 @@ sandbox:
             tmp_path,
             sandbox_spec=ModalSandboxSpec(
                 image="img:test",
-                letta_evals_version="0.99.0",
+                letta_evals_version="0.25.0",
                 timeout_sec=60,
             ),
         )
-        stub = _StubSandbox(version_output="letta-evals 0.17.0")
+        # Exact comparison must not let 0.25.0 match the suffix of 10.25.0.
+        stub = _StubSandbox(version_output="10.25.0")
         monkeypatch.setattr("letta_evals.sandbox.dispatch.ModalSandbox", lambda spec, session_id: stub)
 
         sample = Sample(id="s1", input="hi", ground_truth="hi")


### PR DESCRIPTION
## Summary

- split the bundled Modal image into a shared system/toolchain base and explicit versioned application layers
- install the larger, less frequently changed Letta Code layer before the letta-evals layer so evals pin changes reuse the npm layer
- require `X.Y.Z` application pins for bundled releases, while allowing letta-evals Git URLs pinned to a full commit SHA; reject mutable selectors and credentialed Git URLs
- upgrade the bundled base to Node >=22.19, smoke-test the Letta Code CLI during the build, and preserve the post-install `typing_extensions.Sentinel` guard
- compare released letta-evals pins against installed distribution metadata using exact equality and log the hydrated Modal image ID

## Why

Passing pins only as `Image.from_dockerfile(..., build_args=...)` allowed Modal to reuse a stale Dockerfile image. Requests for different Letta Code versions could resolve to the same image and run an older CLI.

Putting each immutable pin directly in a `run_commands` definition makes it part of that Modal layer's identity. The shared OS/toolchain base remains cached, changing the Letta Code pin rebuilds both application layers, and changing only the evals pin rebuilds the cheaper Python layer.

## Breaking change

When `sandbox.image` is unset, both application version pins are required. Custom registry images remain image-managed and may omit them.

## Validation

- `OPENAI_API_KEY=test uv run --frozen --extra dev pytest -q` - 342 passed, 2 skipped
- `uv run --frozen --extra dev ruff check .`
- `uv run --frozen --extra dev ruff format --check .`
- combined live Modal driver test - 1 passed
  - images contain the requested Letta Code 0.30.5 and 0.30.7 releases and have distinct image IDs
  - Letta Code 0.30.5 exposes `--stateless`
  - sandbox exec round trip succeeds

Fixes #327
