### PR TITLE
fix(execution): Fetch token traces atomically

### DIFF
--- a/letta_evals/execution/trace.py
+++ b/letta_evals/execution/trace.py
@@ -6,14 +6,46 @@ agent state keyed by ``agent_id`` into the trace fields persisted on
 sandboxed runs share the same fetch path.
 """
 
+import asyncio
 import json
 import logging
+import random
 from typing import Any, Optional
+
+from letta_client import APIConnectionError, APITimeoutError
 
 from letta_evals.models import TurnTokenData
 from letta_evals.utils import list_all_agent_messages
 
 logger = logging.getLogger(__name__)
+
+_TOKEN_FETCH_MAX_ATTEMPTS = 3
+_TOKEN_FETCH_RETRY_BASE_SECONDS = 0.5
+_RETRYABLE_TOKEN_FETCH_ERRORS = (APIConnectionError, APITimeoutError)
+
+
+class TokenDataFetchError(RuntimeError):
+    """Raised when a complete, internally consistent token trace cannot be fetched."""
+
+    def __init__(
+        self,
+        agent_id: str,
+        *,
+        completed_runs: int,
+        total_runs: int | None,
+        failed_run_id: str | None,
+        reason: str,
+    ) -> None:
+        total = "unknown" if total_runs is None else str(total_runs)
+        failed_run = f", failed_run_id={failed_run_id}" if failed_run_id else ""
+        super().__init__(
+            f"Atomic token-data fetch failed for agent {agent_id}: {reason} "
+            f"(completed_runs={completed_runs}/{total}{failed_run})"
+        )
+        self.agent_id = agent_id
+        self.completed_runs = completed_runs
+        self.total_runs = total_runs
+        self.failed_run_id = failed_run_id
 
 
 def extract_usage_stats(last_line: str) -> Optional[list[dict]]:
@@ -75,66 +107,135 @@ def _run_sort_key(run_summary: Any) -> tuple[str, str]:
     return created_key, str(getattr(run_summary, "id", ""))
 
 
-async def fetch_token_data(client: Any, agent_id: str) -> list[TurnTokenData]:
-    """Fetch token-level data (IDs + logprobs) for a letta code agent.
-
-    Reads token IDs and logprobs from ``run.metadata.result.turns``, which is
-    populated by Letta's SGLang-native adapter for token-aware model runs.
-
-    Stops at the first half-written turn — ``output_ids`` present but a
-    shorter ``output_token_logprobs`` — returning only the clean prefix, so a
-    partially-flushed generation can't corrupt Tinker's sequence-extension.
-    """
-    token_data: list[TurnTokenData] = []
+async def _list_agent_runs(client: Any, agent_id: str) -> list[Any]:
+    """List every run for an agent, including pages beyond the API limit."""
     try:
-        # Fetch ALL runs for this agent — client tools cause each tool-call
-        # round-trip to be a separate run, so token IDs are scattered.
-        try:
-            runs_page = await client.runs.list(agent_id=agent_id, limit=100, order="asc")
-        except TypeError:
-            # Older generated clients may not expose the ``order`` kwarg.
-            # Fall back to the legacy call and sort locally below.
-            runs_page = await client.runs.list(agent_id=agent_id, limit=100)
-        if not runs_page.items:
-            return token_data
+        runs_page = await client.runs.list(agent_id=agent_id, limit=100, order="asc")
+    except TypeError:
+        # Older generated clients may not expose the ``order`` kwarg.
+        runs_page = await client.runs.list(agent_id=agent_id, limit=100)
 
-        # Token IDs are stored in run.metadata.result.turns (populated by SGLang native adapter)
-        for run_summary in sorted(runs_page.items, key=_run_sort_key):
+    runs: list[Any] = []
+    seen_run_ids: set[str] = set()
+    while True:
+        new_runs = [run for run in runs_page.items if str(run.id) not in seen_run_ids]
+        if runs_page.items and not new_runs:
+            # Defensive stop if an older server ignores the pagination cursor.
+            break
+        runs.extend(new_runs)
+        seen_run_ids.update(str(run.id) for run in new_runs)
+
+        has_next_page = getattr(runs_page, "has_next_page", None)
+        get_next_page = getattr(runs_page, "get_next_page", None)
+        if not callable(has_next_page) or not callable(get_next_page) or not runs_page.has_next_page():
+            break
+        runs_page = await runs_page.get_next_page()
+
+    return runs
+
+
+async def _fetch_token_data_once(client: Any, agent_id: str) -> list[TurnTokenData]:
+    """Fetch one complete token-data snapshot or raise without returning a prefix."""
+    try:
+        # Client tools cause each tool-call round-trip to be a separate run, so
+        # token IDs are scattered across the agent's runs.
+        run_summaries = sorted(await _list_agent_runs(client, agent_id), key=_run_sort_key)
+    except _RETRYABLE_TOKEN_FETCH_ERRORS as exc:
+        raise TokenDataFetchError(
+            agent_id,
+            completed_runs=0,
+            total_runs=None,
+            failed_run_id=None,
+            reason=f"{type(exc).__name__}: {exc}",
+        ) from exc
+
+    token_data: list[TurnTokenData] = []
+
+    for completed_runs, run_summary in enumerate(run_summaries):
+        try:
             run = await client.runs.retrieve(run_id=run_summary.id)
-            result = (run.metadata or {}).get("result", {})
-            for turn in result.get("turns") or []:
-                output_ids = turn.get("output_ids")
-                role = turn.get("role", "assistant")
-                if output_ids:
-                    logprobs = turn.get("output_token_logprobs")
-                    if logprobs is not None and len(output_ids) != len(logprobs):
-                        # Half-written generation: ids present but logprobs
-                        # not fully flushed. Drop it and everything after.
-                        logger.info(
-                            f"Truncating token data at half-written turn in run {run_summary.id} for agent {agent_id}"
-                        )
-                        return token_data
-                    # Assistant turn with token IDs from SGLang
-                    token_data.append(
-                        TurnTokenData(
-                            role=role,
-                            input_ids=turn.get("input_ids"),
-                            output_ids=output_ids,
-                            output_token_logprobs=logprobs,
-                        )
+        except _RETRYABLE_TOKEN_FETCH_ERRORS as exc:
+            raise TokenDataFetchError(
+                agent_id,
+                completed_runs=completed_runs,
+                total_runs=len(run_summaries),
+                failed_run_id=str(run_summary.id),
+                reason=f"{type(exc).__name__}: {exc}",
+            ) from exc
+
+        result = (run.metadata or {}).get("result", {})
+        for turn in result.get("turns") or []:
+            output_ids = turn.get("output_ids")
+            role = turn.get("role", "assistant")
+            if output_ids:
+                logprobs = turn.get("output_token_logprobs")
+                if logprobs is not None and len(output_ids) != len(logprobs):
+                    raise TokenDataFetchError(
+                        agent_id,
+                        completed_runs=completed_runs,
+                        total_runs=len(run_summaries),
+                        failed_run_id=str(run_summary.id),
+                        reason=(f"half-written turn has {len(output_ids)} output IDs but {len(logprobs)} logprobs"),
                     )
-                elif role in ("tool", "tool_return", "tool_return_message") and turn.get("content"):
-                    # Tool return turn — no output_ids, but content is needed
-                    # for proper multi-turn token sequence reconstruction
-                    token_data.append(
-                        TurnTokenData(
-                            role=role,
-                            content=turn.get("content"),
-                        )
+                token_data.append(
+                    TurnTokenData(
+                        role=role,
+                        input_ids=turn.get("input_ids"),
+                        output_ids=output_ids,
+                        output_token_logprobs=logprobs,
                     )
-    except Exception as e:
-        logger.warning(f"Could not fetch token data for agent {agent_id}: {e}")
+                )
+            elif role in ("tool", "tool_return", "tool_return_message") and turn.get("content"):
+                token_data.append(
+                    TurnTokenData(
+                        role=role,
+                        content=turn.get("content"),
+                    )
+                )
+
     return token_data
+
+
+async def fetch_token_data(
+    client: Any,
+    agent_id: str,
+    *,
+    max_attempts: int = _TOKEN_FETCH_MAX_ATTEMPTS,
+    retry_base_seconds: float = _TOKEN_FETCH_RETRY_BASE_SECONDS,
+) -> list[TurnTokenData]:
+    """Fetch token IDs and logprobs atomically, retrying the complete snapshot.
+
+    Each attempt starts with a fresh accumulator. A transport failure or
+    half-written turn discards that attempt's prefix. After ``max_attempts``
+    failures, ``TokenDataFetchError`` propagates so callers can retry the full
+    rollout rather than training or evaluating on incomplete token data.
+    """
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be at least 1")
+
+    last_error: TokenDataFetchError | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return await _fetch_token_data_once(client, agent_id)
+        except TokenDataFetchError as exc:
+            last_error = exc
+            if attempt == max_attempts:
+                break
+            delay = retry_base_seconds * (2 ** (attempt - 1))
+            if delay > 0:
+                delay += random.uniform(0.0, retry_base_seconds)
+            logger.warning(
+                "Token-data fetch attempt %d/%d failed for agent %s; discarding partial data and retrying in %.2fs: %r",
+                attempt,
+                max_attempts,
+                agent_id,
+                delay,
+                exc.__cause__ or exc,
+            )
+            await asyncio.sleep(delay)
+
+    assert last_error is not None
+    raise last_error
 
 
 async def fetch_agent_state(client: Any, agent_id: str) -> Any:

--- a/letta_evals/runner.py
+++ b/letta_evals/runner.py
@@ -14,7 +14,7 @@ from rich.console import Console
 from letta_evals.datasets.hf import hf_dataset_provenance
 from letta_evals.datasets.loader import load_dataset
 from letta_evals.execution.grading import detect_errors, grade_sample, validate_rubric_vars
-from letta_evals.execution.trace import fetch_agent_state, fetch_token_data, fetch_trajectory
+from letta_evals.execution.trace import TokenDataFetchError, fetch_agent_state, fetch_token_data, fetch_trajectory
 from letta_evals.graders.base import Grader
 from letta_evals.graders.rubric import RubricGrader
 from letta_evals.graders.tool import ToolGrader
@@ -508,7 +508,15 @@ class Runner:
                             logger.warning(f"Could not fetch partial trajectory for agent {agent_id}: {fetch_err}")
                     partial_token_data = e.token_data
                     if return_token_data and agent_id:
-                        partial_token_data = await fetch_token_data(self.client, agent_id)
+                        try:
+                            partial_token_data = await fetch_token_data(self.client, agent_id)
+                        except TokenDataFetchError as fetch_err:
+                            logger.warning(
+                                "Could not fetch complete token data for failed agent %s: %r",
+                                agent_id,
+                                fetch_err.__cause__ or fetch_err,
+                            )
+                            partial_token_data = None
                 else:
                     partial_trajectory = locals().get("trajectory") or []
                     partial_token_data = locals().get("token_data")

--- a/tests/test_execution_trace_token_data.py
+++ b/tests/test_execution_trace_token_data.py
@@ -3,16 +3,19 @@
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
+import httpx
 import pytest
+from letta_client import APIConnectionError
 
-from letta_evals.execution.trace import fetch_token_data
+from letta_evals.execution.trace import TokenDataFetchError, fetch_token_data
 
 
 class _FakeRuns:
-    def __init__(self, *, items, runs_by_id, reject_order: bool = False):
+    def __init__(self, *, items, runs_by_id, reject_order: bool = False, retrieve_failures=None):
         self.items = items
         self.runs_by_id = runs_by_id
         self.reject_order = reject_order
+        self.retrieve_failures = dict(retrieve_failures or {})
         self.list_calls = []
         self.retrieve_ids = []
 
@@ -24,6 +27,10 @@ class _FakeRuns:
 
     async def retrieve(self, *, run_id):
         self.retrieve_ids.append(run_id)
+        remaining_failures = self.retrieve_failures.get(run_id, 0)
+        if remaining_failures:
+            self.retrieve_failures[run_id] = remaining_failures - 1
+            raise APIConnectionError(request=httpx.Request("GET", f"https://example.test/v1/runs/{run_id}"))
         return self.runs_by_id[run_id]
 
 
@@ -79,6 +86,44 @@ async def test_fetch_token_data_requests_and_processes_runs_chronologically():
 
 
 @pytest.mark.asyncio
+async def test_fetch_token_data_reads_all_run_pages():
+    first = _run_summary("run-first", datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc))
+    second = _run_summary("run-second", datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc))
+
+    class _Page:
+        def __init__(self, items, next_page=None):
+            self.items = items
+            self.next_page = next_page
+
+        def has_next_page(self):
+            return self.next_page is not None
+
+        async def get_next_page(self):
+            return self.next_page
+
+    fake_runs = _FakeRuns(
+        items=[],
+        runs_by_id={
+            "run-first": _run_with_turns(_assistant_turn([1], [2])),
+            "run-second": _run_with_turns(_assistant_turn([1, 2, 3], [4])),
+        },
+    )
+    second_page = _Page([second])
+    first_page = _Page([first], next_page=second_page)
+
+    async def list_pages(**kwargs):
+        fake_runs.list_calls.append(kwargs)
+        return first_page
+
+    fake_runs.list = list_pages
+
+    token_data = await fetch_token_data(_client(fake_runs), "agent-123")
+
+    assert fake_runs.retrieve_ids == ["run-first", "run-second"]
+    assert [turn.output_ids for turn in token_data] == [[2], [4]]
+
+
+@pytest.mark.asyncio
 async def test_fetch_token_data_sorts_locally_when_client_lacks_order_kwarg():
     older = _run_summary("run-older", datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc))
     newer = _run_summary("run-newer", datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc))
@@ -99,3 +144,78 @@ async def test_fetch_token_data_sorts_locally_when_client_lacks_order_kwarg():
     ]
     assert fake_runs.retrieve_ids == ["run-older", "run-newer"]
     assert [turn.output_ids for turn in token_data] == [[2], [4]]
+
+
+@pytest.mark.asyncio
+async def test_fetch_token_data_retries_the_complete_snapshot_without_duplicate_prefixes():
+    older = _run_summary("run-older", datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc))
+    newer = _run_summary("run-newer", datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc))
+    fake_runs = _FakeRuns(
+        items=[older, newer],
+        runs_by_id={
+            "run-older": _run_with_turns(_assistant_turn([1], [2])),
+            "run-newer": _run_with_turns(_assistant_turn([1, 2, 3], [4])),
+        },
+        retrieve_failures={"run-newer": 1},
+    )
+
+    token_data = await fetch_token_data(
+        _client(fake_runs),
+        "agent-123",
+        max_attempts=2,
+        retry_base_seconds=0,
+    )
+
+    assert fake_runs.retrieve_ids == ["run-older", "run-newer", "run-older", "run-newer"]
+    assert [turn.output_ids for turn in token_data] == [[2], [4]]
+
+
+@pytest.mark.asyncio
+async def test_fetch_token_data_raises_instead_of_returning_a_partial_prefix():
+    older = _run_summary("run-older", datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc))
+    newer = _run_summary("run-newer", datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc))
+    fake_runs = _FakeRuns(
+        items=[older, newer],
+        runs_by_id={
+            "run-older": _run_with_turns(_assistant_turn([1], [2])),
+            "run-newer": _run_with_turns(_assistant_turn([1, 2, 3], [4])),
+        },
+        retrieve_failures={"run-newer": 2},
+    )
+
+    with pytest.raises(TokenDataFetchError) as exc_info:
+        await fetch_token_data(
+            _client(fake_runs),
+            "agent-123",
+            max_attempts=2,
+            retry_base_seconds=0,
+        )
+
+    assert exc_info.value.completed_runs == 1
+    assert exc_info.value.total_runs == 2
+    assert exc_info.value.failed_run_id == "run-newer"
+    assert isinstance(exc_info.value.__cause__, APIConnectionError)
+    assert fake_runs.retrieve_ids == ["run-older", "run-newer", "run-older", "run-newer"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_token_data_rejects_half_written_turns_instead_of_returning_a_prefix():
+    older = _run_summary("run-older", datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc))
+    newer = _run_summary("run-newer", datetime(2026, 1, 1, 12, 1, tzinfo=timezone.utc))
+    half_written_turn = _assistant_turn([1, 2, 3], [4, 5])
+    half_written_turn["output_token_logprobs"] = [[-0.1, 4, None]]
+    fake_runs = _FakeRuns(
+        items=[older, newer],
+        runs_by_id={
+            "run-older": _run_with_turns(_assistant_turn([1], [2])),
+            "run-newer": _run_with_turns(half_written_turn),
+        },
+    )
+
+    with pytest.raises(TokenDataFetchError, match="half-written turn"):
+        await fetch_token_data(
+            _client(fake_runs),
+            "agent-123",
+            max_attempts=1,
+            retry_base_seconds=0,
+        )

--- a/tests/test_runner_sandbox_dispatch.py
+++ b/tests/test_runner_sandbox_dispatch.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 import anyio
 import pytest
 
+from letta_evals.execution.trace import TokenDataFetchError
 from letta_evals.models import (
     GradeResult,
     ModalSandboxSpec,
@@ -471,3 +472,29 @@ sandbox:
 
         fetch_token_data.assert_awaited_once_with(runner.client, "agent-sandbox-1")
         assert result.token_data == token_data
+
+    def test_run_sample_surfaces_atomic_token_fetch_failure(self, tmp_path, monkeypatch):
+        """A failed host fetch marks the sample failed instead of returning partial token data."""
+        _write_suite_yaml(tmp_path)
+        runner = _make_runner_with_sandbox(tmp_path)
+
+        async def fake_in_sandbox(suite, sample, model_handle, t_sample_start):
+            return _canned_result(sample.id)
+
+        fetch_error = TokenDataFetchError(
+            "agent-sandbox-1",
+            completed_runs=3,
+            total_runs=8,
+            failed_run_id="run-4",
+            reason="connection reset",
+        )
+        monkeypatch.setattr("letta_evals.runner.run_sample_in_sandbox", fake_in_sandbox)
+        monkeypatch.setattr("letta_evals.runner.fetch_token_data", AsyncMock(side_effect=fetch_error))
+
+        sample = Sample(id="s1", input="hi", ground_truth="hi")
+        result = anyio.run(runner.run_sample, sample, "openai/gpt-a", True)
+
+        assert result.error is not None
+        assert result.error.exception_type == "TokenDataFetchError"
+        assert "completed_runs=3/8" in result.error.message
+        assert result.token_data is None


### PR DESCRIPTION
## Summary
- retry complete token-data snapshots with a fresh accumulator after transient API failures
- paginate all agent runs and reject half-written generations instead of returning a valid-looking prefix
- surface exhausted fetches as sample errors while preserving best-effort trace collection for already-failed targets

Fixes the data-integrity failure documented in https://github.com/letta-ai/letta-train/issues/469.

## Test plan
- [x] `.venv/bin/pytest -q` (347 passed, 2 skipped)
- [x] `.venv/bin/ruff check .`
- [x] `.venv/bin/ruff format --check .`

👾 Generated with [Letta Code](https://letta.com)