### PR TITLE
fix(sandbox): Migrate Modal sandboxes to v2 filesystem backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ The Modal SDK ships as a base dependency, so `pip install letta-evals` is all
 you need to drive sandboxes. See `docs/modal-sandbox.md` for details
 suite.
 
+The minimum Modal SDK version is now 1.5.4. The sandbox driver enables Modal's
+v2 Sandbox backend by default and uses its path-oriented `sandbox.filesystem`
+APIs for host-to-sandbox file transfers.
+
 ### ⚠ BREAKING CHANGES — `target.sandbox` and `target.working_dir` removed
 
 The `sandbox: bool` and `working_dir: Path` fields on `LettaCodeTargetSpec`

--- a/docs/modal-sandbox.md
+++ b/docs/modal-sandbox.md
@@ -31,6 +31,10 @@ sandbox:
   letta_code_version: "0.30.5"
 ```
 
+The driver requires Modal SDK 1.5.4 or newer and enables Modal's v2 Sandbox
+backend before creating each sandbox. If `MODAL_SANDBOX_V2` is already set in
+the host environment, the driver preserves that explicit value.
+
 The base checks Node `>=22.19.0` during the image build, and the application
 layers smoke-test the Letta Code CLI and `typing_extensions.Sentinel`. The
 runner retains its lightweight startup check for released `letta-evals` pins.

--- a/letta_evals/sandbox/modal.py
+++ b/letta_evals/sandbox/modal.py
@@ -53,6 +53,11 @@ def _check_modal_auth() -> None:
     )
 
 
+def _enable_modal_sandbox_v2() -> None:
+    """Use Modal's v2 Sandbox backend unless the caller configured it explicitly."""
+    os.environ.setdefault("MODAL_SANDBOX_V2", "1")
+
+
 class ModalSandbox(AbstractSandbox):
     """Single-container Modal sandbox driving one sample's worth of work."""
 
@@ -73,6 +78,9 @@ class ModalSandbox(AbstractSandbox):
         return self._image_id
 
     async def start(self) -> None:
+        # Modal 1.5.4 makes v2 opt-in through this setting. Keep an explicit
+        # caller value intact so deployments retain a rollback path.
+        _enable_modal_sandbox_v2()
         modal = _import_modal()
         _check_modal_auth()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "anthropic>=0.80.0",
     "google-genai>=1.0.0",
     "python-dotenv>=1.0.0",
-    "modal>=0.65.0",
+    "modal>=1.5.4",
     "anyio==4.10.0",
     "pandas>=2.3.2",
     "matplotlib>=3.10.6",

--- a/tests/test_modal_sandbox.py
+++ b/tests/test_modal_sandbox.py
@@ -306,11 +306,70 @@ def _install_fake_modal(monkeypatch):
     fake_modal.Image.from_registry = MagicMock(return_value=fake_image)
     fake_sandbox = MagicMock(name="sandbox")
     fake_sandbox.object_id = "sb-xyz"
+    fake_sandbox.filesystem.copy_from_local.aio = AsyncMock()
+    fake_sandbox.filesystem.copy_to_local.aio = AsyncMock()
     fake_modal.Sandbox.create.aio = AsyncMock(return_value=fake_sandbox)
 
     monkeypatch.setitem(sys.modules, "modal", fake_modal)
     monkeypatch.setattr(modal_driver, "_check_modal_auth", lambda: None)
     return fake_modal
+
+
+class TestModalDriverV2:
+    @pytest.mark.parametrize(
+        ("configured", "expected"),
+        [(None, "1"), ("0", "0")],
+        ids=["enabled-by-default", "explicit-value-preserved"],
+    )
+    @pytest.mark.asyncio
+    async def test_start_configures_v2(self, monkeypatch, configured, expected):
+        if configured is None:
+            monkeypatch.delenv("MODAL_SANDBOX_V2", raising=False)
+        else:
+            monkeypatch.setenv("MODAL_SANDBOX_V2", configured)
+        _install_fake_modal(monkeypatch)
+        sandbox = ModalSandbox(
+            spec=ModalSandboxSpec(image="ghcr.io/custom/runtime:1.0"),
+            session_id="unit-v2",
+        )
+
+        await sandbox.start()
+
+        assert os.environ["MODAL_SANDBOX_V2"] == expected
+
+
+class TestModalDriverFilesystem:
+    @pytest.mark.asyncio
+    async def test_upload_file_uses_v2_filesystem_api(self, monkeypatch, tmp_path):
+        fake_modal = _install_fake_modal(monkeypatch)
+        sandbox = ModalSandbox(
+            spec=ModalSandboxSpec(image="ghcr.io/custom/runtime:1.0"),
+            session_id="unit-upload",
+        )
+        local = tmp_path / "input.json"
+        local.write_text("{}\n")
+        await sandbox.start()
+
+        await sandbox.upload_file(local, "/mnt/input.json")
+
+        filesystem = fake_modal.Sandbox.create.aio.return_value.filesystem
+        filesystem.copy_from_local.aio.assert_awaited_once_with(str(local), "/mnt/input.json")
+
+    @pytest.mark.asyncio
+    async def test_download_file_uses_v2_filesystem_api(self, monkeypatch, tmp_path):
+        fake_modal = _install_fake_modal(monkeypatch)
+        sandbox = ModalSandbox(
+            spec=ModalSandboxSpec(image="ghcr.io/custom/runtime:1.0"),
+            session_id="unit-download",
+        )
+        local = tmp_path / "nested" / "result.json"
+        await sandbox.start()
+
+        await sandbox.download_file("/mnt/result.json", local)
+
+        assert local.parent.is_dir()
+        filesystem = fake_modal.Sandbox.create.aio.return_value.filesystem
+        filesystem.copy_to_local.aio.assert_awaited_once_with("/mnt/result.json", str(local))
 
 
 class TestModalDriverImageBuild:

--- a/uv.lock
+++ b/uv.lock
@@ -1001,7 +1001,7 @@ wheels = [
 
 [[package]]
 name = "letta-evals"
-version = "0.24.0"
+version = "0.25.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -1052,7 +1052,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.0" },
     { name = "letta-client", specifier = ">=1.0.0" },
     { name = "matplotlib", specifier = ">=3.10.6" },
-    { name = "modal", specifier = ">=0.65.0" },
+    { name = "modal", specifier = ">=1.5.4" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "openpyxl", marker = "extra == 'skills'", specifier = ">=3.1.5" },
     { name = "pandas", specifier = ">=2.3.2" },
@@ -1192,7 +1192,7 @@ wheels = [
 
 [[package]]
 name = "modal"
-version = "1.5.1"
+version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1209,9 +1209,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/56/a8d1a1dd705044e0c3534642361e8586db98908b683f8231b9fd39a86209/modal-1.5.1.tar.gz", hash = "sha256:f8fb7f4d3ccc5b774370704b1aabb79e629ea7e6681a7f9671af5cf77161be12", size = 801962, upload-time = "2026-06-23T15:44:18.853Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/0d/1a6e710ab64f0c7b7bec9472203dbf6c7c75556dd2d7632da98c96a4e0b0/modal-1.5.4.tar.gz", hash = "sha256:d611bb47fc07117f5d194f7f9a9c0aba4537573a136349bbe45c5694e64bca92", size = 863571, upload-time = "2026-08-12T21:54:12.62Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/67/c91cb2ee6cbae523ae051f5ecfebd9fc24518fb84b9e92859d32fbbe3a71/modal-1.5.1-py3-none-any.whl", hash = "sha256:49aeda1a4fafc71994c3aa63d3e2321419b586de0303113fa5bfc68f31ad5c95", size = 915761, upload-time = "2026-06-23T15:44:16.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/93/ca23b7b421e2c9738b710eb1d33eb25a88cba32dff864003a692a0e21f8d/modal-1.5.4-py3-none-any.whl", hash = "sha256:3e54e26037c445af42f9a9ef9862b66bdd2e0b1faeced5fcc7adf3e5f59e44ed", size = 979381, upload-time = "2026-08-12T21:54:10.378Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- require Modal 1.5.4 and enable the v2 Sandbox backend by default
- keep an explicit MODAL_SANDBOX_V2 setting as an operator rollback path
- verify uploads and downloads use the path-oriented Sandbox filesystem API
- document the SDK floor and v2 behavior

## Validation

- 351 passed, 2 skipped
- Ruff passed with repository exclusions
- uv lock check and git diff check passed
- live Modal smoke: v2 Sandbox sb-01KZYJMJX1M83V9JYSMVJ61XBJ completed upload, exec, and download round-trip and was terminated