### PR TITLE
fix(sandbox): Allow ambient Modal authentication

### DIFF
--- a/letta_evals/sandbox/modal.py
+++ b/letta_evals/sandbox/modal.py
@@ -22,6 +22,11 @@ from letta_evals.sandbox.base import AbstractSandbox, ExecResult, SandboxAuthErr
 
 logger = logging.getLogger(__name__)
 
+_MODAL_AUTH_ERROR_MESSAGE = (
+    "Modal authentication failed. Run `modal token new` for local use or verify "
+    "that the Modal Function identity has access."
+)
+
 
 def _letta_evals_package_spec(pin: str) -> str:
     """Normalize a version or direct reference into a pip package spec."""
@@ -72,10 +77,7 @@ class ModalSandbox(AbstractSandbox):
         try:
             app = await modal.App.lookup.aio(name=self.spec.app_name, create_if_missing=True)
         except modal.exception.AuthError as e:
-            raise SandboxAuthError(
-                "Modal authentication failed. Run `modal token new` for local use or verify "
-                "that the Modal Function identity has access."
-            ) from e
+            raise SandboxAuthError(_MODAL_AUTH_ERROR_MESSAGE) from e
         if self.spec.image is None:
             # The Dockerfile is a shared OS/toolchain base. Application pins
             # live in literal Modal layer commands so each exact pin becomes
@@ -128,7 +130,10 @@ class ModalSandbox(AbstractSandbox):
         if self.spec.idle_timeout_sec is not None:
             create_kwargs["idle_timeout"] = self.spec.idle_timeout_sec
 
-        self._sandbox = await modal.Sandbox.create.aio(**create_kwargs)
+        try:
+            self._sandbox = await modal.Sandbox.create.aio(**create_kwargs)
+        except modal.exception.AuthError as e:
+            raise SandboxAuthError(_MODAL_AUTH_ERROR_MESSAGE) from e
         self._image_id = getattr(image, "object_id", None)
         logger.info(
             "Started Modal sandbox %s (session=%s, image=%s)",

--- a/letta_evals/sandbox/modal.py
+++ b/letta_evals/sandbox/modal.py
@@ -39,20 +39,6 @@ def _import_modal():
     return modal
 
 
-def _check_modal_auth() -> None:
-    """Pre-flight check for Modal credentials before any network call."""
-    token_id = os.getenv("MODAL_TOKEN_ID")
-    token_secret = os.getenv("MODAL_TOKEN_SECRET")
-    if token_id and token_secret:
-        return
-    if (Path.home() / ".modal.toml").exists():
-        return
-    raise SandboxAuthError(
-        "Modal authentication not found. Run `modal token new` or set "
-        "MODAL_TOKEN_ID and MODAL_TOKEN_SECRET environment variables."
-    )
-
-
 def _enable_modal_sandbox_v2() -> None:
     """Use Modal's v2 Sandbox backend unless the caller configured it explicitly."""
     os.environ.setdefault("MODAL_SANDBOX_V2", "1")
@@ -82,9 +68,14 @@ class ModalSandbox(AbstractSandbox):
         # caller value intact so deployments retain a rollback path.
         _enable_modal_sandbox_v2()
         modal = _import_modal()
-        _check_modal_auth()
 
-        app = await modal.App.lookup.aio(name=self.spec.app_name, create_if_missing=True)
+        try:
+            app = await modal.App.lookup.aio(name=self.spec.app_name, create_if_missing=True)
+        except modal.exception.AuthError as e:
+            raise SandboxAuthError(
+                "Modal authentication failed. Run `modal token new` for local use or verify "
+                "that the Modal Function identity has access."
+            ) from e
         if self.spec.image is None:
             # The Dockerfile is a shared OS/toolchain base. Application pins
             # live in literal Modal layer commands so each exact pin becomes

--- a/tests/test_modal_sandbox.py
+++ b/tests/test_modal_sandbox.py
@@ -295,8 +295,6 @@ def _install_fake_modal(monkeypatch):
     import sys
     from unittest.mock import AsyncMock, MagicMock
 
-    import letta_evals.sandbox.modal as modal_driver
-
     fake_modal = MagicMock(name="modal")
     fake_modal.App.lookup.aio = AsyncMock(return_value=MagicMock(name="app"))
     fake_image = MagicMock(name="image")
@@ -311,8 +309,47 @@ def _install_fake_modal(monkeypatch):
     fake_modal.Sandbox.create.aio = AsyncMock(return_value=fake_sandbox)
 
     monkeypatch.setitem(sys.modules, "modal", fake_modal)
-    monkeypatch.setattr(modal_driver, "_check_modal_auth", lambda: None)
     return fake_modal
+
+
+class TestModalDriverAuth:
+    @pytest.mark.asyncio
+    async def test_start_delegates_auth_to_modal_sdk(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("MODAL_TOKEN_ID", raising=False)
+        monkeypatch.delenv("MODAL_TOKEN_SECRET", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        fake_modal = _install_fake_modal(monkeypatch)
+        sandbox = ModalSandbox(
+            spec=ModalSandboxSpec(image="ghcr.io/custom/runtime:1.0"),
+            session_id="unit-sdk-auth",
+        )
+
+        await sandbox.start()
+
+        fake_modal.App.lookup.aio.assert_awaited_once_with(name="letta-evals", create_if_missing=True)
+        fake_modal.Sandbox.create.aio.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_start_translates_modal_auth_error(self, monkeypatch):
+        from letta_evals.sandbox.base import SandboxAuthError
+
+        class FakeModalAuthError(Exception):
+            pass
+
+        fake_modal = _install_fake_modal(monkeypatch)
+        fake_modal.exception.AuthError = FakeModalAuthError
+        sdk_error = FakeModalAuthError("invalid credentials")
+        fake_modal.App.lookup.aio.side_effect = sdk_error
+        sandbox = ModalSandbox(
+            spec=ModalSandboxSpec(image="ghcr.io/custom/runtime:1.0"),
+            session_id="unit-auth-error",
+        )
+
+        with pytest.raises(SandboxAuthError, match="Modal authentication failed") as exc_info:
+            await sandbox.start()
+
+        assert exc_info.value.__cause__ is sdk_error
+        fake_modal.Sandbox.create.aio.assert_not_awaited()
 
 
 class TestModalDriverV2:

--- a/tests/test_modal_sandbox.py
+++ b/tests/test_modal_sandbox.py
@@ -16,7 +16,7 @@ import anyio
 import pytest
 
 from letta_evals.models import ModalSandboxSpec, SuiteSpec
-from letta_evals.sandbox.base import ExecResult
+from letta_evals.sandbox.base import ExecResult, SandboxAuthError
 from letta_evals.sandbox.dispatch import build_upload_filter
 from letta_evals.sandbox.modal import ModalSandbox
 
@@ -330,9 +330,7 @@ class TestModalDriverAuth:
         fake_modal.Sandbox.create.aio.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_start_translates_modal_auth_error(self, monkeypatch):
-        from letta_evals.sandbox.base import SandboxAuthError
-
+    async def test_start_translates_app_lookup_auth_error(self, monkeypatch):
         class FakeModalAuthError(Exception):
             pass
 
@@ -350,6 +348,26 @@ class TestModalDriverAuth:
 
         assert exc_info.value.__cause__ is sdk_error
         fake_modal.Sandbox.create.aio.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_start_translates_sandbox_create_auth_error(self, monkeypatch):
+        class FakeModalAuthError(Exception):
+            pass
+
+        fake_modal = _install_fake_modal(monkeypatch)
+        fake_modal.exception.AuthError = FakeModalAuthError
+        sdk_error = FakeModalAuthError("invalid ambient credentials")
+        fake_modal.Sandbox.create.aio.side_effect = sdk_error
+        sandbox = ModalSandbox(
+            spec=ModalSandboxSpec(image="ghcr.io/custom/runtime:1.0"),
+            session_id="unit-create-auth-error",
+        )
+
+        with pytest.raises(SandboxAuthError, match="Modal authentication failed") as exc_info:
+            await sandbox.start()
+
+        assert exc_info.value.__cause__ is sdk_error
+        fake_modal.App.lookup.aio.assert_awaited_once()
 
 
 class TestModalDriverV2:

--- a/uv.lock
+++ b/uv.lock
@@ -1001,7 +1001,7 @@ wheels = [
 
 [[package]]
 name = "letta-evals"
-version = "0.25.1"
+version = "0.25.2"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

- delegate Modal credential resolution to the Modal SDK
- translate AuthError from both App.lookup and Sandbox.create into SandboxAuthError
- preserve other Modal errors, including permission errors
- add regression coverage for ambient authentication and both error sites
- regenerate uv.lock so the local letta-evals package version matches pyproject.toml

## Validation

- uv lock --check
- uv run --no-sync pytest -q: 354 passed, 2 skipped
- uv run --no-sync ruff check letta_evals/sandbox/modal.py tests/test_modal_sandbox.py
- uv run --no-sync ruff format --check letta_evals/sandbox/modal.py tests/test_modal_sandbox.py
- current local credentials: read-only App.lookup for letta-evals succeeded
- missing local credentials: real Modal AuthError was translated to SandboxAuthError

A deployed Modal Function check will be completed separately. No live Sandbox was created during local validation.

Closes #332